### PR TITLE
 fixes #143: [WriteSupport] Write a dataframe to Neo4j via provided query

### DIFF
--- a/doc/docs/modules/ROOT/pages/quickstart_writer.adoc
+++ b/doc/docs/modules/ROOT/pages/quickstart_writer.adoc
@@ -190,5 +190,3 @@ Under the hod the Spark Connector will flatten the data in this way:
 |NY
 
 |===
-
-

--- a/doc/docs/modules/ROOT/pages/quickstart_writer.adoc
+++ b/doc/docs/modules/ROOT/pages/quickstart_writer.adoc
@@ -190,3 +190,29 @@ Under the hod the Spark Connector will flatten the data in this way:
 |NY
 
 |===
+
+===== Query
+
+In case you use the option `query` the Spark Connector will persist the entire Dataset by using the provided query.
+The nodes will be sent to Neo4j in a batch of rows defined in the `batch.size` property and we will
+perform the under the hood un `UNWIND` operation over the batch.
+
+So given the following simple Spark program:
+
+----
+ds.write
+  .format("org.neo4j.spark.DataSource")
+  .option("url", "bolt://localhost:7687")
+  .option("query", "CREATE (n:Person{fullName: event.name + event.surname})")
+  .save()
+----
+
+Under the hod the Spark Connector will perform the following Cypher query:
+
+[source,cypher]
+----
+UNwIND $events AS event
+CREATE (n:Person{fullName: event.name + event.surname})
+----
+
+Where `event` represents each Dataset row.

--- a/src/main/scala/org/neo4j/spark/service/MappingService.scala
+++ b/src/main/scala/org/neo4j/spark/service/MappingService.scala
@@ -1,5 +1,7 @@
 package org.neo4j.spark.service
 
+import java.util.function.BiConsumer
+
 import org.apache.spark.sql.catalyst.InternalRow
 import org.apache.spark.sql.types.StructType
 import org.neo4j.driver.Values
@@ -7,12 +9,26 @@ import org.neo4j.driver.internal.value.MapValue
 import org.neo4j.spark.util.Neo4jUtil
 import org.neo4j.spark.{Neo4jOptions, QueryType}
 
