### PR TITLE
Add Neo4jDataFrame#createNodes method and renameMap to mergeEdgeList

### DIFF
--- a/README.md
+++ b/README.md
@@ -262,7 +262,8 @@ There are a few different RDD's all named `Neo4jXxxRDD`
     * property names from the sequence are used as column names for the data-frame, currently there is no name translation
     * the result are sent in batches of 10000 to the graph
  2. `mergeEdgeList(sc: SparkContext, dataFrame: DataFrame, source: (String,Seq[String]), relationship: (String,Seq[String]), target: (String,Seq[String]), renameMap: Map[String,String])` to do the
- same as the first method except for `renameMap` parameter. This method can be used to create a relationship between nodes having the same properties.
+ same as the first method except for `renameMap` parameter.<br/>
+ This method can be used to create a relationship between nodes having the same properties.<br/>
  For example: `(keanu:Person {name: 'Keanu'})-[:ACTED_WITH]->(Laurence:Person {name: "Laurence"})` requires a DataFrame with 2 `name` columns which is not possible.
  To overcome this, one can create a DataFrame with `src_node_name` and `dst_node_name` and provide `renameMap = Map("src_node_name" -> "name", "dst_node_name" -> "name")`
  3. `createNodes(sc: SparkContext, dataFrame: DataFrame, nodes: (String,Seq[String]))` to create nodes in Neo4j graph.

--- a/README.md
+++ b/README.md
@@ -267,6 +267,7 @@ There are a few different RDD's all named `Neo4jXxxRDD`
  2. `createNodes(sc: SparkContext, dataFrame: DataFrame, nodes: (String,Seq[String]))` to create nodes in Neo4j graph.
     * nodes are created by first property in sequence, all the others will be set on the node
     * the result are sent in batches of 10000 to the graph
+    * optional `renamedColums` parameter - can be used to create a node with a label different from `DataFrame`'s column name.<br/>
 
 
 ## GraphX - Neo4jGraph

--- a/README.md
+++ b/README.md
@@ -261,12 +261,10 @@ There are a few different RDD's all named `Neo4jXxxRDD`
     * relationships are merged between the two nodes and all properties from sequence will be set on the relationship
     * property names from the sequence are used as column names for the data-frame, currently there is no name translation
     * the result are sent in batches of 10000 to the graph
- 2. `mergeEdgeList(sc: SparkContext, dataFrame: DataFrame, source: (String,Seq[String]), relationship: (String,Seq[String]), target: (String,Seq[String]), renameMap: Map[String,String])` to do the
- same as the first method except for `renameMap` parameter.<br/>
- This method can be used to create a relationship between nodes having the same properties.<br/>
+    * optional `renamedColums` parameter - can be used to create a relationship between nodes having the same properties.<br/>
  For example: `(keanu:Person {name: 'Keanu'})-[:ACTED_WITH]->(Laurence:Person {name: "Laurence"})` requires a DataFrame with 2 `name` columns which is not possible.
- To overcome this, one can create a DataFrame with `src_node_name` and `dst_node_name` and provide `renameMap = Map("src_node_name" -> "name", "dst_node_name" -> "name")`
- 3. `createNodes(sc: SparkContext, dataFrame: DataFrame, nodes: (String,Seq[String]))` to create nodes in Neo4j graph.
+ To overcome this, one can create a DataFrame with `src_node_name` and `dst_node_name` and provide `renamedColumns = Map("src_node_name" -> "name", "dst_node_name" -> "name")`
+ 2. `createNodes(sc: SparkContext, dataFrame: DataFrame, nodes: (String,Seq[String]))` to create nodes in Neo4j graph.
     * nodes are created by first property in sequence, all the others will be set on the node
     * the result are sent in batches of 10000 to the graph
 

--- a/README.md
+++ b/README.md
@@ -255,11 +255,20 @@ There are a few different RDD's all named `Neo4jXxxRDD`
 
 * `Neo4jDataFrame`, a SparkSQL `DataFrame` that you construct either with explicit type information about result names and types
 * or inferred from the first result-row
