### PR TITLE
Fix issue #114, Convert to Java Collections if possible.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,5 @@
+dist: trusty
+
 language: java
 
 jdk:

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>neo4j-contrib</groupId>
     <packaging>jar</packaging>
-    <version>2.4.0-M7</version>
+    <version>2.4.0-M8</version>
     <artifactId>neo4j-spark-connector</artifactId>
     <name>neo4j-spark-connector</name>
     <description>Neo4j Spark Connector using the binary Bolt Driver</description>

--- a/src/test/scala/org/neo4j/spark/Neo4jDataFrameScalaTest.scala
+++ b/src/test/scala/org/neo4j/spark/Neo4jDataFrameScalaTest.scala
@@ -89,6 +89,17 @@ class Neo4jDataFrameScalaTest {
     it.close()
   }
 
+  @Test def createNodesComplexProperties {
+    val rows = sc.makeRDD(Seq(Row(Seq("Laurence", "Fishburne"))))
+    val schema = StructType(Seq(StructField("names", DataTypes.createArrayType(DataTypes.StringType, false))))
+    val df = new SQLContext(sc).createDataFrame(rows, schema)
+    Neo4jDataFrame.createNodes(sc, df, ("Person",Seq("names")))
+
+    val it: ResourceIterator[Long] = server.graph().execute("MATCH (:Person {names: ['Laurence', 'Fishburne']}) RETURN count(*) as c").columnAs("c")
+    assertEquals(1L, it.next())
+    it.close()
+  }
+
   @Test def createNodesWithRename {
     val rows = sc.makeRDD(Seq(Row("Matt", "Doran")))
     val schema = StructType(Seq(StructField("node_name", DataTypes.StringType), StructField("lastname", DataTypes.StringType)))

--- a/src/test/scala/org/neo4j/spark/Neo4jDataFrameScalaTest.scala
+++ b/src/test/scala/org/neo4j/spark/Neo4jDataFrameScalaTest.scala
@@ -62,10 +62,10 @@ class Neo4jDataFrameScalaTest {
   }
 
   @Test def mergeEdgeListWithRelProperties {
-    val rows = sc.makeRDD(Seq(Row("Laurence", "Keanu", "Mentor", Seq("1980"))))
+    val rows = sc.makeRDD(Seq(Row(Seq("Laurence"), Seq("Keanu"), "Mentor", Seq("1980"))))
     val schema = StructType(Seq(
-      StructField("src_name", DataTypes.StringType),
-      StructField("dst_name", DataTypes.StringType),
+      StructField("src_name", DataTypes.createArrayType(DataTypes.StringType, false)),
+      StructField("dst_name", DataTypes.createArrayType(DataTypes.StringType, false)),
       StructField("screen", DataTypes.StringType),
       StructField("met", DataTypes.createArrayType(DataTypes.StringType, false))
     ))
@@ -73,7 +73,7 @@ class Neo4jDataFrameScalaTest {
     val rename = Map("src_name" -> "name", "dst_name" -> "name")
     Neo4jDataFrame.mergeEdgeList(sc, df, ("Person", Seq("src_name")), ("ACTED_WITH", Seq("screen", "met")), ("Person", Seq("dst_name")), rename)
 
-    val it: ResourceIterator[Long] = server.graph().execute("MATCH p=(:Person {name:'Laurence'})-[:ACTED_WITH {screen: 'Mentor', met: ['1980']}]->(:Person {name:'Keanu'}) RETURN count(*) as c").columnAs("c")
+    val it: ResourceIterator[Long] = server.graph().execute("MATCH p=(:Person {name: ['Laurence']})-[:ACTED_WITH {screen: 'Mentor', met: ['1980']}]->(:Person {name:['Keanu']}) RETURN count(*) as c").columnAs("c")
     assertEquals(1L, it.next())
     it.close()
   }

--- a/src/test/scala/org/neo4j/spark/Neo4jDataFrameScalaTest.scala
+++ b/src/test/scala/org/neo4j/spark/Neo4jDataFrameScalaTest.scala
@@ -62,17 +62,18 @@ class Neo4jDataFrameScalaTest {
   }
 
   @Test def mergeEdgeListWithRelProperties {
-    val rows = sc.makeRDD(Seq(Row("Laurence", "Keanu", "Mentor")))
+    val rows = sc.makeRDD(Seq(Row("Laurence", "Keanu", "Mentor", Seq("1980"))))
     val schema = StructType(Seq(
       StructField("src_name", DataTypes.StringType),
       StructField("dst_name", DataTypes.StringType),
-      StructField("screen", DataTypes.StringType)
+      StructField("screen", DataTypes.StringType),
+      StructField("met", DataTypes.createArrayType(DataTypes.StringType, false))
     ))
     val df = new SQLContext(sc).createDataFrame(rows, schema)
     val rename = Map("src_name" -> "name", "dst_name" -> "name")
-    Neo4jDataFrame.mergeEdgeList(sc, df, ("Person",Seq("src_name")),("ACTED_WITH",Seq("screen")),("Person",Seq("dst_name")),rename)
+    Neo4jDataFrame.mergeEdgeList(sc, df, ("Person", Seq("src_name")), ("ACTED_WITH", Seq("screen", "met")), ("Person", Seq("dst_name")), rename)
 
-    val it: ResourceIterator[Long] = server.graph().execute("MATCH p=(:Person {name:'Laurence'})-[:ACTED_WITH {screen:'Mentor'}]->(:Person {name:'Keanu'}) RETURN count(*) as c").columnAs("c")
+    val it: ResourceIterator[Long] = server.graph().execute("MATCH p=(:Person {name:'Laurence'})-[:ACTED_WITH {screen: 'Mentor', met: ['1980']}]->(:Person {name:'Keanu'}) RETURN count(*) as c").columnAs("c")
     assertEquals(1L, it.next())
     it.close()
   }


### PR DESCRIPTION
Recursively convert any Scala collections returned from the Spark Dataframe into Java Collections, which allows them to be set as Neo4j properties.