-import collection.JavaConverters._
+import scala.collection.JavaConverters._
 
 class MappingService(private val options: Neo4jOptions) {
 
-  private def toQuery(record: InternalRow, structType: StructType): java.util.Map[String, Object] = {
-    throw new UnsupportedOperationException("TODO implement the method")
+  private def toQuery(row: InternalRow, schema: StructType): java.util.Map[String, AnyRef] = {
+    val seq = row.toSeq(schema)
+    (0 to schema.size - 1)
+      .flatMap(i => {
+        val field = schema(i)
+        val neo4jValue = Neo4jUtil.convertFromSpark(seq(i), field)
+        neo4jValue match {
+          case map: MapValue => Neo4jUtil.flattenMap(map.asMap(), field.name)
+            .asScala
+            .map(t => (t._1, Values.value(t._2)))
+            .toSeq
+          case _ => Seq((field.name, neo4jValue))
+        }
+      })
+      .toMap
+      .asJava
   }
 
   private def toRelationship(record: InternalRow, structType: StructType): java.util.Map[String, Object] = {
@@ -26,26 +42,14 @@ class MappingService(private val options: Neo4jOptions) {
     rowMap.put("keys", keys)
     rowMap.put("properties", properties)
 
-    val seq = row.toSeq(schema)
-    (0 to schema.size - 1)
-        .flatMap(i => {
-          val field = schema(i)
-          val neo4jValue = Neo4jUtil.convertFromSpark(seq(i), field)
-          neo4jValue match {
-            case map: MapValue => Neo4jUtil.flattenMap(map.asMap(), field.name)
-                .asScala
-                .map(t => (t._1, Values.value(t._2)))
-                .toSeq
-            case _ => Seq((field.name, neo4jValue))
-          }
-        })
-        .foreach(t => {
-          if (options.nodeMetadata.nodeKeys.contains(t._1)) {
-            keys.put(t._1, t._2)
+    toQuery(row, schema)
+      .forEach(new BiConsumer[String, AnyRef] {
+        override def accept(key: String, value: AnyRef): Unit = if (options.nodeMetadata.nodeKeys.contains(key)) {
+            keys.put(key, value)
           } else {
-            properties.put(t._1, t._2)
+            properties.put(key, value)
           }
-        })
+      })
 
     rowMap
   }

--- a/src/main/scala/org/neo4j/spark/service/Neo4jQueryService.scala
+++ b/src/main/scala/org/neo4j/spark/service/Neo4jQueryService.scala
@@ -5,7 +5,10 @@ import org.neo4j.spark.{Neo4jOptions, QueryType}
 import org.neo4j.spark.util.Neo4jImplicits._
 
 class Neo4jQueryWriteStrategy(private val saveMode: SaveMode) extends Neo4jQueryStrategy {
-  override def createStatementForQuery(options: Neo4jOptions): String = throw new UnsupportedOperationException("TODO implement method")
+  override def createStatementForQuery(options: Neo4jOptions): String =
+    s"""UNWIND ${"$"}events AS event
+      |${options.query.value}
+      |""".stripMargin
 
   override def createStatementForRelationships(options: Neo4jOptions): String = throw new UnsupportedOperationException("TODO implement method")
 

--- a/src/main/scala/org/neo4j/spark/service/SchemaService.scala
+++ b/src/main/scala/org/neo4j/spark/service/SchemaService.scala
@@ -7,6 +7,7 @@ import org.neo4j.cypherdsl.core.Cypher
 import org.neo4j.cypherdsl.core.renderer.Renderer
 import org.neo4j.driver.exceptions.ClientException
 import org.neo4j.driver.Session
+import org.neo4j.driver.summary.QueryType
 import org.neo4j.spark.util.Neo4jUtil
 import org.neo4j.spark.{DriverCache, Neo4jOptions, Neo4jQuery}
 
@@ -101,6 +102,11 @@ class SchemaService(private val options: Neo4jOptions, private val jobId: String
       case RELATIONSHIP => queryForRelationship()
       case QUERY => query()
     }
+  }
+
+  def isReadQuery(query: String): Boolean = {
+    val queryType = session.run(s"EXPLAIN $query").consume().queryType()
+    queryType == QueryType.READ_ONLY || queryType == QueryType.SCHEMA_WRITE
   }
 
   override def close(): Unit = {

--- a/src/main/scala/org/neo4j/spark/util/Neo4jUtil.scala
+++ b/src/main/scala/org/neo4j/spark/util/Neo4jUtil.scala
@@ -20,7 +20,6 @@ object Neo4jUtil {
   private val properties = new Properties()
   properties.load(Thread.currentThread().getContextClassLoader().getResourceAsStream("neo4j-spark-connector.properties"))
 
-
   val unsupportedTransientCodes = Set("Neo.TransientError.Transaction.Terminated",
     "Neo.TransientError.Transaction.LockClientStopped") // use the same strategy for TransientException as in the driver
 

--- a/src/main/scala/org/neo4j/spark/util/Validations.scala
+++ b/src/main/scala/org/neo4j/spark/util/Validations.scala
@@ -1,0 +1,39 @@
+package org.neo4j.spark.util
+
+import org.apache.spark.sql.SaveMode
+import org.neo4j.driver.AccessMode
+import org.neo4j.spark.service.SchemaService
+import org.neo4j.spark.{DriverCache, Neo4jOptions, QueryType}
+
+object Validations {
+
+  val writer: (Neo4jOptions, String, SaveMode) => Unit = { (neo4jOptions, jobId, saveMode) =>
+    if (neo4jOptions.session.accessMode == AccessMode.READ) {
+      throw new IllegalArgumentException(s"Mode READ not supported for Data Source writer")
+    }
+    val schemaService = new SchemaService(neo4jOptions, jobId)
+    val cache = new DriverCache(neo4jOptions.connection, jobId)
+    try {
+      neo4jOptions.query.queryType match {
+        case QueryType.QUERY => {
+          if (schemaService.isReadQuery(s"WITH {} AS event ${neo4jOptions.query.value}")) {
+            throw new IllegalArgumentException(s"Please provide a valid WRITE query")
+          }
+        }
+        case QueryType.LABELS => {
+          saveMode match {
+            case SaveMode.Overwrite => {
+              if (neo4jOptions.nodeMetadata.nodeKeys.isEmpty) {
+                throw new IllegalArgumentException(s"${Neo4jOptions.NODE_KEYS} is required when Save Mode is Overwrite")
+              }
+            }
+            case _ => Unit
+          }
+        }
+      }
+    } finally {
+      schemaService.close()
+      cache.close()
+    }
+  }
+}


### PR DESCRIPTION
This PR fixes #143 allowing the user to define a simple query in order to ingest a Spark's Dataset via Cypher query in the following way:

```scala
ds.write
  .format("org.neo4j.spark.DataSource")
  .option("url", "bolt://localhost:7687")
  .option("query", "CREATE (n:Person{fullName: event.name + event.surname})")
  .save()
```