-* Neo4jDataFrame provides `mergeEdgeList(sc: SparkContext, dataFrame: DataFrame, source: (label,Seq[prop]), relationship: (type,Seq[prop]), target: (label,Seq[prop]))` to merge a DataFrame back into a Neo4j graph
-  * both nodes are merged by first propery in sequence, all the others will be set on the entity, relat
-  * relationships are merged between the two nodes and all properties from sequence will be set on the relationship
-  * property names from the sequence are used as column names for the data-frame, currently there is no name translation
-  * the result are sent in batches of 10000 to the graph 
+* Neo4jDataFrame provides:
+ 1.`mergeEdgeList(sc: SparkContext, dataFrame: DataFrame, source: (label,Seq[prop]), relationship: (type,Seq[prop]), target: (label,Seq[prop]))` to merge a DataFrame back into a Neo4j graph
+    * both nodes are merged by first property in sequence, all the others will be set on the entity
+    * relationships are merged between the two nodes and all properties from sequence will be set on the relationship
+    * property names from the sequence are used as column names for the data-frame, currently there is no name translation
+    * the result are sent in batches of 10000 to the graph
+ 2. `mergeEdgeList(sc: SparkContext, dataFrame: DataFrame, source: (String,Seq[String]), relationship: (String,Seq[String]), target: (String,Seq[String]), renameMap: Map[String,String])` to do the
+ same as the first method except for `renameMap` parameter. This method can be used to create a relationship between nodes having the same properties.
+ For example: `(keanu:Person {name: 'Keanu'})-[:ACTED_WITH]->(Laurence:Person {name: "Laurence"})` requires a DataFrame with 2 `name` columns which is not possible.
+ To overcome this, one can create a DataFrame with `src_node_name` and `dst_node_name` and provide `renameMap = Map("src_node_name" -> "name", "dst_node_name" -> "name")`
+ 3. `createNodes(sc: SparkContext, dataFrame: DataFrame, nodes: (String,Seq[String]))` to create nodes in Neo4j graph.
+    * nodes are created by first property in sequence, all the others will be set on the node
+    * the result are sent in batches of 10000 to the graph
+
 
 ## GraphX - Neo4jGraph
 

--- a/src/main/scala/org/neo4j/spark/Neo4jDataFrame.scala
+++ b/src/main/scala/org/neo4j/spark/Neo4jDataFrame.scala
@@ -13,13 +13,26 @@ import org.neo4j.driver.v1.types.{Type, TypeSystem}
 
 import scala.collection.JavaConverters._
 
