### PR TITLE
fixes #140: [ReadSupport] Add support for reading from Neo4j by a provided query

### DIFF
--- a/doc/docs/modules/ROOT/pages/quickstart.adoc
+++ b/doc/docs/modules/ROOT/pages/quickstart.adoc
@@ -128,8 +128,9 @@ in case you set this option will have the priority compared to the one defined i
 |No
 
 |`access.mode`
-|Access mode
-|`write`
+|Used only while you're pulling data from Neo4j. In case is `read` the connector, in a cluster environment
+will route the requests to the followers, otherwise to the leader.
+|`read`
 |No
 
 4+|*Data Read Options*
@@ -168,6 +169,12 @@ every single node property as column prefixed by `source` or `target`
 |`schema.flatten.limit`
 |Number of records to be used to create the Schema (only if APOC are not installed)
 |`10`
+|No
+
+|`schema.strategy`
+|Strategy used by the connector in order to compute the Schema definition for the Dataset. Values `string` and
+`sample`. If `string` coerces all the properties to String otherwise it will try to sample the Neo4j's dataset.
+|`sample`
 |No
 
 |===
@@ -329,12 +336,13 @@ Will create this schema
 
 === Read data by Relationship Type
 
-You can both specify a Cypher Path in this way:
+You can specify a Cypher Path in this way:
 ```scala
 val df = spark.read.format("org.neo4j.spark.DataSource")
       .option("relationship", "BOUGHT")
       .option("relationship.source.labels", "Person")
       .option("relationship.target.labels", "Product")
+      .load()
 
 df.show()
 ```
@@ -362,6 +370,49 @@ otherwise if `false`:
 * `<sourceLabels>` a list of labels for source node
 * `<targetId>` the internal Neo4j id of target node
 * `<targetLabels>` a list of labels for target node
