### PR TITLE
add a new spark parameter:spark.neo4j.bolt.encryption.status

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,12 +62,14 @@ In your pom.xml, add:
 
 ## Config
 
-If you're running Neo4j on localhost with the default ports, you onl have to configure your password in `spark.neo4j.bolt.password=<password>`.
+If you're running Neo4j on localhost with the default ports, you only have to configure your password in `spark.neo4j.bolt.password=<password>`.
 	
 Otherwise set the `spark.neo4j.bolt.url` in your `SparkConf` pointing e.g. to `bolt://host:port`.
 
 You can provide user and password as part of the URL `bolt://neo4j:<password>@localhost` or individually in `spark.neo4j.bolt.user` and `spark.neo4j.bolt.password`.
 
+If you're running Neo4j with the Bolt connector and the option `dbms.connector.bolt.tls_level` in Neo4j is `REQUIRED`, you must set the `spark.neo4j.bolt.encryption.status` to `true` in your `SparkConf`.
+Otherwise, you can either ignore `spark.neo4j.bolt.encryption.status` or  set  `spark.neo4j.bolt.encryption.status` to `false` in your `SparkConf`.
 
 ## Builder API
 

--- a/src/main/scala/org/neo4j/spark/Neo4jConfig.scala
+++ b/src/main/scala/org/neo4j/spark/Neo4jConfig.scala
@@ -4,30 +4,38 @@ import org.apache.spark.SparkConf
 import org.neo4j.driver.v1.{Driver, AuthTokens, Config, GraphDatabase}
 
 /**
-  * @author mh
-  * @since 02.03.16
-  */
-case class Neo4jConfig(val url: String, val user: String = "neo4j", val password: Option[String] = None) {
+ * @author mh
+ * @since 02.03.16
+ */
+case class Neo4jConfig(url: String, user: String = "neo4j", password: Option[String] = None, encryptionStatus: Boolean) {
+  //If the encryptionStatus variable is false, use the withEncryption() method to initialize the config instance,
+  // otherwise use the withoutEncryption() to initialize it.
+  private def createBoltConfig() = if (encryptionStatus) Config.build().withEncryption().toConfig else Config.build().withoutEncryption().toConfig
 
-  def boltConfig() = Config.build.withoutEncryption().toConfig
-
-  def driver(config: Neo4jConfig) : Driver = config.password match {
-    case Some(pwd) => GraphDatabase.driver(config.url, AuthTokens.basic(config.user, pwd), boltConfig())
-    case _ => GraphDatabase.driver(config.url, boltConfig())
+  def driver(config: Neo4jConfig): Driver = config.password match {
+    case Some(pwd) => GraphDatabase.driver(config.url, AuthTokens.basic(config.user, pwd), createBoltConfig())
+    case _ => GraphDatabase.driver(config.url, createBoltConfig())
   }
 
-  def driver() : Driver = driver(this)
+  def driver(): Driver = driver(this)
 
-  def driver(url: String): Driver = GraphDatabase.driver(url, boltConfig())
+  def driver(url: String): Driver = GraphDatabase.driver(url, createBoltConfig())
 
 }
 
 object Neo4jConfig {
-  val prefix = "spark.neo4j.bolt."
+  // List of currently supported parameters
+  private val URL = "spark.neo4j.bolt.url"
+  private val USER = "spark.neo4j.bolt.user"
+  private val PASSWORD = "spark.neo4j.bolt.password"
+  private val ENCRYPTION_STATUS = "spark.neo4j.bolt.encryption.status"
+
   def apply(sparkConf: SparkConf): Neo4jConfig = {
-    val url = sparkConf.get(prefix + "url", "bolt://localhost")
-    val user = sparkConf.get(prefix + "user", "neo4j")
-    val password: Option[String] = sparkConf.getOption(prefix + "password")
-    Neo4jConfig(url, user, password)
+    val url = sparkConf.get(URL, "bolt://localhost")
+    val user = sparkConf.get(USER, "neo4j")
+    val password: Option[String] = sparkConf.getOption(PASSWORD)
+    // default value is false
+    val encryptionStatus = sparkConf.getBoolean(ENCRYPTION_STATUS, defaultValue = false)
+    Neo4jConfig(url, user, password, encryptionStatus)
   }
 }


### PR DESCRIPTION
In NEO4J, if the parameter dbms.connector.bolt. Tls_level is set to REQUIRED, when we connect NEO4J with neo4j-spark connector, the connection will report an error:Connection to the database terminated. This can happen due to network instabilities, or due to restarts of the database.So We add a parameter to control how the Config instance can be created,If the encryptionStatus variable is false, use the withoutEncryption() method to initialize the config instance,otherwise use the withEncryption() to initialize it.