### PR TITLE
Add CQLMode enum

### DIFF
--- a/src/main/scala/org/neo4j/spark/dataframe/Neo4jDataFrame.scala
+++ b/src/main/scala/org/neo4j/spark/dataframe/Neo4jDataFrame.scala
@@ -114,10 +114,8 @@ object Neo4jDataFrame {
   def toJava(x: Any): Any = {
     import scala.collection.JavaConverters._
     x match {
-        // error: No implicit arguments of type: CanBuildFrom[_$3, (Any, Any), That_]
       case y: scala.collection.MapLike[_, _, _] =>
         y.map { case (d, v) => toJava(d) -> toJava(v) } asJava
-      // error: No implicit arguments of type: CanBuildFrom[_$2, Any, That_]
       case y: scala.collection.SetLike[_,_] =>
         y map { item: Any => toJava(item) } asJava
       case y: Iterable[_] =>

--- a/src/main/scala/org/neo4j/spark/dataframe/Neo4jDataFrame.scala
+++ b/src/main/scala/org/neo4j/spark/dataframe/Neo4jDataFrame.scala
@@ -18,11 +18,6 @@ import scala.collection.JavaConverters._
 
 object Neo4jDataFrame {
 
-  object CQLMode extends Enumeration {
-    type CQLMode = Value
-    val MERGE, CREATE, MATCH = Value
-  }
-
   import CQLMode._
   def mergeEdgeList(sc: SparkContext,
                     dataFrame: DataFrame,
@@ -265,4 +260,9 @@ object CypherTypes {
     StructType(fields)
   }
 
+}
+
+object CQLMode extends Enumeration {
+  type CQLMode = Value
+  val MERGE, CREATE, MATCH = Value
 }

--- a/src/test/scala/org/neo4j/spark/Neo4jDataFrameScalaTSE.scala
+++ b/src/test/scala/org/neo4j/spark/Neo4jDataFrameScalaTSE.scala
@@ -8,6 +8,7 @@ import org.apache.spark.sql.{Row, SQLContext}
 import org.junit.Assert._
 import org.junit._
 import org.neo4j.spark.dataframe.Neo4jDataFrame
+import org.neo4j.spark.dataframe.Neo4jDataFrame.CQLMode
 
 
 /**
@@ -129,7 +130,7 @@ class Neo4jDataFrameScalaTSE extends SparkConnectorScalaBaseTSE {
       .createDataFrame(rows, schema)
     Neo4jDataFrame.mergeEdgeList(sc,
       df, ("Person", Seq("src_name")), ("ACTED_WITH", Seq.empty), ("Person", Seq("dst_name")),
-      Map.empty, 1, 10000, "match")
+      Map.empty, 1, 10000, CQLMode.CREATE)
     val count = SparkConnectorScalaSuiteIT.session()
       .run("MATCH p=(:Person {name: 'Laurence'})-[:ACTED_WITH]->(:Person {name:'Keanu'}) RETURN count(*) as c").single().get("c").asLong()
     assertEquals(0L, count)

--- a/src/test/scala/org/neo4j/spark/Neo4jDataFrameScalaTSE.scala
+++ b/src/test/scala/org/neo4j/spark/Neo4jDataFrameScalaTSE.scala
@@ -8,7 +8,7 @@ import org.apache.spark.sql.{Row, SQLContext}
 import org.junit.Assert._
 import org.junit._
 import org.neo4j.spark.dataframe.Neo4jDataFrame
-import org.neo4j.spark.dataframe.Neo4jDataFrame.CQLMode
+import org.neo4j.spark.dataframe.CQLMode
 
 
 /**


### PR DESCRIPTION
- Add a CQLMode enum contains MERGE, CREATE, MATCH which can reduce the error caused by passing typos to `Neo4jDataFrame.mergeEdgeList(nodeOperation="")`.
- IDEA shows `toJava` function in Neo4jDataFrame object has an error:`No implicit arguments of type: CanBuildFrom[_$2, Any, That_]`, this error doesn't affect code compiles.