+
+==== Schema
+
+If APOC are installed, schema will be created with `apoc.meta.relTypeProperties`. Otherwise the first 10 (or any number specified by the `schema.flatten.limit` option) results will be flattened and the schema will be create from those properties.
+
+=== Read data by custom Cypher Query
+
+You can specify a Cypher query in this way:
+```scala
+val df = spark.read.format("org.neo4j.spark.DataSource")
+      .option("query", "MATCH (n:Person) WITH n LIMIT 2 RETURN collect(n) AS nodes")
+      .load()
+
+df.show()
+```
+
+[NOTE]
+We recommend that individual property fields be returned, rather than returning  graph entity (node, relationship, and path) types.
+This best maps to spark's type system and yields best results.
+So instead writing this `MATCH (p:Person) RETURN p` please write this: `MATCH (p:Person) RETURN id(p) as id, p.name as name`.
+If your query returns a graph entity please use the `labels` or `relationship`.
+
+The struct of the Dataset returned by the query is influenced by the query itself, in this particular context it could happen
+that the connector could not be able to sample the Schema from the query, in these particular cases we suggest trying with
+the option `schema.strategy` defined as `string` as it follows:
+
+```scala
+val df = spark.read.format("org.neo4j.spark.DataSource")
+      .option("query", "MATCH (n:Person) WITH n LIMIT 2 RETURN collect(n) AS nodes")
+      .option("schema.strategy", "string")
+      .load()
+
+df.show()
+```
+
+This means that the struct returned by the query will be composed by strings that you can than cast via simply Spark's
+transformations.
+
+[NOTE]
+Inference (`schema.strategy` = `sample`) is good when all instances of a property in neo4j are the same type,
+and string followed by cast is better when property types may differ.
+Remember that Neo4j does not enforce property typing, and so `person.age` could sometimes be a `long
+and sometimes be a `string`.
 
 ==== Schema
 

--- a/src/main/scala/org/neo4j/spark/service/Neo4jQueryService.scala
+++ b/src/main/scala/org/neo4j/spark/service/Neo4jQueryService.scala
@@ -40,7 +40,7 @@ class Neo4jQueryWriteStrategy(private val saveMode: SaveMode) extends Neo4jQuery
 class Neo4jQueryReadStrategy extends Neo4jQueryStrategy {
   private val renderer: Renderer = Renderer.getDefaultRenderer
 
-  override def createStatementForQuery(options: Neo4jOptions): String = throw new UnsupportedOperationException("TODO implement")
+  override def createStatementForQuery(options: Neo4jOptions): String = options.query.value
 
   override def createStatementForRelationships(options: Neo4jOptions): String = {
     s"""MATCH (${Neo4jUtil.RELATIONSHIP_SOURCE_ALIAS}:${options.relationshipMetadata.source.labels.mkString(":")})

--- a/src/main/scala/org/neo4j/spark/util/Neo4jImplicits.scala
+++ b/src/main/scala/org/neo4j/spark/util/Neo4jImplicits.scala
@@ -1,9 +1,59 @@
 package org.neo4j.spark.util
 
+import java.util
+
 import javax.lang.model.SourceVersion
+import org.apache.spark.sql.types.{DataTypes, StructField, StructType}
+import org.neo4j.driver.types.{Entity, Node, Relationship}
+import org.neo4j.spark.service.SchemaService
+
+import scala.collection.JavaConverters._
 
 object Neo4jImplicits {
   implicit class CypherImplicits(str: String) {
     def quote(): String = if (!SourceVersion.isIdentifier(str) && !str.trim.startsWith("`")  && !str.trim.endsWith("`")) s"`$str`" else str
+  }
+
+  implicit class EntityImplicits(entity: Entity) {
+    def toStruct(): StructType = {
+      val fields = entity.asMap().asScala
+        .groupBy(_._1)
+        .map(t => {
+          val value = t._2.head._2
+          val cypherType = SchemaService.normalizedClassNameFromGraphEntity(value)
+          StructField(t._1, SchemaService.cypherToSparkType(cypherType))
+        })
+      val entityFields = entity match {
+        case node: Node => {
+          Seq(StructField(Neo4jUtil.INTERNAL_ID_FIELD, DataTypes.LongType, nullable = false),
+            StructField(Neo4jUtil.INTERNAL_LABELS_FIELD, DataTypes.createArrayType(DataTypes.StringType), nullable = true))
+        }
+        case relationship: Relationship => {
+          Seq(StructField(Neo4jUtil.INTERNAL_REL_ID_FIELD, DataTypes.LongType, false),
+            StructField(Neo4jUtil.INTERNAL_REL_TYPE_FIELD, DataTypes.StringType, false),
+            StructField(Neo4jUtil.INTERNAL_REL_SOURCE_ID_FIELD, DataTypes.LongType, false),
+            StructField(Neo4jUtil.INTERNAL_REL_TARGET_ID_FIELD, DataTypes.LongType, false))
+        }
+      }
+
+      StructType(entityFields ++ fields)
+    }
+
+    def toMap(): java.util.Map[String, Any] = {
+      val entityMap = entity.asMap().asScala
+      val entityFields = entity match {
+        case node: Node => {
+          Map(Neo4jUtil.INTERNAL_ID_FIELD -> node.id(),
+            Neo4jUtil.INTERNAL_LABELS_FIELD-> node.labels())
+        }
+        case relationship: Relationship => {
+          Map(Neo4jUtil.INTERNAL_REL_ID_FIELD -> relationship.id(),
+            Neo4jUtil.INTERNAL_REL_TYPE_FIELD -> relationship.`type`(),
+            Neo4jUtil.INTERNAL_REL_SOURCE_ID_FIELD -> relationship.startNodeId(),
+            Neo4jUtil.INTERNAL_REL_TARGET_ID_FIELD -> relationship.endNodeId())
+        }
+      }
+      (entityFields ++ entityMap).asJava
+    }
   }
 }

--- a/src/main/scala/org/neo4j/spark/writer/Neo4jDataSourceWriter.scala
+++ b/src/main/scala/org/neo4j/spark/writer/Neo4jDataSourceWriter.scala
@@ -5,6 +5,7 @@ import org.apache.spark.sql.catalyst.InternalRow
 import org.apache.spark.sql.sources.v2.DataSourceOptions
 import org.apache.spark.sql.sources.v2.writer.{DataSourceWriter, DataWriterFactory, WriterCommitMessage}
 import org.apache.spark.sql.types.StructType
+import org.neo4j.driver.AccessMode
 import org.neo4j.spark.util.Validations
 import org.neo4j.spark.{DriverCache, Neo4jOptions}
 
@@ -13,7 +14,10 @@ class Neo4jDataSourceWriter(jobId: String,
                             saveMode: SaveMode,
                             options: DataSourceOptions) extends DataSourceWriter {
 
-  private val neo4jOptions: Neo4jOptions = new Neo4jOptions(options.asMap())
+  private val optionsMap = options.asMap()
+  optionsMap.put(Neo4jOptions.ACCESS_MODE, AccessMode.WRITE.toString)
+
+  private val neo4jOptions: Neo4jOptions = new Neo4jOptions(optionsMap)
     .validate(neo4jOptions => Validations.writer(neo4jOptions, jobId, saveMode))
 
   private val driverCache = new DriverCache(neo4jOptions.connection, jobId)

--- a/src/test/scala/org/neo4j/spark/DataSourceWriterTSE.scala
+++ b/src/test/scala/org/neo4j/spark/DataSourceWriterTSE.scala
@@ -374,7 +374,7 @@ class DataSourceWriterTSE extends SparkConnectorScalaBaseTSE {
     assertEquals(total, records.size)
   }
 
-  @Test
+  @Test(expected = classOf[SparkException])
   def `should throw an error because the node already exists`(): Unit = {
     SparkConnectorScalaSuiteIT.session()
       .writeTransaction(new TransactionWork[Result] {
@@ -398,6 +398,7 @@ class DataSourceWriterTSE extends SparkConnectorScalaBaseTSE {
       case sparkException: SparkException => {
         val clientException = ExceptionUtils.getRootCause(sparkException)
         assertTrue(clientException.getMessage.endsWith("already exists with label `Person` and property `surname` = 'Santurbano'"))
+        throw sparkException
       }
       case _ => fail(s"should be thrown a ${classOf[SparkException].getName}")
     } finally {

--- a/src/test/scala/org/neo4j/spark/Neo4jOptionsTest.scala
+++ b/src/test/scala/org/neo4j/spark/Neo4jOptionsTest.scala
@@ -113,7 +113,7 @@ class Neo4jOptionsTest {
     val neo4jOptions: Neo4jOptions = new Neo4jOptions(options)
 
     assertEquals("", neo4jOptions.session.database)
-    assertEquals(AccessMode.WRITE, neo4jOptions.session.accessMode)
+    assertEquals(AccessMode.READ, neo4jOptions.session.accessMode)
 
     assertEquals("basic", neo4jOptions.connection.auth)
     assertEquals("", neo4jOptions.connection.username)


### PR DESCRIPTION
fixes #140 

We added the `query` option so the user can define a Cypher query like this:

```scala
val df = spark.read.format("org.neo4j.spark.DataSource")
      .option("query", "MATCH (n:Person) WITH n LIMIT 2 RETURN collect(n) AS nodes")
      .option("schema.strategy", "string")
      .load()

df.show()
```

Moreover, we added the property `schema.strategy` with `string` and `sample` (default) values, wi the first one all the fields returned by the query will be coerced to String.