### PR TITLE
Fixed Antora documentation generation

### DIFF
--- a/doc/docs.yml
+++ b/doc/docs.yml
@@ -1,10 +1,10 @@
 site:
   title: Neo4j Spark Connector User Guide
-  url: /docs
+  url: /neo4j-spark-docs
 content:
   sources:
-    - url: ../
-      branches: antora_docs
+    - url: https://github.com/neo4j-contrib/neo4j-spark-connector
+      branches: '4.0'
       start_path: doc/docs
 ui:
   bundle:

--- a/doc/server.js
+++ b/doc/server.js
@@ -3,6 +3,6 @@ const express = require('express')
 const app = express()
 app.use(express.static('./build/site'))
 
-app.get('/', (req, res) => res.redirect('/docs/1.0.0'))
+app.get('/', (req, res) => res.redirect('/neo4j-spark-docs/1.0.0'))
 
 app.listen(8000, () => console.log('📘 http://localhost:8000'))


### PR DESCRIPTION
Fixed the following 2 problems with the Antora configuration:

- Antora builds correctly but browsing to `localhost:8000` we get an error: `Cannot GET /docs/1.0.0`
- Antora builds correctly but `build/site` folder remains empty (no playbook were generated)