+case class RelationshipRow(label: String,
+                           properties: Seq[String],
+                           srcNodeLabel: String,
+                           srcNodeNameCol: String,
+                           dstNodeLabel: String,
+                           dstNodeNameCol: String)
+
 object Neo4jDataFrame {
 
   def mergeEdgeList(sc: SparkContext, dataFrame: DataFrame, source: (String,Seq[String]), relationship: (String,Seq[String]), target: (String,Seq[String])): Unit = {
+    mergeEdgeList(sc, dataFrame, source,relationship, target, Map.empty)
+  }
+
+  def mergeEdgeList(sc: SparkContext, dataFrame: DataFrame, source: (String,Seq[String]), relationship: (String,Seq[String]), target: (String,Seq[String]), renameMap: Map[String,String]): Unit = {
+    val sourceLbel = renameMap.getOrElse(source._2.head, source._2.head)
+    val targetLabel = renameMap.getOrElse(target._2.head, target._2.head)
     val mergeStatement = s"""
       UNWIND {rows} as row
-      MERGE (source:`${source._1}` {`${source._2.head}` : row.source.`${source._2.head}`}) ON CREATE SET source += row.source
-      MERGE (target:`${target._1}` {`${target._2.head}` : row.target.`${target._2.head}`}) ON CREATE SET target += row.target
+      MERGE (source:`${source._1}` {`${source._2.head}` : row.source.`${sourceLbel}`}) ON CREATE SET source += row.source
+      MERGE (target:`${target._1}` {`${target._2.head}` : row.target.`${targetLabel}`}) ON CREATE SET target += row.target
       MERGE (source)-[rel:`${relationship._1}`]->(target) ON CREATE SET rel += row.relationship
       """
     val partitions = Math.max(1,(dataFrame.count() / 10000).asInstanceOf[Int])
@@ -27,11 +40,56 @@ object Neo4jDataFrame {
     dataFrame.repartition(partitions).foreachPartition( rows => {
       val params: AnyRef = rows.map(r =>
         Map(
-          "source" -> source._2.map( c => (c, r.getAs[AnyRef](c))).toMap.asJava,
-          "target" -> target._2.map( c => (c, r.getAs[AnyRef](c))).toMap.asJava,
+          "source" -> source._2.map( c => (renameMap.getOrElse(c,c), r.getAs[AnyRef](c))).toMap.asJava,
+          "target" -> target._2.map( c => (renameMap.getOrElse(c,c), r.getAs[AnyRef](c))).toMap.asJava,
           "relationship" -> relationship._2.map( c => (c, r.getAs[AnyRef](c))).toMap.asJava)
           .asJava).asJava
           execute(config, mergeStatement, Map("rows" -> params).asJava, write = true)
+    })
+  }
+
+
+  def createNodes(sc: SparkContext, dataFrame: DataFrame, nodes: (String,Seq[String])): Unit = {
+
+    val nodeLabel = nodes._2.head
+    val createStatement = s"""
+        UNWIND {rows} as row
+        CREATE (node:`${nodes._1}` {`${nodeLabel}` : row.source.`${nodeLabel}`})
+        SET node = row.node_properties
+        """
+    val partitions = Math.max(1,(dataFrame.count() / 10000).asInstanceOf[Int])
+    val config = Neo4jConfig( sc.getConf )
+    dataFrame.repartition(partitions).foreachPartition( rows => {
+      val params: AnyRef = rows.map(r =>
+        Map(
+          "node_properties" -> nodes._2.map( c => (c, r.getAs[AnyRef](c))).toMap.asJava)
+          .asJava).asJava
+      Neo4jDataFrame.execute(config, createStatement, Map("rows" -> params).asJava, write = true)
+    })
+  }
+
+  def createRelationships(sc: SparkContext,
+                          dataFrame: DataFrame,
+                          relationships: RelationshipRow): Unit = {
+
+    val createStatement = s"""
+          UNWIND {rows} as row
+          MATCH (a:`${relationships.srcNodeLabel}`),(b:`${relationships.dstNodeLabel}`)
+          WHERE a.name = row.src_node_name AND b.name = row.dst_node_name
+          CREATE (a)-[r:`${relationships.label}`]->(b)
+          SET r = row.rel_properties
+          """
+
+    val partitions = Math.max(1,(dataFrame.count() / 10000).asInstanceOf[Int])
+    val config = Neo4jConfig( sc.getConf )
+    dataFrame.repartition(partitions).foreachPartition( rows => {
+      val params: AnyRef = rows.map(r =>
+        Map(
+          "rel_properties" -> relationships.properties.map( c => (c, r.getAs[AnyRef](c))).toMap.asJava,
+          "src_node_name" -> r.getAs[AnyRef](relationships.srcNodeNameCol),
+          "dst_node_name" -> r.getAs[AnyRef](relationships.dstNodeNameCol))
+          .asJava).asJava
+      Neo4jDataFrame.execute(config, createStatement, Map("rows" -> params).asJava, write = true)
     })
   }
 

--- a/src/test/scala/org/neo4j/spark/Neo4jDataFrameScalaTest.scala
+++ b/src/test/scala/org/neo4j/spark/Neo4jDataFrameScalaTest.scala
@@ -47,4 +47,27 @@ class Neo4jDataFrameScalaTest {
     assertEquals(1L, it.next())
     it.close()
   }
+
+  @Test def mergeEdgeListWithRename {
+    val rows = sc.makeRDD(Seq(Row("Carrie-Anne", "Laurence")))
+    val schema = StructType(Seq(StructField("src_name", DataTypes.StringType), StructField("dst_name", DataTypes.StringType)))
+    val df = new SQLContext(sc).createDataFrame(rows, schema)
+    val rename = Map("src_name" -> "name", "dst_name" -> "name")
+    Neo4jDataFrame.mergeEdgeList(sc, df, ("Person",Seq("src_name")),("ACTED_WITH",Seq.empty),("Person",Seq("dst_name")), rename)
+
+    val it: ResourceIterator[Long] = server.graph().execute("MATCH p=(:Person {name:'Carrie-Anne'})-[:ACTED_WITH]->(:Person {name:'Laurence'}) RETURN count(*) as c").columnAs("c")
+    assertEquals(1L, it.next())
+    it.close()
+  }
+
+  @Test def createNodes {
+    val rows = sc.makeRDD(Seq(Row("Laurence", "Fishburne")))
+    val schema = StructType(Seq(StructField("name", DataTypes.StringType), StructField("lastname", DataTypes.StringType)))
+    val df = new SQLContext(sc).createDataFrame(rows, schema)
+    Neo4jDataFrame.createNodes(sc, df, ("Person",Seq("name","lastname")))
+
+    val it: ResourceIterator[Long] = server.graph().execute("MATCH (:Person {name:'Laurence', lastname: 'Fishburne'}) RETURN count(*) as c").columnAs("c")
+    assertEquals(1L, it.next())
+    it.close()
+  }
 }

--- a/src/test/scala/org/neo4j/spark/Neo4jDataFrameScalaTest.scala
+++ b/src/test/scala/org/neo4j/spark/Neo4jDataFrameScalaTest.scala
@@ -49,13 +49,13 @@ class Neo4jDataFrameScalaTest {
   }
 
   @Test def mergeEdgeListWithRename {
-    val rows = sc.makeRDD(Seq(Row("Carrie-Anne", "Laurence")))
+    val rows = sc.makeRDD(Seq(Row("Carrie-Anne", "Foster")))
     val schema = StructType(Seq(StructField("src_name", DataTypes.StringType), StructField("dst_name", DataTypes.StringType)))
     val df = new SQLContext(sc).createDataFrame(rows, schema)
     val rename = Map("src_name" -> "name", "dst_name" -> "name")
-    Neo4jDataFrame.mergeEdgeList(sc, df, ("Person",Seq("src_name")),("ACTED_WITH",Seq.empty),("Person",Seq("dst_name")), rename)
+    Neo4jDataFrame.mergeEdgeList(sc, df, ("Person",Seq("src_name")),("ACTED_WITH",Seq.empty),("Person",Seq("dst_name")),rename)
 
-    val it: ResourceIterator[Long] = server.graph().execute("MATCH p=(:Person {name:'Carrie-Anne'})-[:ACTED_WITH]->(:Person {name:'Laurence'}) RETURN count(*) as c").columnAs("c")
+    val it: ResourceIterator[Long] = server.graph().execute("MATCH p=(:Person {name:'Carrie-Anne'})-[:ACTED_WITH]->(:Person {name:'Foster'}) RETURN count(*) as c").columnAs("c")
     assertEquals(1L, it.next())
     it.close()
   }
@@ -67,6 +67,18 @@ class Neo4jDataFrameScalaTest {
     Neo4jDataFrame.createNodes(sc, df, ("Person",Seq("name","lastname")))
 
     val it: ResourceIterator[Long] = server.graph().execute("MATCH (:Person {name:'Laurence', lastname: 'Fishburne'}) RETURN count(*) as c").columnAs("c")
+    assertEquals(1L, it.next())
+    it.close()
+  }
+
+  @Test def createNodesWithRename {
+    val rows = sc.makeRDD(Seq(Row("Matt", "Doran")))
+    val schema = StructType(Seq(StructField("node_name", DataTypes.StringType), StructField("lastname", DataTypes.StringType)))
+    val df = new SQLContext(sc).createDataFrame(rows, schema)
+    val rename = Map("node_name" -> "name")
+    Neo4jDataFrame.createNodes(sc, df, ("Person",Seq("node_name","lastname")), rename)
+
+    val it: ResourceIterator[Long] = server.graph().execute("MATCH (:Person {name:'Matt', lastname: 'Doran'}) RETURN count(*) as c").columnAs("c")
     assertEquals(1L, it.next())
     it.close()
   }


### PR DESCRIPTION
In this pull request, we're adding new capability to mergeEdgeList, creating a relationship between nodes having the same properties. For example:
(keanu:Person {name: 'Keanu'})-[:ACTED_WITH]->(Laurence:Person {name: "Laurence"})

In addition, we're adding new method createNodes to Neo4jDataFrame