### PR TITLE
Updated saveGraph.updateNodes to use numPartitions instead of batch size.

### DIFF
--- a/src/main/scala/org/neo4j/spark/Neo4jGraph.scala
+++ b/src/main/scala/org/neo4j/spark/Neo4jGraph.scala
@@ -104,8 +104,8 @@ object Neo4jGraph {
           }) +
             s" $matchMerge (n)-[rel:${relType.quote}]->(m) SET rel.${relProp.quote} = row.value return count(*)"
         val batchSize = ((graph.numEdges / 100) + 1).toInt
-
-        graph.edges.repartition(batchSize).mapPartitions[Long](
+        val numPartitions = ((graph.numEdges / batchSize) + 1).toInt
+        graph.edges.repartition(numPartitions).mapPartitions[Long](
           p => {
             val rows = p.map(e => Seq(("from", e.srcId), ("to", e.dstId), ("value", e.attr)).toMap.asJava).toList.asJava
             val res1 = execute(config, updateRels, Map("data" -> rows)).rows

--- a/src/main/scala/org/neo4j/spark/Neo4jGraph.scala
+++ b/src/main/scala/org/neo4j/spark/Neo4jGraph.scala
@@ -62,7 +62,8 @@ object Neo4jGraph {
 
     def updateNodes(updateNodesStatement: String, nodes: RDD[(VertexId, VD)], total: Option[Long] = None): Long = {
       val batchSize = ((total.getOrElse(nodes.count()) / 100) + 1).toInt
-      nodes.repartition(batchSize).mapPartitions[Long](
+      val numPartitions = ((total.getOrElse(nodes.count()) / batchSize) + 1).toInt
+      nodes.repartition(numPartitions).mapPartitions[Long](
         p => {
           // TODO was toIterable instead of toList but bug in java-driver
           val rows = p.map(v => Seq(("id", v._1), ("value", v._2)).toMap.asJava).toList.asJava


### PR DESCRIPTION
Bug discovered during customer PoC, seems we are using **batchSize** where **numPartitions** should be.
