### PR TITLE
fixes #133: Neo4jDataFrame#mergeEdgeList should skip node creation

### DIFF
--- a/README.md
+++ b/README.md
@@ -270,6 +270,7 @@ names and types or inferred from the first result-row; it provides:
     * the `unwindBatchSize` parameter defines for each partition the batch size sent to Neo4j.<br/>
     * optional `renamedColumns` parameter - can be used to create a relationship between nodes having the same properties.
     *For example*: `(keanu:Person {name: 'Keanu'})-[:ACTED_WITH]->(Laurence:Person {name: "Laurence"})` requires a DataFrame with 2 `name` columns which is not possible.
+    * optional `ingestNodes` which can have three values: `merge` (the default) merges the nodes, `create` creates the nodes, `skip` skip the creation
  To overcome this, one can create a DataFrame with `src_node_name` and `dst_node_name` and provide `renamedColumns = Map("src_node_name" -> "name", "dst_node_name" -> "name")`
  * `createNodes(sc: SparkContext, dataFrame: DataFrame, nodes: (String,Seq[String]), partitions: Int = 1, unwindBatchSize: Int = 10000, merger: Boolean = false)` to create nodes in Neo4j graph.
     * nodes are created by first property in sequence, all the others will be set on the node

--- a/README.md
+++ b/README.md
@@ -270,7 +270,7 @@ names and types or inferred from the first result-row; it provides:
     * the `unwindBatchSize` parameter defines for each partition the batch size sent to Neo4j.<br/>
     * optional `renamedColumns` parameter - can be used to create a relationship between nodes having the same properties.
     *For example*: `(keanu:Person {name: 'Keanu'})-[:ACTED_WITH]->(Laurence:Person {name: "Laurence"})` requires a DataFrame with 2 `name` columns which is not possible.
-    * optional `ingestNodes` which can have three values: `merge` (the default) merges the nodes, `create` creates the nodes, `skip` skip the creation
+    * optional `ingestNodes` which can have three values: `merge` (the default) merges the nodes, `create` creates the nodes, `match` skip the creations
  To overcome this, one can create a DataFrame with `src_node_name` and `dst_node_name` and provide `renamedColumns = Map("src_node_name" -> "name", "dst_node_name" -> "name")`
  * `createNodes(sc: SparkContext, dataFrame: DataFrame, nodes: (String,Seq[String]), partitions: Int = 1, unwindBatchSize: Int = 10000, merger: Boolean = false)` to create nodes in Neo4j graph.
     * nodes are created by first property in sequence, all the others will be set on the node

--- a/README.md
+++ b/README.md
@@ -270,7 +270,7 @@ names and types or inferred from the first result-row; it provides:
     * the `unwindBatchSize` parameter defines for each partition the batch size sent to Neo4j.<br/>
     * optional `renamedColumns` parameter - can be used to create a relationship between nodes having the same properties.
     *For example*: `(keanu:Person {name: 'Keanu'})-[:ACTED_WITH]->(Laurence:Person {name: "Laurence"})` requires a DataFrame with 2 `name` columns which is not possible.
-    * optional `ingestNodes` which can have three values: `merge` (the default) merges the nodes, `create` creates the nodes, `match` skip the creations
+    * optional `nodeOperation` which can have three values: `merge` (the default) merges the nodes, `create` creates the nodes, `match` skip the creations
  To overcome this, one can create a DataFrame with `src_node_name` and `dst_node_name` and provide `renamedColumns = Map("src_node_name" -> "name", "dst_node_name" -> "name")`
  * `createNodes(sc: SparkContext, dataFrame: DataFrame, nodes: (String,Seq[String]), partitions: Int = 1, unwindBatchSize: Int = 10000, merger: Boolean = false)` to create nodes in Neo4j graph.
     * nodes are created by first property in sequence, all the others will be set on the node

--- a/src/main/scala/org/neo4j/spark/dataframe/Neo4jDataFrame.scala
+++ b/src/main/scala/org/neo4j/spark/dataframe/Neo4jDataFrame.scala
@@ -25,10 +25,21 @@ object Neo4jDataFrame {
                     target: (String, Seq[String]),
                     renamedColumns: Map[String, String] = Map.empty,
                     partitions: Int = 1,
-                    unwindBatchSize: Int = 10000): Unit = {
+                    unwindBatchSize: Int = 10000,
+                    ingestNodes: String = "merge"): Unit = {
 
-    createNodes(sc, dataFrame, source, renamedColumns, partitions, unwindBatchSize, true)
-    createNodes(sc, dataFrame, target, renamedColumns, partitions, unwindBatchSize, true)
+    ingestNodes match {
+      case "merge" => {
+        createNodes(sc, dataFrame, source, renamedColumns, partitions, unwindBatchSize, true)
+        createNodes(sc, dataFrame, target, renamedColumns, partitions, unwindBatchSize, true)
+      }
+      case "create" => {
+        createNodes(sc, dataFrame, source, renamedColumns, partitions, unwindBatchSize)
+        createNodes(sc, dataFrame, target, renamedColumns, partitions, unwindBatchSize)
+      }
+      case "skip" => // ignore
+      case _ => throw new UnsupportedOperationException(s"Admitted values for ingestionNodes are `merge`, `create`, `skip`; you provided $ingestNodes")
+    }
 
     val sourceKey: String = renamedColumns.getOrElse(source._2.head, source._2.head).quote
     val targetKey: String = renamedColumns.getOrElse(target._2.head, target._2.head).quote

--- a/src/main/scala/org/neo4j/spark/dataframe/Neo4jDataFrame.scala
+++ b/src/main/scala/org/neo4j/spark/dataframe/Neo4jDataFrame.scala
@@ -26,9 +26,9 @@ object Neo4jDataFrame {
                     renamedColumns: Map[String, String] = Map.empty,
                     partitions: Int = 1,
                     unwindBatchSize: Int = 10000,
-                    ingestNodes: String = "merge"): Unit = {
+                    nodeOperation: String = "merge"): Unit = {
 
-    ingestNodes match {
+    nodeOperation match {
       case "merge" => {
         createNodes(sc, dataFrame, source, renamedColumns, partitions, unwindBatchSize, true)
         createNodes(sc, dataFrame, target, renamedColumns, partitions, unwindBatchSize, true)
@@ -37,8 +37,8 @@ object Neo4jDataFrame {
         createNodes(sc, dataFrame, source, renamedColumns, partitions, unwindBatchSize)
         createNodes(sc, dataFrame, target, renamedColumns, partitions, unwindBatchSize)
       }
-      case "skip" => // ignore
-      case _ => throw new UnsupportedOperationException(s"Admitted values for ingestionNodes are `merge`, `create`, `skip`; you provided $ingestNodes")
+      case "match" => // ignore
+      case _ => throw new UnsupportedOperationException(s"Admitted values for ingestionNodes are `merge`, `create`, `match`; you provided $nodeOperation")
     }
 
     val sourceKey: String = renamedColumns.getOrElse(source._2.head, source._2.head).quote

--- a/src/test/scala/org/neo4j/spark/Neo4jDataFrameScalaTSE.scala
+++ b/src/test/scala/org/neo4j/spark/Neo4jDataFrameScalaTSE.scala
@@ -104,17 +104,34 @@ class Neo4jDataFrameScalaTSE extends SparkConnectorScalaBaseTSE {
       StructField("timestamp", DataTypes.TimestampType),
       StructField("date", DataTypes.DateType)))
     val df = new SQLContext(sc).createDataFrame(rows, schema)
-    Neo4jDataFrame.createNodes(sc, df, ("Person",Seq("name","lastname", "timestamp", "date")))
+    Neo4jDataFrame.createNodes(sc, df, ("Person", Seq("name", "lastname", "timestamp", "date")))
     val nodeMap = SparkConnectorScalaSuiteIT.session()
-        .run("MATCH (n:Person {name:'Matt', lastname: 'Doran'}) RETURN n")
-        .single()
-        .get("n")
-        .asNode()
-        .asMap()
+      .run("MATCH (n:Person {name:'Matt', lastname: 'Doran'}) RETURN n")
+      .single()
+      .get("n")
+      .asNode()
+      .asMap()
     val actualTimestamp = nodeMap.get("timestamp")
     val actualDate = nodeMap.get("date")
 
     assertEquals(timestamp.toInstant.atZone(ZoneOffset.UTC), actualTimestamp)
     assertEquals(date.toLocalDate, actualDate)
+  }
+
+  @Test
+  def shouldFailBecauseTheNodesNotExist {
+    val rows = sc.makeRDD(Seq(Row(Seq("Laurence"), Seq("Keanu"), "Mentor", Seq("1980"))))
+    val schema = StructType(Seq(
+      StructField("src_name", DataTypes.createArrayType(DataTypes.StringType, false)),
+      StructField("dst_name", DataTypes.createArrayType(DataTypes.StringType, false))
+    ))
+    val df = new SQLContext(sc)
+      .createDataFrame(rows, schema)
+    Neo4jDataFrame.mergeEdgeList(sc,
+      df, ("Person", Seq("src_name")), ("ACTED_WITH", Seq.empty), ("Person", Seq("dst_name")),
+      Map.empty, 1, 10000, "skip")
+    val count = SparkConnectorScalaSuiteIT.session()
+      .run("MATCH p=(:Person {name: 'Laurence'})-[:ACTED_WITH]->(:Person {name:'Keanu'}) RETURN count(*) as c").single().get("c").asLong()
+    assertEquals(0L, count)
   }
 }

--- a/src/test/scala/org/neo4j/spark/Neo4jDataFrameScalaTSE.scala
+++ b/src/test/scala/org/neo4j/spark/Neo4jDataFrameScalaTSE.scala
@@ -129,7 +129,7 @@ class Neo4jDataFrameScalaTSE extends SparkConnectorScalaBaseTSE {
       .createDataFrame(rows, schema)
     Neo4jDataFrame.mergeEdgeList(sc,
       df, ("Person", Seq("src_name")), ("ACTED_WITH", Seq.empty), ("Person", Seq("dst_name")),
-      Map.empty, 1, 10000, "skip")
+      Map.empty, 1, 10000, "match")
     val count = SparkConnectorScalaSuiteIT.session()
       .run("MATCH p=(:Person {name: 'Laurence'})-[:ACTED_WITH]->(:Person {name:'Keanu'}) RETURN count(*) as c").single().get("c").asLong()
     assertEquals(0L, count)


### PR DESCRIPTION
- [x] Added new parameter `ingestNodes` which can have three values `merge` (the default), `create`, `skip`
- [x] Added test
- [x] Updated the Readme.md