### PR TITLE
Fixes issue #161: Add PushDownFilters support

### DIFF
--- a/doc/docs/modules/ROOT/pages/quickstart.adoc
+++ b/doc/docs/modules/ROOT/pages/quickstart.adoc
@@ -211,7 +211,7 @@ When using `relationship.node.map = true` or `query` the PushDownFilters support
 
 ==== How we extract the schema
 
-As Neo4j has ha schema-less approach and Spark needs a Schema in order to create a Dataset,
+As Neo4j has a schema-less approach and Spark needs a Schema in order to create a Dataset,
 we use several approaches in order to sample the dataset into Neo4j and compute the schema for Spark's Dataset.
 
 ===== Extract schema for Nodes

--- a/doc/docs/modules/ROOT/pages/quickstart.adoc
+++ b/doc/docs/modules/ROOT/pages/quickstart.adoc
@@ -408,12 +408,6 @@ df.show()
 This means that the struct returned by the query will be composed by strings that you can than cast via simply Spark's
 transformations.
 
-[NOTE]
-Inference (`schema.strategy` = `sample`) is good when all instances of a property in neo4j are the same type,
-and string followed by cast is better when property types may differ.
-Remember that Neo4j does not enforce property typing, and so `person.age` could sometimes be a `long
-and sometimes be a `string`.
-
 ==== Schema
 
 If APOC are installed, schema will be created with `apoc.meta.relTypeProperties`. Otherwise the first 10 (or any number specified by the `schema.flatten.limit` option) results will be flattened and the schema will be create from those properties.

--- a/doc/docs/modules/ROOT/pages/quickstart.adoc
+++ b/doc/docs/modules/ROOT/pages/quickstart.adoc
@@ -177,6 +177,11 @@ every single node property as column prefixed by `source` or `target`
 |`sample`
 |No
 
+|`pushdown.filters.enabled`
+|Enable or disable the Push Down Filters support
+|`true`
+|No
+
 |===
 
 ^*^ Just one of the options can be specified.
@@ -194,6 +199,15 @@ Reading data from a Neo4j Database can be done in 3 ways:
 Spark works with data in a tabular fixed schema. To accomplish this Neo4j Connector has a schema infer system that creates the schema based on the data requested for the read. Each read data method has is own strategy to create it, that will be explained it each section.
 
 TK list of supported data types
+
+=== Consideration on the filters
+
+The Neo4j Spark Connector implements the SupportPushDownFilters interface, that allows you to push the Spark filters down to the Neo4j layer. In this way the data that Spark will receive will be already filtered by Neo4j.
+
+You can manually disable the Push Down Filters support using the `pushdown.filters.enabled` option and set it to `false` (default is `true`).
+
+[NOTE]
+When using `relationship.node.map = true` or `query` the PushDownFilters support is not active, thus the filters will be applied by Spark and not by Neo4j.
 
 ==== How we extract the schema
 
@@ -388,8 +402,6 @@ If `relationship.node.map` is set to **true**
 * ``\`<target>`.\`[property]` `` for the target node map property
 
 in this case, all the map values will be strings, so the filter value must be a string too.
-
-**Note**: when using `relationship.node.map = true` the PushDownFilters support is not active, thus the filters will be applied by Spark and not by Neo4j.
 
 ```scala
 val df = spark.read.format("org.neo4j.spark.DataSource")

--- a/doc/docs/modules/ROOT/pages/quickstart.adoc
+++ b/doc/docs/modules/ROOT/pages/quickstart.adoc
@@ -371,9 +371,36 @@ otherwise if `false`:
 * `<targetId>` the internal Neo4j id of target node
 * `<targetLabels>` a list of labels for target node
 
+==== Filter
+
+You can use Spark to filter properties of the relationship, the source node, or the target node. Just use the correct prefix:
+
+If `relationship.node.map` is set to **false**
+
+* `source.[property]` for the source node properties
+* `rel.[property]` for the relation property
+* `target.[property]` for the target node property
+
+If `relationship.node.map` is set to **true**
+
+* ``\`<source>`.[property]`` for the source node map properties
+* ``\`<rel>`.[property]`` for the relation map property
+* ``\`<target>`.[property]`` for the target node map property
+
+```scala
+val df = spark.read.format("org.neo4j.spark.DataSource")
+      .option("relationship.node.map", false)
+      .option("relationship", "BOUGHT")
+      .option("relationship.source.labels", "Person")
+      .option("relationship.target.labels", "Product")
+      .load()
+
+df.where("source.name = 'John Doe' AND target.price >= 33")
+```
+
 ==== Schema
 
-If APOC are installed, schema will be created with `apoc.meta.relTypeProperties`. Otherwise the first 10 (or any number specified by the `schema.flatten.limit` option) results will be flattened and the schema will be create from those properties.
+If APOC are available, the schema will be created with `apoc.meta.relTypeProperties`. Otherwise the first 10 (or any number specified by the `schema.flatten.limit` option) results will be flattened and the schema will be create from those properties.
 
 === Read data by custom Cypher Query
 

--- a/doc/docs/modules/ROOT/pages/quickstart.adoc
+++ b/doc/docs/modules/ROOT/pages/quickstart.adoc
@@ -377,15 +377,19 @@ You can use Spark to filter properties of the relationship, the source node, or 
 
 If `relationship.node.map` is set to **false**
 
-* `source.[property]` for the source node properties
-* `rel.[property]` for the relation property
-* `target.[property]` for the target node property
+* ``\`source.[property]` `` for the source node properties
+* ``\`rel.[property]` `` for the relation property
+* ``\`target.[property]` `` for the target node property
 
 If `relationship.node.map` is set to **true**
 
-* ``\`<source>`.[property]`` for the source node map properties
-* ``\`<rel>`.[property]`` for the relation map property
-* ``\`<target>`.[property]`` for the target node map property
+* ``\`<source>`.\`[property]` `` for the source node map properties
+* ``\`<rel>`.\`[property]` `` for the relation map property
+* ``\`<target>`.\`[property]` `` for the target node map property
+
+in this case, all the map values will be strings, so the filter value must be a string too.
+
+**Note**: when using `relationship.node.map = true` the PushDownFilters support is not active, thus the filters will be applied by Spark and not by Neo4j.
 
 ```scala
 val df = spark.read.format("org.neo4j.spark.DataSource")

--- a/doc/docs/modules/ROOT/pages/quickstart.adoc
+++ b/doc/docs/modules/ROOT/pages/quickstart.adoc
@@ -439,6 +439,12 @@ df.show()
 This means that the struct returned by the query will be composed by strings that you can than cast via simply Spark's
 transformations.
 
+[NOTE]
+Inference (`schema.strategy` = `sample`) is good when all instances of a property in neo4j are the same type,
+and string followed by cast is better when property types may differ.
+Remember that Neo4j does not enforce property typing, and so `person.age` could sometimes be a `long
+and sometimes be a `string`.
+
 ==== Schema
 
 If APOC are installed, schema will be created with `apoc.meta.relTypeProperties`. Otherwise the first 10 (or any number specified by the `schema.flatten.limit` option) results will be flattened and the schema will be create from those properties.

--- a/doc/docs/modules/ROOT/pages/quickstart.adoc
+++ b/doc/docs/modules/ROOT/pages/quickstart.adoc
@@ -206,6 +206,12 @@ The Neo4j Spark Connector implements the SupportPushDownFilters interface, that 
 
 You can manually disable the Push Down Filters support using the `pushdown.filters.enabled` option and set it to `false` (default is `true`).
 
+If you use use the filter function more than once, like in this example:
+```scala
+df.where("name = 'John Doe'").where("age = 32")
+```
+The conditions will be automatically joined with an `AND` operator.
+
 [NOTE]
 When using `relationship.node.map = true` or `query` the PushDownFilters support is not active, thus the filters will be applied by Spark and not by Neo4j.
 
@@ -321,7 +327,8 @@ When reading data with this method, the Dataframe will contain all the fields co
 
 ==== Schema
 
-If APOC are installed, schema will be created with `apoc.meta.nodeTypeProperties`. Otherwise the first 10 (or any number specified by the `schema.flatten.limit` option) results will be flattened and the schema will be create from those properties.
+If APOC are available, the schema will be created with `apoc.meta.nodeTypeProperties`.
+Otherwise the first 10 (or any number specified by the `schema.flatten.limit` option) results will be flattened and the schema will be create from those properties.
 
 ===== Example
 
@@ -416,7 +423,8 @@ df.where("source.name = 'John Doe' AND target.price >= 33")
 
 ==== Schema
 
-If APOC are available, the schema will be created with `apoc.meta.relTypeProperties`. Otherwise the first 10 (or any number specified by the `schema.flatten.limit` option) results will be flattened and the schema will be create from those properties.
+If APOC are available, the schema will be created with `apoc.meta.relTypeProperties`. 
+Otherwise the first 10 (or any number specified by the `schema.flatten.limit` option) results will be flattened and the schema will be create from those properties.
 
 === Read data by custom Cypher Query
 

--- a/src/main/scala/org/neo4j/spark/Neo4jOptions.scala
+++ b/src/main/scala/org/neo4j/spark/Neo4jOptions.scala
@@ -31,6 +31,7 @@ class Neo4jOptions(private val parameters: java.util.Map[String, String]) extend
     parameters.get(parameter).trim()
   }
 
+  val pushdownFiltersEnabled: Boolean = getParameter(PUSHDOWN_FILTERS_ENABLED, DEFAULT_PUSHDOWN_FILTERS_ENABLED.toString).toBoolean
 
   val schemaMetadata = Neo4jSchemaMetadata(getParameter(SCHEMA_FLATTEN_LIMIT, DEFAULT_SCHEMA_FLATTEN_LIMIT.toString).toInt,
     SchemaStrategy.withName(getParameter(SCHEMA_STRATEGY, DEFAULT_SCHEMA_STRATEGY.toString).toUpperCase))
@@ -242,6 +243,8 @@ object Neo4jOptions {
   val DATABASE = "database"
   val ACCESS_MODE = "access.mode"
 
+  val PUSHDOWN_FILTERS_ENABLED = "pushdown.filters.enabled"
+
   // schema options
   val SCHEMA_STRATEGY = "schema.strategy"
   val SCHEMA_FLATTEN_LIMIT = "schema.flatten.limit"
@@ -274,6 +277,7 @@ object Neo4jOptions {
   val DEFAULT_TRANSACTION_RETRIES = 3
   val DEFAULT_RELATIONSHIP_NODES_MAP = true
   val DEFAULT_SCHEMA_STRATEGY = SchemaStrategy.SAMPLE
+  val DEFAULT_PUSHDOWN_FILTERS_ENABLED = true
 }
 
 object QueryType extends Enumeration {

--- a/src/main/scala/org/neo4j/spark/reader/Neo4jDataSourceReader.scala
+++ b/src/main/scala/org/neo4j/spark/reader/Neo4jDataSourceReader.scala
@@ -3,14 +3,18 @@ package org.neo4j.spark.reader
 import java.util
 
 import org.apache.spark.sql.catalyst.InternalRow
+import org.apache.spark.sql.sources.Filter
 import org.apache.spark.sql.sources.v2.DataSourceOptions
-import org.apache.spark.sql.sources.v2.reader.{DataSourceReader, InputPartition}
+import org.apache.spark.sql.sources.v2.reader.{DataSourceReader, InputPartition, SupportsPushDownFilters, SupportsPushDownRequiredColumns}
 import org.apache.spark.sql.types.StructType
 import org.neo4j.spark.Neo4jOptions
 import org.neo4j.spark.service.SchemaService
 import org.neo4j.spark.util.Validations
 
-class Neo4jDataSourceReader(private val options: DataSourceOptions, private val jobId: String) extends DataSourceReader {
+class Neo4jDataSourceReader(private val options: DataSourceOptions, private val jobId: String) extends DataSourceReader
+  with SupportsPushDownFilters {
+
+  private var filters: Array[Filter] = Array[Filter]()
 
   private val neo4jOptions: Neo4jOptions = new Neo4jOptions(options.asMap())
     .validate(options => Validations.read(options, jobId))
@@ -27,7 +31,14 @@ class Neo4jDataSourceReader(private val options: DataSourceOptions, private val 
   override def planInputPartitions: util.ArrayList[InputPartition[InternalRow]] = {
     val schema = readSchema()
     val factoryList = new java.util.ArrayList[InputPartition[InternalRow]]
-    factoryList.add(new Neo4jInputPartitionReader(neo4jOptions, schema, jobId))
+    factoryList.add(new Neo4jInputPartitionReader(neo4jOptions, filters, schema, jobId))
     factoryList
   }
+
+  override def pushFilters(filtersArray: Array[Filter]): Array[Filter] = {
+    filters = filtersArray
+    filters
+  }
+
+  override def pushedFilters(): Array[Filter] = filters
 }

--- a/src/main/scala/org/neo4j/spark/reader/Neo4jDataSourceReader.scala
+++ b/src/main/scala/org/neo4j/spark/reader/Neo4jDataSourceReader.scala
@@ -36,8 +36,11 @@ class Neo4jDataSourceReader(private val options: DataSourceOptions, private val 
   }
 
   override def pushFilters(filtersArray: Array[Filter]): Array[Filter] = {
-    filters = filtersArray
-    filters
+    if (neo4jOptions.pushdownFiltersEnabled) {
+      filters = filtersArray
+    }
+
+    filtersArray
   }
 
   override def pushedFilters(): Array[Filter] = filters

--- a/src/main/scala/org/neo4j/spark/service/Neo4jQueryService.scala
+++ b/src/main/scala/org/neo4j/spark/service/Neo4jQueryService.scala
@@ -38,7 +38,7 @@ class Neo4jQueryWriteStrategy(private val saveMode: SaveMode) extends Neo4jQuery
   }
 }
 
-class Neo4jQueryReadStrategy(filters: Array[Filter]) extends Neo4jQueryStrategy {
+class Neo4jQueryReadStrategy(filters: Array[Filter] = Array.empty[Filter]) extends Neo4jQueryStrategy {
   private val renderer: Renderer = Renderer.getDefaultRenderer
 
   override def createStatementForQuery(options: Neo4jOptions): String = options.query.value
@@ -110,7 +110,7 @@ class Neo4jQueryReadStrategy(filters: Array[Filter]) extends Neo4jQueryStrategy 
 
   private def createNode(name: String, labels: Seq[String]) = {
     val primaryLabel = labels.head
-    val otherLabels = labels.takeRight(labels.size - 1)
+    val otherLabels = labels.tail
     Cypher.node(primaryLabel, otherLabels.asJava).named(name)
   }
 }

--- a/src/main/scala/org/neo4j/spark/service/Neo4jQueryService.scala
+++ b/src/main/scala/org/neo4j/spark/service/Neo4jQueryService.scala
@@ -52,7 +52,7 @@ class Neo4jQueryReadStrategy(filters: Array[Filter]) extends Neo4jQueryStrategy 
 
     val matchQuery = Cypher.`match`(sourceNode).`match`(targetNode).`match`(relationship)
 
-    if (options.pushdownFiltersEnabled && filters.nonEmpty) {
+    if (filters.nonEmpty) {
       val filtersMap: Map[PropertyContainer, Array[Filter]] = filters.map(filter => {
         if (filter.isAttribute(Neo4jUtil.RELATIONSHIP_SOURCE_ALIAS)) {
           (sourceNode, filter)
@@ -87,7 +87,7 @@ class Neo4jQueryReadStrategy(filters: Array[Filter]) extends Neo4jQueryStrategy 
     val node = createNode(Neo4jUtil.NODE_ALIAS, options.nodeMetadata.labels)
     val matchQuery = Cypher.`match`(node)
 
-    if (options.pushdownFiltersEnabled && filters.nonEmpty) {
+    if (filters.nonEmpty) {
       matchQuery.where(
         filters.map {
           Neo4jUtil.mapSparkFiltersToCypher(_, node)

--- a/src/main/scala/org/neo4j/spark/util/Neo4jImplicits.scala
+++ b/src/main/scala/org/neo4j/spark/util/Neo4jImplicits.scala
@@ -7,6 +7,7 @@ import org.apache.spark.sql.types.{DataTypes, StructField, StructType}
 import org.neo4j.driver.types.{Entity, Node, Relationship}
 import org.neo4j.spark.service.SchemaService
 import org.apache.spark.sql.sources.{And, EqualNullSafe, EqualTo, Filter, GreaterThan, GreaterThanOrEqual, In, IsNotNull, IsNull, LessThan, LessThanOrEqual, Not, Or, StringContains, StringEndsWith, StringStartsWith}
+import org.neo4j.cypherdsl.core.Condition
 
 import scala.collection.JavaConverters._
 
@@ -73,11 +74,14 @@ object Neo4jImplicits {
       case startWith: StringStartsWith => startWith.attribute
       case endsWith: StringEndsWith => endsWith.attribute
       case contains: StringContains => contains.attribute
+      case not: Not => not.child.getAttribute.orNull
       case _ => null
     })
 
     def isAttribute(entityType: String): Boolean = {
       getAttribute.exists(_.startsWith(entityType))
     }
+
+    def getAttributeWithoutEntityName: Option[String] = filter.getAttribute.map(_.split('.').drop(1).mkString("."))
   }
 }

--- a/src/main/scala/org/neo4j/spark/util/Neo4jImplicits.scala
+++ b/src/main/scala/org/neo4j/spark/util/Neo4jImplicits.scala
@@ -2,12 +2,10 @@ package org.neo4j.spark.util
 
 
 import javax.lang.model.SourceVersion
-import org.apache.spark.sql.sources.{EqualNullSafe, Filter}
 import org.apache.spark.sql.types.{DataTypes, StructField, StructType}
 import org.neo4j.driver.types.{Entity, Node, Relationship}
 import org.neo4j.spark.service.SchemaService
-import org.apache.spark.sql.sources.{And, EqualNullSafe, EqualTo, Filter, GreaterThan, GreaterThanOrEqual, In, IsNotNull, IsNull, LessThan, LessThanOrEqual, Not, Or, StringContains, StringEndsWith, StringStartsWith}
-import org.neo4j.cypherdsl.core.Condition
+import org.apache.spark.sql.sources.{EqualNullSafe, EqualTo, Filter, GreaterThan, GreaterThanOrEqual, In, IsNotNull, IsNull, LessThan, LessThanOrEqual, Not, StringContains, StringEndsWith, StringStartsWith}
 
 import scala.collection.JavaConverters._
 
@@ -82,6 +80,6 @@ object Neo4jImplicits {
       getAttribute.exists(_.startsWith(entityType))
     }
 
-    def getAttributeWithoutEntityName: Option[String] = filter.getAttribute.map(_.split('.').drop(1).mkString("."))
+    def getAttributeWithoutEntityName: Option[String] = filter.getAttribute.map(_.split('.').tail.mkString("."))
   }
 }

--- a/src/main/scala/org/neo4j/spark/util/Neo4jImplicits.scala
+++ b/src/main/scala/org/neo4j/spark/util/Neo4jImplicits.scala
@@ -1,17 +1,19 @@
 package org.neo4j.spark.util
 
-import java.util
 
 import javax.lang.model.SourceVersion
+import org.apache.spark.sql.sources.{EqualNullSafe, Filter}
 import org.apache.spark.sql.types.{DataTypes, StructField, StructType}
 import org.neo4j.driver.types.{Entity, Node, Relationship}
 import org.neo4j.spark.service.SchemaService
+import org.apache.spark.sql.sources.{And, EqualNullSafe, EqualTo, Filter, GreaterThan, GreaterThanOrEqual, In, IsNotNull, IsNull, LessThan, LessThanOrEqual, Not, Or, StringContains, StringEndsWith, StringStartsWith}
 
 import scala.collection.JavaConverters._
 
 object Neo4jImplicits {
+
   implicit class CypherImplicits(str: String) {
-    def quote(): String = if (!SourceVersion.isIdentifier(str) && !str.trim.startsWith("`")  && !str.trim.endsWith("`")) s"`$str`" else str
+    def quote(): String = if (!SourceVersion.isIdentifier(str) && !str.trim.startsWith("`") && !str.trim.endsWith("`")) s"`$str`" else str
   }
 
   implicit class EntityImplicits(entity: Entity) {
@@ -44,7 +46,7 @@ object Neo4jImplicits {
       val entityFields = entity match {
         case node: Node => {
           Map(Neo4jUtil.INTERNAL_ID_FIELD -> node.id(),
-            Neo4jUtil.INTERNAL_LABELS_FIELD-> node.labels())
+            Neo4jUtil.INTERNAL_LABELS_FIELD -> node.labels())
         }
         case relationship: Relationship => {
           Map(Neo4jUtil.INTERNAL_REL_ID_FIELD -> relationship.id(),
@@ -54,6 +56,27 @@ object Neo4jImplicits {
         }
       }
       (entityFields ++ entityMap).asJava
+    }
+  }
+
+  implicit class FilterImplicit(filter: Filter) {
+    def getAttribute: Option[String] = Option(filter match {
+      case eqns: EqualNullSafe => eqns.attribute
+      case eq: EqualTo => eq.attribute
+      case gt: GreaterThan => gt.attribute
+      case gte: GreaterThanOrEqual => gte.attribute
+      case lt: LessThan => lt.attribute
+      case lte: LessThanOrEqual => lte.attribute
+      case in: In => in.attribute
+      case notNull: IsNotNull => notNull.attribute
+      case isNull: IsNull => isNull.attribute
+      case startWith: StringStartsWith => startWith.attribute
+      case endsWith: StringEndsWith => endsWith.attribute
+      case contains: StringContains => contains.attribute
+    })
+
+    def isAttribute(entityType: String): Boolean = {
+      getAttribute.exists(_.startsWith(entityType))
     }
   }
 }

--- a/src/main/scala/org/neo4j/spark/util/Neo4jImplicits.scala
+++ b/src/main/scala/org/neo4j/spark/util/Neo4jImplicits.scala
@@ -73,6 +73,7 @@ object Neo4jImplicits {
       case startWith: StringStartsWith => startWith.attribute
       case endsWith: StringEndsWith => endsWith.attribute
       case contains: StringContains => contains.attribute
+      case _ => null
     })
 
     def isAttribute(entityType: String): Boolean = {

--- a/src/main/scala/org/neo4j/spark/util/Neo4jUtil.scala
+++ b/src/main/scala/org/neo4j/spark/util/Neo4jUtil.scala
@@ -10,13 +10,14 @@ import com.fasterxml.jackson.databind.module.SimpleModule
 import org.apache.spark.sql.catalyst.InternalRow
 import org.apache.spark.sql.catalyst.expressions.{GenericRowWithSchema, UnsafeArrayData, UnsafeMapData, UnsafeRow}
 import org.apache.spark.sql.catalyst.util.{ArrayBasedMapData, ArrayData, DateTimeUtils}
+import org.apache.spark.sql.sources.{And, EqualNullSafe, EqualTo, Filter, GreaterThan, GreaterThanOrEqual, In, IsNotNull, IsNull, LessThan, LessThanOrEqual, Not, Or, StringContains, StringEndsWith, StringStartsWith}
 import org.apache.spark.sql.types._
 import org.apache.spark.unsafe.types.UTF8String
-import org.neo4j.driver.internal.{InternalDatabaseName, InternalIsoDuration, InternalNode, InternalPoint2D, InternalPoint3D, InternalRelationship}
+import org.neo4j.cypherdsl.core.{Condition, Cypher, ListExpression}
+import org.neo4j.driver.internal.{InternalIsoDuration, InternalNode, InternalPoint2D, InternalPoint3D, InternalRelationship}
 import org.neo4j.driver.types.{Entity, Node, Path}
 import org.neo4j.driver.{Session, Transaction, Values}
 import org.neo4j.spark.service.SchemaService
-import org.neo4j.spark.service.SchemaService.{durationType, pointType, timeType}
 import org.neo4j.spark.util.Neo4jImplicits.EntityImplicits
 
 import scala.collection.JavaConverters._
@@ -205,15 +206,38 @@ object Neo4jUtil {
 
   def flattenMap(map: java.util.Map[String, AnyRef],
                  prefix: String = ""): java.util.Map[String, AnyRef] = map.asScala.flatMap(t => {
-      val key = if (prefix != "") s"$prefix.${t._1}" else t._1
-      t._2 match {
-        case nestedMap: Map[String, AnyRef] => flattenMap(nestedMap.asJava, key).asScala.toSeq
-        case _ => Seq((key, t._2))
-      }
-    })
+    val key = if (prefix != "") s"$prefix.${t._1}" else t._1
+    t._2 match {
+      case nestedMap: Map[String, AnyRef] => flattenMap(nestedMap.asJava, key).asScala.toSeq
+      case _ => Seq((key, t._2))
+    }
+  })
     .toMap
     .asJava
 
   def connectorVersion: String = properties.getOrDefault("version", "UNKNOWN").toString
 
+  def mapSparkFiltersToCypher(filter: Filter, node: org.neo4j.cypherdsl.core.Node): Condition = {
+    filter match {
+      case eqns: EqualNullSafe => node.property(eqns.attribute).isEqualTo(Cypher.literalOf(eqns.value))
+      case eq: EqualTo => node.property(eq.attribute).isEqualTo(Cypher.literalOf(eq.value))
+      case gt: GreaterThan => node.property(gt.attribute).gt(Cypher.literalOf(gt.value))
+      case gte: GreaterThanOrEqual => node.property(gte.attribute).gte(Cypher.literalOf(gte.value))
+      case lt: LessThan => node.property(lt.attribute).lt(Cypher.literalOf(lt.value))
+      case lte: LessThanOrEqual => node.property(lte.attribute).lte(Cypher.literalOf(lte.value))
+      case in: In => {
+        val values = in.values.map(Cypher.literalOf)
+        node.property(in.attribute).in(Cypher.literalOf(values.toIterable.asJava))
+      }
+      case notNull: IsNotNull => node.property(notNull.attribute).isNotNull
+      case isNull: IsNull => node.property(isNull.attribute).isNull
+      case startWith: StringStartsWith => node.property(startWith.attribute).startsWith(Cypher.literalOf(startWith.value))
+      case endsWith: StringEndsWith => node.property(endsWith.attribute).endsWith(Cypher.literalOf(endsWith.value))
+      case contains: StringContains => node.property(contains.attribute).contains(Cypher.literalOf(contains.value))
+      case not: Not => mapSparkFiltersToCypher(not.child, node).not()
+      case or: Or => mapSparkFiltersToCypher(or.left, node).or(mapSparkFiltersToCypher(or.right, node))
+      case and: And => mapSparkFiltersToCypher(and.left, node).and(mapSparkFiltersToCypher(and.right, node))
+      case filter@(_: Filter) => throw new IllegalArgumentException(s"Filter of type `${filter}` is not supported.")
+    }
+  }
 }

--- a/src/main/scala/org/neo4j/spark/util/Neo4jUtil.scala
+++ b/src/main/scala/org/neo4j/spark/util/Neo4jUtil.scala
@@ -13,9 +13,9 @@ import org.apache.spark.sql.catalyst.util.{ArrayBasedMapData, ArrayData, DateTim
 import org.apache.spark.sql.sources.{And, EqualNullSafe, EqualTo, Filter, GreaterThan, GreaterThanOrEqual, In, IsNotNull, IsNull, LessThan, LessThanOrEqual, Not, Or, StringContains, StringEndsWith, StringStartsWith}
 import org.apache.spark.sql.types._
 import org.apache.spark.unsafe.types.UTF8String
-import org.neo4j.cypherdsl.core.{Condition, Cypher, ListExpression}
+import org.neo4j.cypherdsl.core.{Condition, Cypher}
 import org.neo4j.driver.internal.{InternalIsoDuration, InternalNode, InternalPoint2D, InternalPoint3D, InternalRelationship}
-import org.neo4j.driver.types.{Entity, Node, Path}
+import org.neo4j.driver.types.{Entity, Path}
 import org.neo4j.driver.{Session, Transaction, Values}
 import org.neo4j.spark.service.SchemaService
 import org.neo4j.spark.util.Neo4jImplicits.EntityImplicits
@@ -217,26 +217,26 @@ object Neo4jUtil {
 
   def connectorVersion: String = properties.getOrDefault("version", "UNKNOWN").toString
 
-  def mapSparkFiltersToCypher(filter: Filter, node: org.neo4j.cypherdsl.core.Node): Condition = {
+  def mapSparkFiltersToCypher(filter: Filter, container: org.neo4j.cypherdsl.core.PropertyContainer, attributeAlias: Option[String] = None): Condition = {
     filter match {
-      case eqns: EqualNullSafe => node.property(eqns.attribute).isEqualTo(Cypher.literalOf(eqns.value))
-      case eq: EqualTo => node.property(eq.attribute).isEqualTo(Cypher.literalOf(eq.value))
-      case gt: GreaterThan => node.property(gt.attribute).gt(Cypher.literalOf(gt.value))
-      case gte: GreaterThanOrEqual => node.property(gte.attribute).gte(Cypher.literalOf(gte.value))
-      case lt: LessThan => node.property(lt.attribute).lt(Cypher.literalOf(lt.value))
-      case lte: LessThanOrEqual => node.property(lte.attribute).lte(Cypher.literalOf(lte.value))
+      case eqns: EqualNullSafe => container.property(attributeAlias.getOrElse(eqns.attribute)).isEqualTo(Cypher.literalOf(eqns.value))
+      case eq: EqualTo => container.property(attributeAlias.getOrElse(eq.attribute)).isEqualTo(Cypher.literalOf(eq.value))
+      case gt: GreaterThan => container.property(attributeAlias.getOrElse(gt.attribute)).gt(Cypher.literalOf(gt.value))
+      case gte: GreaterThanOrEqual => container.property(attributeAlias.getOrElse(gte.attribute)).gte(Cypher.literalOf(gte.value))
+      case lt: LessThan => container.property(attributeAlias.getOrElse(lt.attribute)).lt(Cypher.literalOf(lt.value))
+      case lte: LessThanOrEqual => container.property(attributeAlias.getOrElse(lte.attribute)).lte(Cypher.literalOf(lte.value))
       case in: In => {
         val values = in.values.map(Cypher.literalOf)
-        node.property(in.attribute).in(Cypher.literalOf(values.toIterable.asJava))
+        container.property(attributeAlias.getOrElse(in.attribute)).in(Cypher.literalOf(values.toIterable.asJava))
       }
-      case notNull: IsNotNull => node.property(notNull.attribute).isNotNull
-      case isNull: IsNull => node.property(isNull.attribute).isNull
-      case startWith: StringStartsWith => node.property(startWith.attribute).startsWith(Cypher.literalOf(startWith.value))
-      case endsWith: StringEndsWith => node.property(endsWith.attribute).endsWith(Cypher.literalOf(endsWith.value))
-      case contains: StringContains => node.property(contains.attribute).contains(Cypher.literalOf(contains.value))
-      case not: Not => mapSparkFiltersToCypher(not.child, node).not()
-      case or: Or => mapSparkFiltersToCypher(or.left, node).or(mapSparkFiltersToCypher(or.right, node))
-      case and: And => mapSparkFiltersToCypher(and.left, node).and(mapSparkFiltersToCypher(and.right, node))
+      case notNull: IsNotNull => container.property(attributeAlias.getOrElse(notNull.attribute)).isNotNull
+      case isNull: IsNull => container.property(attributeAlias.getOrElse(isNull.attribute)).isNull
+      case startWith: StringStartsWith => container.property(attributeAlias.getOrElse(startWith.attribute)).startsWith(Cypher.literalOf(startWith.value))
+      case endsWith: StringEndsWith => container.property(attributeAlias.getOrElse(endsWith.attribute)).endsWith(Cypher.literalOf(endsWith.value))
+      case contains: StringContains => container.property(attributeAlias.getOrElse(contains.attribute)).contains(Cypher.literalOf(contains.value))
+      case not: Not => mapSparkFiltersToCypher(not.child, container, attributeAlias).not()
+      case or: Or => mapSparkFiltersToCypher(or.left, container, attributeAlias).or(mapSparkFiltersToCypher(or.right, container, attributeAlias))
+      case and: And => mapSparkFiltersToCypher(and.left, container, attributeAlias).and(mapSparkFiltersToCypher(and.right, container, attributeAlias))
       case filter@(_: Filter) => throw new IllegalArgumentException(s"Filter of type `${filter}` is not supported.")
     }
   }

--- a/src/main/scala/org/neo4j/spark/util/Neo4jUtil.scala
+++ b/src/main/scala/org/neo4j/spark/util/Neo4jUtil.scala
@@ -235,8 +235,8 @@ object Neo4jUtil {
       case endsWith: StringEndsWith => container.property(attributeAlias.getOrElse(endsWith.attribute)).endsWith(Cypher.literalOf(endsWith.value))
       case contains: StringContains => container.property(attributeAlias.getOrElse(contains.attribute)).contains(Cypher.literalOf(contains.value))
       case not: Not => mapSparkFiltersToCypher(not.child, container, attributeAlias).not()
-      case or: Or => mapSparkFiltersToCypher(or.left, container, attributeAlias).or(mapSparkFiltersToCypher(or.right, container, attributeAlias))
-      case and: And => mapSparkFiltersToCypher(and.left, container, attributeAlias).and(mapSparkFiltersToCypher(and.right, container, attributeAlias))
+      // case or: Or => mapSparkFiltersToCypher(or.left, containerLeft, attributeAlias).or(mapSparkFiltersToCypher(or.right, containerRight, attributeAlias))
+      // case and: And => mapSparkFiltersToCypher(and.left, containerLeft, attributeAlias).and(mapSparkFiltersToCypher(and.right, containerRight, attributeAlias))
       case filter@(_: Filter) => throw new IllegalArgumentException(s"Filter of type `${filter}` is not supported.")
     }
   }

--- a/src/main/scala/org/neo4j/spark/util/Neo4jUtil.scala
+++ b/src/main/scala/org/neo4j/spark/util/Neo4jUtil.scala
@@ -220,7 +220,7 @@ object Neo4jUtil {
   def mapSparkFiltersToCypher(filter: Filter, container: org.neo4j.cypherdsl.core.PropertyContainer, attributeAlias: Option[String] = None): Condition =
     filter match {
       case eqns: EqualNullSafe => container.property(attributeAlias.getOrElse(eqns.attribute))
-        .isNull.or(container.property(attributeAlias.getOrElse(eqns.attribute)).isEqualTo(Cypher.literalOf(eqns.value)))
+        .isNull.and(Cypher.literalOf(eqns.value).isNull).or(container.property(attributeAlias.getOrElse(eqns.attribute)).isEqualTo(Cypher.literalOf(eqns.value)))
       case eq: EqualTo => container.property(attributeAlias.getOrElse(eq.attribute))
         .isEqualTo(Cypher.literalOf(eq.value))
       case gt: GreaterThan => container.property(attributeAlias.getOrElse(gt.attribute))
@@ -238,11 +238,11 @@ object Neo4jUtil {
       case notNull: IsNotNull => container.property(attributeAlias.getOrElse(notNull.attribute)).isNotNull
       case isNull: IsNull => container.property(attributeAlias.getOrElse(isNull.attribute)).isNull
       case startWith: StringStartsWith => container.property(attributeAlias.getOrElse(startWith.attribute))
-        .startsWith(Functions.coalesce(Cypher.literalOf(startWith.value), Cypher.literalOf("")))
+        .startsWith(Cypher.literalOf(startWith.value))
       case endsWith: StringEndsWith => container.property(attributeAlias.getOrElse(endsWith.attribute))
-        .endsWith(Functions.coalesce(Cypher.literalOf(endsWith.value), Cypher.literalOf("")))
+        .endsWith(Cypher.literalOf(endsWith.value))
       case contains: StringContains => container.property(attributeAlias.getOrElse(contains.attribute))
-        .contains(Functions.coalesce(Cypher.literalOf(contains.value), Cypher.literalOf("")))
+        .contains(Cypher.literalOf(contains.value))
       case not: Not => mapSparkFiltersToCypher(not.child, container, attributeAlias).not()
       case filter@(_: Filter) => throw new IllegalArgumentException(s"Filter of type `${filter}` is not supported.")
     }

--- a/src/main/scala/org/neo4j/spark/util/Neo4jUtil.scala
+++ b/src/main/scala/org/neo4j/spark/util/Neo4jUtil.scala
@@ -13,7 +13,7 @@ import org.apache.spark.sql.catalyst.util.{ArrayBasedMapData, ArrayData, DateTim
 import org.apache.spark.sql.sources.{And, EqualNullSafe, EqualTo, Filter, GreaterThan, GreaterThanOrEqual, In, IsNotNull, IsNull, LessThan, LessThanOrEqual, Not, Or, StringContains, StringEndsWith, StringStartsWith}
 import org.apache.spark.sql.types._
 import org.apache.spark.unsafe.types.UTF8String
-import org.neo4j.cypherdsl.core.{Condition, Cypher}
+import org.neo4j.cypherdsl.core.{Condition, Cypher, Functions}
 import org.neo4j.driver.internal.{InternalIsoDuration, InternalNode, InternalPoint2D, InternalPoint3D, InternalRelationship}
 import org.neo4j.driver.types.{Entity, Path}
 import org.neo4j.driver.{Session, Transaction, Values}
@@ -219,24 +219,31 @@ object Neo4jUtil {
 
   def mapSparkFiltersToCypher(filter: Filter, container: org.neo4j.cypherdsl.core.PropertyContainer, attributeAlias: Option[String] = None): Condition = {
     filter match {
-      case eqns: EqualNullSafe => container.property(attributeAlias.getOrElse(eqns.attribute)).isEqualTo(Cypher.literalOf(eqns.value))
-      case eq: EqualTo => container.property(attributeAlias.getOrElse(eq.attribute)).isEqualTo(Cypher.literalOf(eq.value))
-      case gt: GreaterThan => container.property(attributeAlias.getOrElse(gt.attribute)).gt(Cypher.literalOf(gt.value))
-      case gte: GreaterThanOrEqual => container.property(attributeAlias.getOrElse(gte.attribute)).gte(Cypher.literalOf(gte.value))
-      case lt: LessThan => container.property(attributeAlias.getOrElse(lt.attribute)).lt(Cypher.literalOf(lt.value))
-      case lte: LessThanOrEqual => container.property(attributeAlias.getOrElse(lte.attribute)).lte(Cypher.literalOf(lte.value))
+      case eqns: EqualNullSafe => container.property(attributeAlias.getOrElse(eqns.attribute))
+        .isEqualTo(Functions.coalesce(Cypher.literalOf(eqns.value), Cypher.literalOf("")))
+      case eq: EqualTo => container.property(attributeAlias.getOrElse(eq.attribute))
+        .isEqualTo(Functions.coalesce(Cypher.literalOf(eq.value), Cypher.literalOf("")))
+      case gt: GreaterThan => container.property(attributeAlias.getOrElse(gt.attribute))
+        .gt(Functions.coalesce(Cypher.literalOf(gt.value), Cypher.literalOf(0)))
+      case gte: GreaterThanOrEqual => container.property(attributeAlias.getOrElse(gte.attribute))
+        .gte(Functions.coalesce(Cypher.literalOf(gte.value), Cypher.literalOf(0)))
+      case lt: LessThan => container.property(attributeAlias.getOrElse(lt.attribute))
+        .lt(Functions.coalesce(Cypher.literalOf(lt.value), Cypher.literalOf(0)))
+      case lte: LessThanOrEqual => container.property(attributeAlias.getOrElse(lte.attribute))
+        .lte(Functions.coalesce(Cypher.literalOf(lte.value), Cypher.literalOf(0)))
       case in: In => {
         val values = in.values.map(Cypher.literalOf)
         container.property(attributeAlias.getOrElse(in.attribute)).in(Cypher.literalOf(values.toIterable.asJava))
       }
       case notNull: IsNotNull => container.property(attributeAlias.getOrElse(notNull.attribute)).isNotNull
       case isNull: IsNull => container.property(attributeAlias.getOrElse(isNull.attribute)).isNull
-      case startWith: StringStartsWith => container.property(attributeAlias.getOrElse(startWith.attribute)).startsWith(Cypher.literalOf(startWith.value))
-      case endsWith: StringEndsWith => container.property(attributeAlias.getOrElse(endsWith.attribute)).endsWith(Cypher.literalOf(endsWith.value))
-      case contains: StringContains => container.property(attributeAlias.getOrElse(contains.attribute)).contains(Cypher.literalOf(contains.value))
+      case startWith: StringStartsWith => container.property(attributeAlias.getOrElse(startWith.attribute))
+        .startsWith(Functions.coalesce(Cypher.literalOf(startWith.value), Cypher.literalOf("")))
+      case endsWith: StringEndsWith => container.property(attributeAlias.getOrElse(endsWith.attribute))
+        .endsWith(Functions.coalesce(Cypher.literalOf(endsWith.value), Cypher.literalOf("")))
+      case contains: StringContains => container.property(attributeAlias.getOrElse(contains.attribute))
+        .contains(Functions.coalesce(Cypher.literalOf(contains.value), Cypher.literalOf("")))
       case not: Not => mapSparkFiltersToCypher(not.child, container, attributeAlias).not()
-      // case or: Or => mapSparkFiltersToCypher(or.left, containerLeft, attributeAlias).or(mapSparkFiltersToCypher(or.right, containerRight, attributeAlias))
-      // case and: And => mapSparkFiltersToCypher(and.left, containerLeft, attributeAlias).and(mapSparkFiltersToCypher(and.right, containerRight, attributeAlias))
       case filter@(_: Filter) => throw new IllegalArgumentException(s"Filter of type `${filter}` is not supported.")
     }
   }

--- a/src/test/scala/org/neo4j/spark/DataSourceReaderTSE.scala
+++ b/src/test/scala/org/neo4j/spark/DataSourceReaderTSE.scala
@@ -353,6 +353,19 @@ class DataSourceReaderTSE extends SparkConnectorScalaBaseTSE {
   }
 
   @Test
+  def testReadNodeWithDifferentOperatorFilter(): Unit = {
+    val df: DataFrame = initTest(s"""
+     CREATE (p1:Person {name: 'John Doe'}),
+      (p2:Person {name: 'Jane Doe'})
+     """)
+
+    val result = df.select("name").where("name != 'John Doe'").collectAsList()
+
+    assertEquals(1, result.size())
+    assertEquals("Jane Doe", result.get(0).getString(0))
+  }
+
+  @Test
   def testReadNodeWithGtFilter(): Unit = {
     val df: DataFrame = initTest(s"""
      CREATE (p1:Person {age: 19}),
@@ -360,9 +373,10 @@ class DataSourceReaderTSE extends SparkConnectorScalaBaseTSE {
       (p3:Person {age: 21})
      """)
 
-    val result = df.where("age > 20").collectAsList()
+    val result = df.select("age").where("age > 20").collectAsList()
 
     assertEquals(1, result.size())
+    assertEquals(21, result.get(0).getLong(0))
   }
 
   @Test
@@ -373,9 +387,11 @@ class DataSourceReaderTSE extends SparkConnectorScalaBaseTSE {
       (p3:Person {age: 21})
      """)
 
-    val result = df.where("age >= 20").collectAsList()
+    val result = df.select("age").where("age >= 20").collectAsList()
 
     assertEquals(2, result.size())
+    assertEquals(20, result.get(0).getLong(0))
+    assertEquals(21, result.get(1).getLong(0))
   }
 
   @Test
@@ -386,9 +402,11 @@ class DataSourceReaderTSE extends SparkConnectorScalaBaseTSE {
       (p3:Person {score: 21,  limit: 12})
      """)
 
-    val result = df.where("score >= limit").collectAsList()
+    val result = df.select("score").where("score >= limit").collectAsList()
 
     assertEquals(2, result.size())
+    assertEquals(20, result.get(0).getLong(0))
+    assertEquals(21, result.get(1).getLong(0))
   }
 
   @Test
@@ -399,9 +417,10 @@ class DataSourceReaderTSE extends SparkConnectorScalaBaseTSE {
       (p3:Person {age: 43})
      """)
 
-    val result = df.where("age < 40").collectAsList()
+    val result = df.select("age").where("age < 40").collectAsList()
 
     assertEquals(1, result.size())
+    assertEquals(39, result.get(0).getLong(0))
   }
 
   @Test
@@ -412,9 +431,11 @@ class DataSourceReaderTSE extends SparkConnectorScalaBaseTSE {
       (p3:Person {age: 43})
      """)
 
-    val result = df.where("age <= 41").collectAsList()
+    val result = df.select("age").where("age <= 41").collectAsList()
 
     assertEquals(2, result.size())
+    assertEquals(39, result.get(0).getLong(0))
+    assertEquals(41, result.get(1).getLong(0))
   }
 
   @Test
@@ -425,9 +446,11 @@ class DataSourceReaderTSE extends SparkConnectorScalaBaseTSE {
       (p3:Person {age: 43})
      """)
 
-    val result = df.where("age IN(41,43)").collectAsList()
+    val result = df.select("age").where("age IN(41,43)").collectAsList()
 
     assertEquals(2, result.size())
+    assertEquals(41, result.get(0).getLong(0))
+    assertEquals(43, result.get(1).getLong(0))
   }
 
   @Test
@@ -438,9 +461,10 @@ class DataSourceReaderTSE extends SparkConnectorScalaBaseTSE {
       (p3:Person {age: 43})
      """)
 
-    val result = df.where("age IS NULL").collectAsList()
+    val result = df.select("age").where("age IS NULL").collectAsList()
 
     assertEquals(1, result.size())
+    assertNull(result.get(0).get(0))
   }
 
   @Test
@@ -451,9 +475,11 @@ class DataSourceReaderTSE extends SparkConnectorScalaBaseTSE {
       (p3:Person {age: 43})
      """)
 
-    val result = df.where("age IS NOT NULL").collectAsList()
+    val result = df.select("age").where("age IS NOT NULL").collectAsList()
 
     assertEquals(2, result.size())
+    assertEquals(39, result.get(0).getLong(0))
+    assertEquals(43, result.get(1).getLong(0))
   }
 
   @Test
@@ -464,9 +490,11 @@ class DataSourceReaderTSE extends SparkConnectorScalaBaseTSE {
       (p3:Person {age: 43})
      """)
 
-    val result = df.where("age = 43 OR age = 39 OR age = 32").collectAsList()
+    val result = df.select("age").where("age = 43 OR age = 39 OR age = 32").collectAsList()
 
     assertEquals(2, result.size())
+    assertEquals(39, result.get(0).getLong(0))
+    assertEquals(43, result.get(1).getLong(0))
   }
 
   @Test
@@ -477,9 +505,11 @@ class DataSourceReaderTSE extends SparkConnectorScalaBaseTSE {
       (p3:Person {age: 43})
      """)
 
-    val result = df.where("age >= 39 AND age <= 43").collectAsList()
+    val result = df.select("age").where("age >= 39 AND age <= 43").collectAsList()
 
     assertEquals(2, result.size())
+    assertEquals(39, result.get(0).getLong(0))
+    assertEquals(43, result.get(1).getLong(0))
   }
 
   @Test
@@ -490,9 +520,13 @@ class DataSourceReaderTSE extends SparkConnectorScalaBaseTSE {
       (p3:Person {name: 'John Butler'})
      """)
 
-    val result = df.where("name LIKE 'John%'").collectAsList()
+    val result = df.select("name").where("name LIKE 'John%'").collectAsList()
 
     assertEquals(3, result.size())
+    assertEquals("John Mayer", result.get(0).getString(0))
+    assertEquals("John Scofield", result.get(1).getString(0))
+    assertEquals("John Butler", result.get(2).getString(0))
+
   }
 
   @Test
@@ -503,9 +537,10 @@ class DataSourceReaderTSE extends SparkConnectorScalaBaseTSE {
       (p3:Person {name: 'John Butler'})
      """)
 
-    val result = df.where("name LIKE '%Scofield'").collectAsList()
+    val result = df.select("name").where("name LIKE '%Scofield'").collectAsList()
 
     assertEquals(1, result.size())
+    assertEquals("John Scofield", result.get(0).getString(0))
   }
 
   @Test
@@ -516,9 +551,10 @@ class DataSourceReaderTSE extends SparkConnectorScalaBaseTSE {
       (p3:Person {name: 'John Butler'})
      """)
 
-    val result = df.where("name LIKE '%ay%'").collectAsList()
+    val result = df.select("name").where("name LIKE '%ay%'").collectAsList()
 
     assertEquals(1, result.size())
+    assertEquals("John Mayer", result.get(0).getString(0))
   }
 
   @Test
@@ -546,7 +582,7 @@ class DataSourceReaderTSE extends SparkConnectorScalaBaseTSE {
       .option("relationship.target.labels", "Person")
       .load()
 
-    assertEquals(1, df.filter("`<source>`.`id` = '14' AND `<target>`.`id` = '16'").collectAsList().size())
+    assertEquals(1, df.filter("`<source>`.`id` = '14' AND `<target>`.`id` = '16'").count)
   }
 
   @Test
@@ -575,7 +611,7 @@ class DataSourceReaderTSE extends SparkConnectorScalaBaseTSE {
       .option("relationship.target.labels", "Person")
       .load()
 
-    assertEquals(1, df.filter("`source.id` = 14 AND `target.id` = 16").collectAsList().size())
+    assertEquals(1, df.filter("`source.id` = 14 AND `target.id` = 16").count)
   }
 
   @Test

--- a/src/test/scala/org/neo4j/spark/DataSourceReaderTSE.scala
+++ b/src/test/scala/org/neo4j/spark/DataSourceReaderTSE.scala
@@ -387,7 +387,7 @@ class DataSourceReaderTSE extends SparkConnectorScalaBaseTSE {
       (p3:Person {age: 21})
      """)
 
-    val result = df.select("age").where("age >= 20").collectAsList()
+    val result = df.select("age").orderBy("age").where("age >= 20").collectAsList()
 
     assertEquals(2, result.size())
     assertEquals(20, result.get(0).getLong(0))
@@ -402,7 +402,7 @@ class DataSourceReaderTSE extends SparkConnectorScalaBaseTSE {
       (p3:Person {score: 21,  limit: 12})
      """)
 
-    val result = df.select("score").where("score >= limit").collectAsList()
+    val result = df.select("score").orderBy("score").where("score >= limit").collectAsList()
 
     assertEquals(2, result.size())
     assertEquals(20, result.get(0).getLong(0))
@@ -417,7 +417,7 @@ class DataSourceReaderTSE extends SparkConnectorScalaBaseTSE {
       (p3:Person {age: 43})
      """)
 
-    val result = df.select("age").where("age < 40").collectAsList()
+    val result = df.select("age").orderBy("age").where("age < 40").collectAsList()
 
     assertEquals(1, result.size())
     assertEquals(39, result.get(0).getLong(0))
@@ -431,7 +431,7 @@ class DataSourceReaderTSE extends SparkConnectorScalaBaseTSE {
       (p3:Person {age: 43})
      """)
 
-    val result = df.select("age").where("age <= 41").collectAsList()
+    val result = df.select("age").orderBy("age").where("age <= 41").collectAsList()
 
     assertEquals(2, result.size())
     assertEquals(39, result.get(0).getLong(0))
@@ -446,7 +446,7 @@ class DataSourceReaderTSE extends SparkConnectorScalaBaseTSE {
       (p3:Person {age: 43})
      """)
 
-    val result = df.select("age").where("age IN(41,43)").collectAsList()
+    val result = df.select("age").orderBy("age").where("age IN(41,43)").collectAsList()
 
     assertEquals(2, result.size())
     assertEquals(41, result.get(0).getLong(0))
@@ -475,7 +475,7 @@ class DataSourceReaderTSE extends SparkConnectorScalaBaseTSE {
       (p3:Person {age: 43})
      """)
 
-    val result = df.select("age").where("age IS NOT NULL").collectAsList()
+    val result = df.select("age").orderBy("age").where("age IS NOT NULL").collectAsList()
 
     assertEquals(2, result.size())
     assertEquals(39, result.get(0).getLong(0))
@@ -490,7 +490,7 @@ class DataSourceReaderTSE extends SparkConnectorScalaBaseTSE {
       (p3:Person {age: 43})
      """)
 
-    val result = df.select("age").where("age = 43 OR age = 39 OR age = 32").collectAsList()
+    val result = df.select("age").orderBy("age").where("age = 43 OR age = 39 OR age = 32").collectAsList()
 
     assertEquals(2, result.size())
     assertEquals(39, result.get(0).getLong(0))
@@ -505,7 +505,7 @@ class DataSourceReaderTSE extends SparkConnectorScalaBaseTSE {
       (p3:Person {age: 43})
      """)
 
-    val result = df.select("age").where("age >= 39 AND age <= 43").collectAsList()
+    val result = df.select("age").orderBy("age").where("age >= 39 AND age <= 43").collectAsList()
 
     assertEquals(2, result.size())
     assertEquals(39, result.get(0).getLong(0))
@@ -520,13 +520,12 @@ class DataSourceReaderTSE extends SparkConnectorScalaBaseTSE {
       (p3:Person {name: 'John Butler'})
      """)
 
-    val result = df.select("name").where("name LIKE 'John%'").collectAsList()
+    val result = df.select("name").orderBy("name").where("name LIKE 'John%'").collectAsList()
 
     assertEquals(3, result.size())
-    assertEquals("John Mayer", result.get(0).getString(0))
-    assertEquals("John Scofield", result.get(1).getString(0))
-    assertEquals("John Butler", result.get(2).getString(0))
-
+    assertEquals("John Butler", result.get(0).getString(0))
+    assertEquals("John Mayer", result.get(1).getString(0))
+    assertEquals("John Scofield", result.get(2).getString(0))
   }
 
   @Test

--- a/src/test/scala/org/neo4j/spark/DataSourceReaderTSE.scala
+++ b/src/test/scala/org/neo4j/spark/DataSourceReaderTSE.scala
@@ -292,7 +292,8 @@ class DataSourceReaderTSE extends SparkConnectorScalaBaseTSE {
   def testReadNodeWithArrayZonedDateTime(): Unit = {
     val datetime1 = "2015-06-24T12:50:35.556+01:00"
     val datetime2 = "2015-06-23T12:50:35.556+01:00"
-    val df: DataFrame = initTest(s"""
+    val df: DataFrame = initTest(
+      s"""
      CREATE (p:Person {aTime: [
       datetime('$datetime1'),
       datetime('$datetime2')
@@ -328,7 +329,8 @@ class DataSourceReaderTSE extends SparkConnectorScalaBaseTSE {
 
   @Test
   def testReadNodeWithEqualToFilter(): Unit = {
-    val df: DataFrame = initTest(s"""
+    val df: DataFrame = initTest(
+      s"""
      CREATE (p1:Person {name: 'John Doe'}),
       (p2:Person {name: 'Jane Doe'})
      """)
@@ -340,8 +342,23 @@ class DataSourceReaderTSE extends SparkConnectorScalaBaseTSE {
   }
 
   @Test
+  def testReadNodeWithEqualToDateFilter(): Unit = {
+    val df: DataFrame = initTest(
+      s"""
+     CREATE (p1:Person {birth: date('1998-02-04')}),
+      (p2:Person {birth: date('1988-01-05')})
+     """)
+
+    val result = df.select("birth").where("birth = '1988-01-05'").collectAsList()
+
+    assertEquals(1, result.size())
+    assertEquals(java.sql.Date.valueOf("1988-01-05"), result.get(0).getDate(0))
+  }
+
+  @Test
   def testReadNodeWithNotEqualToFilter(): Unit = {
-    val df: DataFrame = initTest(s"""
+    val df: DataFrame = initTest(
+      s"""
      CREATE (p1:Person {name: 'John Doe'}),
       (p2:Person {name: 'Jane Doe'})
      """)
@@ -353,8 +370,23 @@ class DataSourceReaderTSE extends SparkConnectorScalaBaseTSE {
   }
 
   @Test
+  def testReadNodeWithNotEqualToDateFilter(): Unit = {
+    val df: DataFrame = initTest(
+      s"""
+     CREATE (p1:Person {birth: date('1998-02-04')}),
+      (p2:Person {birth: date('1988-01-05')})
+     """)
+
+    val result = df.select("birth").where("NOT birth = '1988-01-05'").collectAsList()
+
+    assertEquals(1, result.size())
+    assertEquals(java.sql.Date.valueOf("1998-02-04"), result.get(0).getDate(0))
+  }
+
+  @Test
   def testReadNodeWithDifferentOperatorFilter(): Unit = {
-    val df: DataFrame = initTest(s"""
+    val df: DataFrame = initTest(
+      s"""
      CREATE (p1:Person {name: 'John Doe'}),
       (p2:Person {name: 'Jane Doe'})
      """)
@@ -367,7 +399,8 @@ class DataSourceReaderTSE extends SparkConnectorScalaBaseTSE {
 
   @Test
   def testReadNodeWithGtFilter(): Unit = {
-    val df: DataFrame = initTest(s"""
+    val df: DataFrame = initTest(
+      s"""
      CREATE (p1:Person {age: 19}),
       (p2:Person {age: 20}),
       (p3:Person {age: 21})
@@ -380,8 +413,44 @@ class DataSourceReaderTSE extends SparkConnectorScalaBaseTSE {
   }
 
   @Test
+  def testReadNodeWithGtDateFilter(): Unit = {
+    val df: DataFrame = initTest(
+      s"""
+     CREATE (p1:Person {birth: date('1998-02-04')}),
+      (p2:Person {birth: date('1988-01-05')}),
+      (p3:Person {birth: date('1994-10-16')})
+     """)
+
+    val result = df.select("birth").orderBy("birth").where("birth > '1990-01-01'").collectAsList()
+
+    assertEquals(2, result.size())
+    assertEquals(java.sql.Date.valueOf("1994-10-16"), result.get(0).getDate(0))
+    assertEquals(java.sql.Date.valueOf("1998-02-04"), result.get(1).getDate(0))
+  }
+
+  @Test
+  def testReadNodeWithGtSpatialFilter(): Unit = {
+    val df: DataFrame = initTest(
+      s"""
+     CREATE (p:Person {location: point({x: 12, y: 12})}),
+      (p2:Person {location: point({x: -6, y: -6})})
+     """)
+
+    val result = df.select("location").where("location.x > 0").collectAsList()
+    val row = result.get(0).getAs[GenericRowWithSchema](0);
+
+    assertEquals(1, result.size())
+
+    assertEquals("point-2d", row.get(0))
+    assertEquals(7203, row.get(1))
+    assertEquals(12.0, row.get(2))
+    assertEquals(12.0, row.get(3))
+  }
+
+  @Test
   def testReadNodeWithGteFilter(): Unit = {
-    val df: DataFrame = initTest(s"""
+    val df: DataFrame = initTest(
+      s"""
      CREATE (p1:Person {age: 19}),
       (p2:Person {age: 20}),
       (p3:Person {age: 21})
@@ -396,7 +465,8 @@ class DataSourceReaderTSE extends SparkConnectorScalaBaseTSE {
 
   @Test
   def testReadNodeWithGteFilterWithProp(): Unit = {
-    val df: DataFrame = initTest(s"""
+    val df: DataFrame = initTest(
+      s"""
      CREATE (p1:Person {score: 19, limit: 20}),
       (p2:Person {score: 20,  limit: 18}),
       (p3:Person {score: 21,  limit: 12})
@@ -411,7 +481,8 @@ class DataSourceReaderTSE extends SparkConnectorScalaBaseTSE {
 
   @Test
   def testReadNodeWithLtFilter(): Unit = {
-    val df: DataFrame = initTest(s"""
+    val df: DataFrame = initTest(
+      s"""
      CREATE (p1:Person {age: 39}),
       (p2:Person {age: 41}),
       (p3:Person {age: 43})
@@ -425,7 +496,8 @@ class DataSourceReaderTSE extends SparkConnectorScalaBaseTSE {
 
   @Test
   def testReadNodeWithLteFilter(): Unit = {
-    val df: DataFrame = initTest(s"""
+    val df: DataFrame = initTest(
+      s"""
      CREATE (p1:Person {age: 39}),
       (p2:Person {age: 41}),
       (p3:Person {age: 43})
@@ -440,7 +512,8 @@ class DataSourceReaderTSE extends SparkConnectorScalaBaseTSE {
 
   @Test
   def testReadNodeWithInFilter(): Unit = {
-    val df: DataFrame = initTest(s"""
+    val df: DataFrame = initTest(
+      s"""
      CREATE (p1:Person {age: 39}),
       (p2:Person {age: 41}),
       (p3:Person {age: 43})
@@ -455,7 +528,8 @@ class DataSourceReaderTSE extends SparkConnectorScalaBaseTSE {
 
   @Test
   def testReadNodeWithIsNullFilter(): Unit = {
-    val df: DataFrame = initTest(s"""
+    val df: DataFrame = initTest(
+      s"""
      CREATE (p1:Person {age: 39}),
       (p2:Person {age: null}),
       (p3:Person {age: 43})
@@ -469,7 +543,8 @@ class DataSourceReaderTSE extends SparkConnectorScalaBaseTSE {
 
   @Test
   def testReadNodeWithIsNotNullFilter(): Unit = {
-    val df: DataFrame = initTest(s"""
+    val df: DataFrame = initTest(
+      s"""
      CREATE (p1:Person {age: 39}),
       (p2:Person {age: null}),
       (p3:Person {age: 43})
@@ -484,7 +559,8 @@ class DataSourceReaderTSE extends SparkConnectorScalaBaseTSE {
 
   @Test
   def testReadNodeWithOrCondition(): Unit = {
-    val df: DataFrame = initTest(s"""
+    val df: DataFrame = initTest(
+      s"""
      CREATE (p1:Person {age: 39}),
       (p2:Person {age: null}),
       (p3:Person {age: 43})
@@ -499,7 +575,8 @@ class DataSourceReaderTSE extends SparkConnectorScalaBaseTSE {
 
   @Test
   def testReadNodeWithAndCondition(): Unit = {
-    val df: DataFrame = initTest(s"""
+    val df: DataFrame = initTest(
+      s"""
      CREATE (p1:Person {age: 39}),
       (p2:Person {age: null}),
       (p3:Person {age: 43})
@@ -514,7 +591,8 @@ class DataSourceReaderTSE extends SparkConnectorScalaBaseTSE {
 
   @Test
   def testReadNodeWithStartsWith(): Unit = {
-    val df: DataFrame = initTest(s"""
+    val df: DataFrame = initTest(
+      s"""
      CREATE (p1:Person {name: 'John Mayer'}),
       (p2:Person {name: 'John Scofield'}),
       (p3:Person {name: 'John Butler'})
@@ -530,7 +608,8 @@ class DataSourceReaderTSE extends SparkConnectorScalaBaseTSE {
 
   @Test
   def testReadNodeWithEndsWith(): Unit = {
-    val df: DataFrame = initTest(s"""
+    val df: DataFrame = initTest(
+      s"""
      CREATE (p1:Person {name: 'John Mayer'}),
       (p2:Person {name: 'John Scofield'}),
       (p3:Person {name: 'John Butler'})
@@ -544,7 +623,8 @@ class DataSourceReaderTSE extends SparkConnectorScalaBaseTSE {
 
   @Test
   def testReadNodeWithContains(): Unit = {
-    val df: DataFrame = initTest(s"""
+    val df: DataFrame = initTest(
+      s"""
      CREATE (p1:Person {name: 'John Mayer'}),
       (p2:Person {name: 'John Scofield'}),
       (p3:Person {name: 'John Butler'})
@@ -680,10 +760,10 @@ class DataSourceReaderTSE extends SparkConnectorScalaBaseTSE {
     val total = 100
     val fixtureQuery: String =
       s"""UNWIND range(1, $total) as id
-        |CREATE (pr:Product {id: id * rand(), name: 'Product ' + id})
-        |CREATE (pe:Person {id: id, fullName: 'Person ' + id})
-        |CREATE (pe)-[:BOUGHT{when: rand(), quantity: rand() * 1000}]->(pr)
-        |RETURN *
+         |CREATE (pr:Product {id: id * rand(), name: 'Product ' + id})
+         |CREATE (pe:Person {id: id, fullName: 'Person ' + id})
+         |CREATE (pe)-[:BOUGHT{when: rand(), quantity: rand() * 1000}]->(pr)
+         |RETURN *
     """.stripMargin
 
     SparkConnectorScalaSuiteIT.session()
@@ -702,7 +782,7 @@ class DataSourceReaderTSE extends SparkConnectorScalaBaseTSE {
 
     val count = df.collectAsList()
       .asScala
-      .filter(row =>row.getAs[Long]("<rel.id>") != null
+      .filter(row => row.getAs[Long]("<rel.id>") != null
         && row.getAs[String]("<rel.type>") != null
         && row.getAs[Long]("rel.when") != null
         && row.getAs[Long]("rel.quantity") != null
@@ -744,7 +824,7 @@ class DataSourceReaderTSE extends SparkConnectorScalaBaseTSE {
 
     val rows = df.collectAsList().asScala
     val count = rows
-      .filter(row =>row.getAs[Long]("<rel.id>") != null
+      .filter(row => row.getAs[Long]("<rel.id>") != null
         && row.getAs[String]("<rel.type>") != null
         && row.getAs[Long]("rel.when") != null
         && row.getAs[Long]("rel.quantity") != null
@@ -848,11 +928,11 @@ class DataSourceReaderTSE extends SparkConnectorScalaBaseTSE {
       .map(_.getAs[Row]("rel"))
       .filter(row =>
         row.getAs[Long]("<rel.id>") != null
-        && !row.getAs[String]("<rel.type>").isEmpty
-        && row.getAs[Long]("<source.id>") != null
-        && row.getAs[Long]("<target.id>") != null
-        && row.getAs[Double]("when") != null
-        && row.getAs[Double]("quantity") != null
+          && !row.getAs[String]("<rel.type>").isEmpty
+          && row.getAs[Long]("<source.id>") != null
+          && row.getAs[Long]("<target.id>") != null
+          && row.getAs[Double]("when") != null
+          && row.getAs[Double]("quantity") != null
       )
       .size
     assertEquals(100, countRel)

--- a/src/test/scala/org/neo4j/spark/DataSourceReaderTSE.scala
+++ b/src/test/scala/org/neo4j/spark/DataSourceReaderTSE.scala
@@ -522,7 +522,7 @@ class DataSourceReaderTSE extends SparkConnectorScalaBaseTSE {
   }
 
   @Test
-  def testRelFilters(): Unit = {
+  def testRelFiltersWithMap(): Unit = {
     val fixtureQuery: String =
       """UNWIND range(1,100) as id
         |CREATE (p:Person {id:id,ids:[id,id]}) WITH collect(p) as people
@@ -542,12 +542,40 @@ class DataSourceReaderTSE extends SparkConnectorScalaBaseTSE {
     val df = ss.read.format(classOf[DataSource].getName)
       .option("url", SparkConnectorScalaSuiteIT.server.getBoltUrl)
       .option("relationship", "KNOWS")
-      // .option("relationship.nodes.map", "false")
       .option("relationship.source.labels", "Person")
       .option("relationship.target.labels", "Person")
       .load()
 
-    df.filter("`<source>`.id = 10").show()
+    assertEquals(1, df.filter("`<source>`.`id` = '10' AND `<target>`.`id` = '1'").collectAsList().size())
+  }
+
+  @Test
+  def testRelFiltersWithoutMap(): Unit = {
+    val fixtureQuery: String =
+      """UNWIND range(1,100) as id
+        |CREATE (p:Person {id:id,ids:[id,id]}) WITH collect(p) as people
+        |UNWIND people as p1
+        |UNWIND range(1,10) as friend
+        |WITH p1, people[(p1.id + friend) % size(people)] as p2
+        |CREATE (p1)-[:KNOWS]->(p2)
+        |RETURN *
+    """.stripMargin
+
+    SparkConnectorScalaSuiteIT.session()
+      .writeTransaction(
+        new TransactionWork[ResultSummary] {
+          override def execute(tx: Transaction): ResultSummary = tx.run(fixtureQuery).consume()
+        })
+
+    val df = ss.read.format(classOf[DataSource].getName)
+      .option("url", SparkConnectorScalaSuiteIT.server.getBoltUrl)
+      .option("relationship", "KNOWS")
+      .option("relationship.nodes.map", "false")
+      .option("relationship.source.labels", "Person")
+      .option("relationship.target.labels", "Person")
+      .load()
+
+    assertEquals(1, df.filter("`source.id` = 10 AND `target.id` = 1").collectAsList().size())
   }
 
   @Test

--- a/src/test/scala/org/neo4j/spark/DataSourceReaderTSE.scala
+++ b/src/test/scala/org/neo4j/spark/DataSourceReaderTSE.scala
@@ -522,7 +522,36 @@ class DataSourceReaderTSE extends SparkConnectorScalaBaseTSE {
   }
 
   @Test
-  def testReadNodeRepartition(): Unit = {
+  def testRelFilters(): Unit = {
+    val fixtureQuery: String =
+      """UNWIND range(1,100) as id
+        |CREATE (p:Person {id:id,ids:[id,id]}) WITH collect(p) as people
+        |UNWIND people as p1
+        |UNWIND range(1,10) as friend
+        |WITH p1, people[(p1.id + friend) % size(people)] as p2
+        |CREATE (p1)-[:KNOWS]->(p2)
+        |RETURN *
+    """.stripMargin
+
+    SparkConnectorScalaSuiteIT.session()
+      .writeTransaction(
+        new TransactionWork[ResultSummary] {
+          override def execute(tx: Transaction): ResultSummary = tx.run(fixtureQuery).consume()
+        })
+
+    val df = ss.read.format(classOf[DataSource].getName)
+      .option("url", SparkConnectorScalaSuiteIT.server.getBoltUrl)
+      .option("relationship", "KNOWS")
+      // .option("relationship.nodes.map", "false")
+      .option("relationship.source.labels", "Person")
+      .option("relationship.target.labels", "Person")
+      .load()
+
+    df.filter("`<source>`.id = 10").show()
+  }
+
+  @Test
+  def testReadRelationshipFilters(): Unit = {
     val fixtureQuery: String =
       """UNWIND range(1,100) as id
         |CREATE (p:Person {id:id,ids:[id,id]}) WITH collect(p) as people

--- a/src/test/scala/org/neo4j/spark/DataSourceReaderTSE.scala
+++ b/src/test/scala/org/neo4j/spark/DataSourceReaderTSE.scala
@@ -546,7 +546,7 @@ class DataSourceReaderTSE extends SparkConnectorScalaBaseTSE {
       .option("relationship.target.labels", "Person")
       .load()
 
-    assertEquals(1, df.filter("`<source>`.`id` = '10' AND `<target>`.`id` = '1'").collectAsList().size())
+    assertEquals(1, df.filter("`<source>`.`id` = '14' AND `<target>`.`id` = '16'").collectAsList().size())
   }
 
   @Test
@@ -575,7 +575,7 @@ class DataSourceReaderTSE extends SparkConnectorScalaBaseTSE {
       .option("relationship.target.labels", "Person")
       .load()
 
-    assertEquals(1, df.filter("`source.id` = 10 AND `target.id` = 1").collectAsList().size())
+    assertEquals(1, df.filter("`source.id` = 14 AND `target.id` = 16").collectAsList().size())
   }
 
   @Test

--- a/src/test/scala/org/neo4j/spark/DataSourceReaderWithApocTSE.scala
+++ b/src/test/scala/org/neo4j/spark/DataSourceReaderWithApocTSE.scala
@@ -387,7 +387,7 @@ class DataSourceReaderWithApocTSE extends SparkConnectorScalaBaseWithApocTSE {
       (p3:Person {age: 21})
      """)
 
-    val result = df.select("age").where("age >= 20").collectAsList()
+    val result = df.select("age").orderBy("age").where("age >= 20").collectAsList()
 
     assertEquals(2, result.size())
     assertEquals(20, result.get(0).getLong(0))
@@ -402,7 +402,7 @@ class DataSourceReaderWithApocTSE extends SparkConnectorScalaBaseWithApocTSE {
       (p3:Person {score: 21,  limit: 12})
      """)
 
-    val result = df.select("score").where("score >= limit").collectAsList()
+    val result = df.select("score").orderBy("score").where("score >= limit").collectAsList()
 
     assertEquals(2, result.size())
     assertEquals(20, result.get(0).getLong(0))
@@ -417,7 +417,7 @@ class DataSourceReaderWithApocTSE extends SparkConnectorScalaBaseWithApocTSE {
       (p3:Person {age: 43})
      """)
 
-    val result = df.select("age").where("age < 40").collectAsList()
+    val result = df.select("age").orderBy("age").where("age < 40").collectAsList()
 
     assertEquals(1, result.size())
     assertEquals(39, result.get(0).getLong(0))
@@ -431,7 +431,7 @@ class DataSourceReaderWithApocTSE extends SparkConnectorScalaBaseWithApocTSE {
       (p3:Person {age: 43})
      """)
 
-    val result = df.select("age").where("age <= 41").collectAsList()
+    val result = df.select("age").orderBy("age").where("age <= 41").collectAsList()
 
     assertEquals(2, result.size())
     assertEquals(39, result.get(0).getLong(0))
@@ -446,7 +446,7 @@ class DataSourceReaderWithApocTSE extends SparkConnectorScalaBaseWithApocTSE {
       (p3:Person {age: 43})
      """)
 
-    val result = df.select("age").where("age IN(41,43)").collectAsList()
+    val result = df.select("age").orderBy("age").where("age IN(41,43)").collectAsList()
 
     assertEquals(2, result.size())
     assertEquals(41, result.get(0).getLong(0))
@@ -475,7 +475,7 @@ class DataSourceReaderWithApocTSE extends SparkConnectorScalaBaseWithApocTSE {
       (p3:Person {age: 43})
      """)
 
-    val result = df.select("age").where("age IS NOT NULL").collectAsList()
+    val result = df.select("age").orderBy("age").where("age IS NOT NULL").collectAsList()
 
     assertEquals(2, result.size())
     assertEquals(39, result.get(0).getLong(0))
@@ -490,7 +490,7 @@ class DataSourceReaderWithApocTSE extends SparkConnectorScalaBaseWithApocTSE {
       (p3:Person {age: 43})
      """)
 
-    val result = df.select("age").where("age = 43 OR age = 39 OR age = 32").collectAsList()
+    val result = df.select("age").orderBy("age").where("age = 43 OR age = 39 OR age = 32").collectAsList()
 
     assertEquals(2, result.size())
     assertEquals(39, result.get(0).getLong(0))
@@ -505,7 +505,7 @@ class DataSourceReaderWithApocTSE extends SparkConnectorScalaBaseWithApocTSE {
       (p3:Person {age: 43})
      """)
 
-    val result = df.select("age").where("age >= 39 AND age <= 43").collectAsList()
+    val result = df.select("age").orderBy("age").where("age >= 39 AND age <= 43").collectAsList()
 
     assertEquals(2, result.size())
     assertEquals(39, result.get(0).getLong(0))
@@ -520,13 +520,12 @@ class DataSourceReaderWithApocTSE extends SparkConnectorScalaBaseWithApocTSE {
       (p3:Person {name: 'John Butler'})
      """)
 
-    val result = df.select("name").where("name LIKE 'John%'").collectAsList()
+    val result = df.select("name").orderBy("name").where("name LIKE 'John%'").collectAsList()
 
     assertEquals(3, result.size())
-    assertEquals("John Mayer", result.get(0).getString(0))
-    assertEquals("John Scofield", result.get(1).getString(0))
-    assertEquals("John Butler", result.get(2).getString(0))
-
+    assertEquals("John Butler", result.get(0).getString(0))
+    assertEquals("John Mayer", result.get(1).getString(0))
+    assertEquals("John Scofield", result.get(2).getString(0))
   }
 
   @Test
@@ -681,10 +680,10 @@ class DataSourceReaderWithApocTSE extends SparkConnectorScalaBaseWithApocTSE {
     val total = 100
     val fixtureQuery: String =
       s"""UNWIND range(1, $total) as id
-        |CREATE (pr:Product {id: id * rand(), name: 'Product ' + id})
-        |CREATE (pe:Person {id: id, fullName: 'Person ' + id})
-        |CREATE (pe)-[:BOUGHT{when: rand(), quantity: rand() * 1000}]->(pr)
-        |RETURN *
+         |CREATE (pr:Product {id: id * rand(), name: 'Product ' + id})
+         |CREATE (pe:Person {id: id, fullName: 'Person ' + id})
+         |CREATE (pe)-[:BOUGHT{when: rand(), quantity: rand() * 1000}]->(pr)
+         |RETURN *
     """.stripMargin
 
     SparkConnectorScalaSuiteWithApocIT.session()
@@ -703,7 +702,7 @@ class DataSourceReaderWithApocTSE extends SparkConnectorScalaBaseWithApocTSE {
 
     val count = df.collectAsList()
       .asScala
-      .filter(row =>row.getAs[Long]("<rel.id>") != null
+      .filter(row => row.getAs[Long]("<rel.id>") != null
         && row.getAs[String]("<rel.type>") != null
         && row.getAs[Long]("rel.when") != null
         && row.getAs[Long]("rel.quantity") != null
@@ -745,7 +744,7 @@ class DataSourceReaderWithApocTSE extends SparkConnectorScalaBaseWithApocTSE {
 
     val rows = df.collectAsList().asScala
     val count = rows
-      .filter(row =>row.getAs[Long]("<rel.id>") != null
+      .filter(row => row.getAs[Long]("<rel.id>") != null
         && row.getAs[String]("<rel.type>") != null
         && row.getAs[Long]("rel.when") != null
         && row.getAs[Long]("rel.quantity") != null

--- a/src/test/scala/org/neo4j/spark/DataSourceReaderWithApocTSE.scala
+++ b/src/test/scala/org/neo4j/spark/DataSourceReaderWithApocTSE.scala
@@ -353,6 +353,19 @@ class DataSourceReaderWithApocTSE extends SparkConnectorScalaBaseWithApocTSE {
   }
 
   @Test
+  def testReadNodeWithDifferentOperatorFilter(): Unit = {
+    val df: DataFrame = initTest(s"""
+     CREATE (p1:Person {name: 'John Doe'}),
+      (p2:Person {name: 'Jane Doe'})
+     """)
+
+    val result = df.select("name").where("name != 'John Doe'").collectAsList()
+
+    assertEquals(1, result.size())
+    assertEquals("Jane Doe", result.get(0).getString(0))
+  }
+
+  @Test
   def testReadNodeWithGtFilter(): Unit = {
     val df: DataFrame = initTest(s"""
      CREATE (p1:Person {age: 19}),
@@ -360,9 +373,10 @@ class DataSourceReaderWithApocTSE extends SparkConnectorScalaBaseWithApocTSE {
       (p3:Person {age: 21})
      """)
 
-    val result = df.where("age > 20").collectAsList()
+    val result = df.select("age").where("age > 20").collectAsList()
 
     assertEquals(1, result.size())
+    assertEquals(21, result.get(0).getLong(0))
   }
 
   @Test
@@ -373,9 +387,11 @@ class DataSourceReaderWithApocTSE extends SparkConnectorScalaBaseWithApocTSE {
       (p3:Person {age: 21})
      """)
 
-    val result = df.where("age >= 20").collectAsList()
+    val result = df.select("age").where("age >= 20").collectAsList()
 
     assertEquals(2, result.size())
+    assertEquals(20, result.get(0).getLong(0))
+    assertEquals(21, result.get(1).getLong(0))
   }
 
   @Test
@@ -386,9 +402,11 @@ class DataSourceReaderWithApocTSE extends SparkConnectorScalaBaseWithApocTSE {
       (p3:Person {score: 21,  limit: 12})
      """)
 
-    val result = df.where("score >= limit").collectAsList()
+    val result = df.select("score").where("score >= limit").collectAsList()
 
     assertEquals(2, result.size())
+    assertEquals(20, result.get(0).getLong(0))
+    assertEquals(21, result.get(1).getLong(0))
   }
 
   @Test
@@ -399,9 +417,10 @@ class DataSourceReaderWithApocTSE extends SparkConnectorScalaBaseWithApocTSE {
       (p3:Person {age: 43})
      """)
 
-    val result = df.where("age < 40").collectAsList()
+    val result = df.select("age").where("age < 40").collectAsList()
 
     assertEquals(1, result.size())
+    assertEquals(39, result.get(0).getLong(0))
   }
 
   @Test
@@ -412,9 +431,11 @@ class DataSourceReaderWithApocTSE extends SparkConnectorScalaBaseWithApocTSE {
       (p3:Person {age: 43})
      """)
 
-    val result = df.where("age <= 41").collectAsList()
+    val result = df.select("age").where("age <= 41").collectAsList()
 
     assertEquals(2, result.size())
+    assertEquals(39, result.get(0).getLong(0))
+    assertEquals(41, result.get(1).getLong(0))
   }
 
   @Test
@@ -425,9 +446,11 @@ class DataSourceReaderWithApocTSE extends SparkConnectorScalaBaseWithApocTSE {
       (p3:Person {age: 43})
      """)
 
-    val result = df.where("age IN(41,43)").collectAsList()
+    val result = df.select("age").where("age IN(41,43)").collectAsList()
 
     assertEquals(2, result.size())
+    assertEquals(41, result.get(0).getLong(0))
+    assertEquals(43, result.get(1).getLong(0))
   }
 
   @Test
@@ -438,9 +461,10 @@ class DataSourceReaderWithApocTSE extends SparkConnectorScalaBaseWithApocTSE {
       (p3:Person {age: 43})
      """)
 
-    val result = df.where("age IS NULL").collectAsList()
+    val result = df.select("age").where("age IS NULL").collectAsList()
 
     assertEquals(1, result.size())
+    assertNull(result.get(0).get(0))
   }
 
   @Test
@@ -451,9 +475,11 @@ class DataSourceReaderWithApocTSE extends SparkConnectorScalaBaseWithApocTSE {
       (p3:Person {age: 43})
      """)
 
-    val result = df.where("age IS NOT NULL").collectAsList()
+    val result = df.select("age").where("age IS NOT NULL").collectAsList()
 
     assertEquals(2, result.size())
+    assertEquals(39, result.get(0).getLong(0))
+    assertEquals(43, result.get(1).getLong(0))
   }
 
   @Test
@@ -464,9 +490,11 @@ class DataSourceReaderWithApocTSE extends SparkConnectorScalaBaseWithApocTSE {
       (p3:Person {age: 43})
      """)
 
-    val result = df.where("age = 43 OR age = 39 OR age = 32").collectAsList()
+    val result = df.select("age").where("age = 43 OR age = 39 OR age = 32").collectAsList()
 
     assertEquals(2, result.size())
+    assertEquals(39, result.get(0).getLong(0))
+    assertEquals(43, result.get(1).getLong(0))
   }
 
   @Test
@@ -477,9 +505,11 @@ class DataSourceReaderWithApocTSE extends SparkConnectorScalaBaseWithApocTSE {
       (p3:Person {age: 43})
      """)
 
-    val result = df.where("age >= 39 AND age <= 43").collectAsList()
+    val result = df.select("age").where("age >= 39 AND age <= 43").collectAsList()
 
     assertEquals(2, result.size())
+    assertEquals(39, result.get(0).getLong(0))
+    assertEquals(43, result.get(1).getLong(0))
   }
 
   @Test
@@ -490,9 +520,13 @@ class DataSourceReaderWithApocTSE extends SparkConnectorScalaBaseWithApocTSE {
       (p3:Person {name: 'John Butler'})
      """)
 
-    val result = df.where("name LIKE 'John%'").collectAsList()
+    val result = df.select("name").where("name LIKE 'John%'").collectAsList()
 
     assertEquals(3, result.size())
+    assertEquals("John Mayer", result.get(0).getString(0))
+    assertEquals("John Scofield", result.get(1).getString(0))
+    assertEquals("John Butler", result.get(2).getString(0))
+
   }
 
   @Test
@@ -503,9 +537,10 @@ class DataSourceReaderWithApocTSE extends SparkConnectorScalaBaseWithApocTSE {
       (p3:Person {name: 'John Butler'})
      """)
 
-    val result = df.where("name LIKE '%Scofield'").collectAsList()
+    val result = df.select("name").where("name LIKE '%Scofield'").collectAsList()
 
     assertEquals(1, result.size())
+    assertEquals("John Scofield", result.get(0).getString(0))
   }
 
   @Test
@@ -516,9 +551,10 @@ class DataSourceReaderWithApocTSE extends SparkConnectorScalaBaseWithApocTSE {
       (p3:Person {name: 'John Butler'})
      """)
 
-    val result = df.where("name LIKE '%ay%'").collectAsList()
+    val result = df.select("name").where("name LIKE '%ay%'").collectAsList()
 
     assertEquals(1, result.size())
+    assertEquals("John Mayer", result.get(0).getString(0))
   }
 
   @Test
@@ -546,7 +582,7 @@ class DataSourceReaderWithApocTSE extends SparkConnectorScalaBaseWithApocTSE {
       .option("relationship.target.labels", "Person")
       .load()
 
-    assertEquals(1, df.filter("`<source>`.`id` = '10' AND `<target>`.`id` = '1'").collectAsList().size())
+    assertEquals(1, df.filter("`<source>`.`id` = '14' AND `<target>`.`id` = '16'").collectAsList().size())
   }
 
   @Test
@@ -575,7 +611,7 @@ class DataSourceReaderWithApocTSE extends SparkConnectorScalaBaseWithApocTSE {
       .option("relationship.target.labels", "Person")
       .load()
 
-    assertEquals(1, df.filter("`source.id` = 10 AND `target.id` = 1").collectAsList().size())
+    assertEquals(1, df.filter("`source.id` = 14 AND `target.id` = 16").collectAsList().size())
   }
 
   @Test

--- a/src/test/scala/org/neo4j/spark/DataSourceReaderWithApocTSE.scala
+++ b/src/test/scala/org/neo4j/spark/DataSourceReaderWithApocTSE.scala
@@ -327,6 +327,201 @@ class DataSourceReaderWithApocTSE extends SparkConnectorScalaBaseWithApocTSE {
   }
 
   @Test
+  def testReadNodeWithEqualToFilter(): Unit = {
+    val df: DataFrame = initTest(s"""
+     CREATE (p1:Person {name: 'John Doe'}),
+      (p2:Person {name: 'Jane Doe'})
+     """)
+
+    val result = df.select("name").where("name = 'John Doe'").collectAsList()
+
+    assertEquals(1, result.size())
+    assertEquals("John Doe", result.get(0).getString(0))
+  }
+
+  @Test
+  def testReadNodeWithNotEqualToFilter(): Unit = {
+    val df: DataFrame = initTest(s"""
+     CREATE (p1:Person {name: 'John Doe'}),
+      (p2:Person {name: 'Jane Doe'})
+     """)
+
+    val result = df.select("name").where("NOT name = 'John Doe'").collectAsList()
+
+    assertEquals(1, result.size())
+    assertEquals("Jane Doe", result.get(0).getString(0))
+  }
+
+  @Test
+  def testReadNodeWithGtFilter(): Unit = {
+    val df: DataFrame = initTest(s"""
+     CREATE (p1:Person {age: 19}),
+      (p2:Person {age: 20}),
+      (p3:Person {age: 21})
+     """)
+
+    val result = df.where("age > 20").collectAsList()
+
+    assertEquals(1, result.size())
+  }
+
+  @Test
+  def testReadNodeWithGteFilter(): Unit = {
+    val df: DataFrame = initTest(s"""
+     CREATE (p1:Person {age: 19}),
+      (p2:Person {age: 20}),
+      (p3:Person {age: 21})
+     """)
+
+    val result = df.where("age >= 20").collectAsList()
+
+    assertEquals(2, result.size())
+  }
+
+  @Test
+  def testReadNodeWithGteFilterWithProp(): Unit = {
+    val df: DataFrame = initTest(s"""
+     CREATE (p1:Person {score: 19, limit: 20}),
+      (p2:Person {score: 20,  limit: 18}),
+      (p3:Person {score: 21,  limit: 12})
+     """)
+
+    val result = df.where("score >= limit").collectAsList()
+
+    assertEquals(2, result.size())
+  }
+
+  @Test
+  def testReadNodeWithLtFilter(): Unit = {
+    val df: DataFrame = initTest(s"""
+     CREATE (p1:Person {age: 39}),
+      (p2:Person {age: 41}),
+      (p3:Person {age: 43})
+     """)
+
+    val result = df.where("age < 40").collectAsList()
+
+    assertEquals(1, result.size())
+  }
+
+  @Test
+  def testReadNodeWithLteFilter(): Unit = {
+    val df: DataFrame = initTest(s"""
+     CREATE (p1:Person {age: 39}),
+      (p2:Person {age: 41}),
+      (p3:Person {age: 43})
+     """)
+
+    val result = df.where("age <= 41").collectAsList()
+
+    assertEquals(2, result.size())
+  }
+
+  @Test
+  def testReadNodeWithInFilter(): Unit = {
+    val df: DataFrame = initTest(s"""
+     CREATE (p1:Person {age: 39}),
+      (p2:Person {age: 41}),
+      (p3:Person {age: 43})
+     """)
+
+    val result = df.where("age IN(41,43)").collectAsList()
+
+    assertEquals(2, result.size())
+  }
+
+  @Test
+  def testReadNodeWithIsNullFilter(): Unit = {
+    val df: DataFrame = initTest(s"""
+     CREATE (p1:Person {age: 39}),
+      (p2:Person {age: null}),
+      (p3:Person {age: 43})
+     """)
+
+    val result = df.where("age IS NULL").collectAsList()
+
+    assertEquals(1, result.size())
+  }
+
+  @Test
+  def testReadNodeWithIsNotNullFilter(): Unit = {
+    val df: DataFrame = initTest(s"""
+     CREATE (p1:Person {age: 39}),
+      (p2:Person {age: null}),
+      (p3:Person {age: 43})
+     """)
+
+    val result = df.where("age IS NOT NULL").collectAsList()
+
+    assertEquals(2, result.size())
+  }
+
+  @Test
+  def testReadNodeWithOrCondition(): Unit = {
+    val df: DataFrame = initTest(s"""
+     CREATE (p1:Person {age: 39}),
+      (p2:Person {age: null}),
+      (p3:Person {age: 43})
+     """)
+
+    val result = df.where("age = 43 OR age = 39 OR age = 32").collectAsList()
+
+    assertEquals(2, result.size())
+  }
+
+  @Test
+  def testReadNodeWithAndCondition(): Unit = {
+    val df: DataFrame = initTest(s"""
+     CREATE (p1:Person {age: 39}),
+      (p2:Person {age: null}),
+      (p3:Person {age: 43})
+     """)
+
+    val result = df.where("age >= 39 AND age <= 43").collectAsList()
+
+    assertEquals(2, result.size())
+  }
+
+  @Test
+  def testReadNodeWithStartsWith(): Unit = {
+    val df: DataFrame = initTest(s"""
+     CREATE (p1:Person {name: 'John Mayer'}),
+      (p2:Person {name: 'John Scofield'}),
+      (p3:Person {name: 'John Butler'})
+     """)
+
+    val result = df.where("name LIKE 'John%'").collectAsList()
+
+    assertEquals(3, result.size())
+  }
+
+  @Test
+  def testReadNodeWithEndsWith(): Unit = {
+    val df: DataFrame = initTest(s"""
+     CREATE (p1:Person {name: 'John Mayer'}),
+      (p2:Person {name: 'John Scofield'}),
+      (p3:Person {name: 'John Butler'})
+     """)
+
+    val result = df.where("name LIKE '%Scofield'").collectAsList()
+
+    assertEquals(1, result.size())
+  }
+
+  @Test
+  def testReadNodeWithContains(): Unit = {
+    val df: DataFrame = initTest(s"""
+     CREATE (p1:Person {name: 'John Mayer'}),
+      (p2:Person {name: 'John Scofield'}),
+      (p3:Person {name: 'John Butler'})
+     """)
+
+    val result = df.where("name LIKE '%ay%'").collectAsList()
+
+    assertEquals(1, result.size())
+  }
+
+  @Test
   def testReadNodeRepartition(): Unit = {
     val fixtureQuery: String =
       """UNWIND range(1,100) as id
@@ -340,8 +535,6 @@ class DataSourceReaderWithApocTSE extends SparkConnectorScalaBaseWithApocTSE {
 
     val df: DataFrame = initTest(fixtureQuery)
     val repartitionedDf = df.repartition(10)
-
-    df.printSchema()
 
     assertEquals(10, repartitionedDf.rdd.getNumPartitions)
     val numNode = repartitionedDf.collect().length

--- a/src/test/scala/org/neo4j/spark/Neo4jOptionsTest.scala
+++ b/src/test/scala/org/neo4j/spark/Neo4jOptionsTest.scala
@@ -133,5 +133,7 @@ class Neo4jOptionsTest {
     assertEquals(-1, neo4jOptions.connection.acquisitionTimeout)
     assertEquals(-1, neo4jOptions.connection.connectionTimeout)
     assertEquals(-1, neo4jOptions.connection.livenessCheckTimeout)
+
+    assertTrue(neo4jOptions.pushdownFiltersEnabled)
   }
 }

--- a/src/test/scala/org/neo4j/spark/Neo4jQueryServiceTest.scala
+++ b/src/test/scala/org/neo4j/spark/Neo4jQueryServiceTest.scala
@@ -1,5 +1,6 @@
 package org.neo4j.spark
 
+import org.apache.spark.sql.sources.{EqualTo, Filter}
 import org.junit.Assert._
 import org.junit.Test
 import org.neo4j.spark.service.{Neo4jQueryReadStrategy, Neo4jQueryService}
@@ -13,7 +14,7 @@ class Neo4jQueryServiceTest {
     options.put(QueryType.LABELS.toString.toLowerCase, "Person")
     val neo4jOptions: Neo4jOptions = new Neo4jOptions(options)
 
-    val query: String = new Neo4jQueryService(neo4jOptions, new Neo4jQueryReadStrategy()).createQuery()
+    val query: String = new Neo4jQueryService(neo4jOptions, new Neo4jQueryReadStrategy(Array[Filter]())).createQuery()
 
     assertEquals("MATCH (n:`Person`) RETURN n", query)
   }
@@ -25,8 +26,24 @@ class Neo4jQueryServiceTest {
     options.put(QueryType.LABELS.toString.toLowerCase, ":Person:Player:Midfield")
     val neo4jOptions: Neo4jOptions = new Neo4jOptions(options)
 
-    val query: String = new Neo4jQueryService(neo4jOptions, new Neo4jQueryReadStrategy()).createQuery()
+    val query: String = new Neo4jQueryService(neo4jOptions, new Neo4jQueryReadStrategy(Array[Filter]())).createQuery()
 
     assertEquals("MATCH (n:`Person`:`Player`:`Midfield`) RETURN n", query)
+  }
+
+  @Test
+  def testNodeFilterEqualTo(): Unit = {
+    val options: java.util.Map[String, String] = new java.util.HashMap[String, String]()
+    options.put(Neo4jOptions.URL, "bolt://localhost")
+    options.put(QueryType.LABELS.toString.toLowerCase, "Person")
+    val neo4jOptions: Neo4jOptions = new Neo4jOptions(options)
+
+    val filters: Array[Filter] = Array[Filter](
+      EqualTo("name", "John Doe")
+    )
+
+    val query: String = new Neo4jQueryService(neo4jOptions, new Neo4jQueryReadStrategy(filters)).createQuery()
+
+    assertEquals("MATCH (n:`Person`) WHERE n.name = 'John Doe' RETURN n", query)
   }
 }

--- a/src/test/scala/org/neo4j/spark/Neo4jQueryServiceTest.scala
+++ b/src/test/scala/org/neo4j/spark/Neo4jQueryServiceTest.scala
@@ -1,6 +1,6 @@
 package org.neo4j.spark
 
-import org.apache.spark.sql.sources.{EqualTo, Filter}
+import org.apache.spark.sql.sources.{EqualTo, Filter, Not, Or}
 import org.junit.Assert._
 import org.junit.Test
 import org.neo4j.spark.service.{Neo4jQueryReadStrategy, Neo4jQueryService}
@@ -45,5 +45,47 @@ class Neo4jQueryServiceTest {
     val query: String = new Neo4jQueryService(neo4jOptions, new Neo4jQueryReadStrategy(filters)).createQuery()
 
     assertEquals("MATCH (n:`Person`) WHERE n.name = 'John Doe' RETURN n", query)
+  }
+
+  @Test
+  def testRelationshipFilterEqualTo(): Unit = {
+    val options: java.util.Map[String, String] = new java.util.HashMap[String, String]()
+    options.put(Neo4jOptions.URL, "bolt://localhost")
+    options.put("relationship", "KNOWS")
+    options.put("relationship.nodes.map", "false")
+    options.put("relationship.source.labels", "Person")
+    options.put("relationship.target.labels", "Person")
+    val neo4jOptions: Neo4jOptions = new Neo4jOptions(options)
+
+    val filters: Array[Filter] = Array[Filter](
+      EqualTo("source.name", "John Doe")
+    )
+
+    val query: String = new Neo4jQueryService(neo4jOptions, new Neo4jQueryReadStrategy(filters)).createQuery()
+
+    assertEquals("MATCH (source:`Person`) " +
+      "MATCH (target:`Person`) " +
+      "MATCH (source)-[rel:`KNOWS`]->(target) WHERE source.name = 'John Doe' RETURN source, rel, target", query)
+  }
+
+  @Test
+  def testRelationshipFilterNotEqualTo(): Unit = {
+    val options: java.util.Map[String, String] = new java.util.HashMap[String, String]()
+    options.put(Neo4jOptions.URL, "bolt://localhost")
+    options.put("relationship", "KNOWS")
+    options.put("relationship.nodes.map", "false")
+    options.put("relationship.source.labels", "Person")
+    options.put("relationship.target.labels", "Person")
+    val neo4jOptions: Neo4jOptions = new Neo4jOptions(options)
+
+    val filters: Array[Filter] = Array[Filter](
+      Or(EqualTo("source.name", "John Doe"), EqualTo("target.name", "John Doe"))
+    )
+
+    val query: String = new Neo4jQueryService(neo4jOptions, new Neo4jQueryReadStrategy(filters)).createQuery()
+
+    assertEquals("MATCH (source:`Person`) " +
+      "MATCH (target:`Person`) " +
+      "MATCH (source)-[rel:`KNOWS`]->(target) WHERE (source.name = 'John Doe' OR target.name = 'John Doe') RETURN source, rel, target", query)
   }
 }

--- a/src/test/scala/org/neo4j/spark/Neo4jQueryServiceTest.scala
+++ b/src/test/scala/org/neo4j/spark/Neo4jQueryServiceTest.scala
@@ -1,6 +1,6 @@
 package org.neo4j.spark
 
-import org.apache.spark.sql.sources.{EqualTo, Filter, Not, Or}
+import org.apache.spark.sql.sources.{And, EqualTo, Filter, GreaterThanOrEqual, LessThan, Not, Or}
 import org.junit.Assert._
 import org.junit.Test
 import org.neo4j.spark.service.{Neo4jQueryReadStrategy, Neo4jQueryService}
@@ -87,5 +87,82 @@ class Neo4jQueryServiceTest {
     assertEquals("MATCH (source:`Person`) " +
       "MATCH (target:`Person`) " +
       "MATCH (source)-[rel:`KNOWS`]->(target) WHERE (source.name = coalesce('John Doe', '') OR target.name = coalesce('John Doe', '')) RETURN source, rel, target", query)
+  }
+
+  @Test
+  def testComplexNodeConditions(): Unit = {
+    val options: java.util.Map[String, String] = new java.util.HashMap[String, String]()
+    options.put(Neo4jOptions.URL, "bolt://localhost")
+    options.put("labels", "Person")
+    val neo4jOptions: Neo4jOptions = new Neo4jOptions(options)
+
+    val filters: Array[Filter] = Array[Filter](
+      Or(EqualTo("name", "John Doe"), EqualTo("name", "John Scofield")),
+      Or(EqualTo("age", 15), GreaterThanOrEqual("age", 18)),
+      Or(Not(EqualTo("age", 22)), Not(LessThan("age", 11)))
+    )
+
+    val query: String = new Neo4jQueryService(neo4jOptions, new Neo4jQueryReadStrategy(filters)).createQuery()
+
+    assertEquals(
+      "MATCH (n:`Person`)" +
+        " WHERE ((n.name = coalesce('John Doe', '') OR n.name = coalesce('John Scofield', ''))" +
+        " AND (n.age = coalesce(15, '') OR n.age >= coalesce(18, 0))" +
+        " AND (NOT (n.age = coalesce(22, '')) OR NOT (n.age < coalesce(11, 0))))" +
+        " RETURN n", query)
+  }
+
+  @Test
+  def testRelationshipFilterComplexConditionsNoMap(): Unit = {
+    val options: java.util.Map[String, String] = new java.util.HashMap[String, String]()
+    options.put(Neo4jOptions.URL, "bolt://localhost")
+    options.put("relationship", "KNOWS")
+    options.put("relationship.nodes.map", "false")
+    options.put("relationship.source.labels", "Person")
+    options.put("relationship.target.labels", "Person:Customer")
+    val neo4jOptions: Neo4jOptions = new Neo4jOptions(options)
+
+    val filters: Array[Filter] = Array[Filter](
+      Or(Or(EqualTo("source.name", "John Doe"), EqualTo("target.name", "John Doraemon")), EqualTo("source.name", "Jane Doe")),
+      Or(EqualTo("target.age", 34), EqualTo("target.age", 18)),
+      EqualTo("rel.score", 12)
+    )
+
+    val query: String = new Neo4jQueryService(neo4jOptions, new Neo4jQueryReadStrategy(filters)).createQuery()
+
+    assertEquals("MATCH (source:`Person`) " +
+      "MATCH (target:`Person`:`Customer`) " +
+      "MATCH (source)-[rel:`KNOWS`]->(target) " +
+      "WHERE ((source.name = coalesce('John Doe', '') OR target.name = coalesce('John Doraemon', '') OR source.name = coalesce('Jane Doe', '')) " +
+      "AND (target.age = coalesce(34, '') OR target.age = coalesce(18, '')) " +
+      "AND rel.score = coalesce(12, '')) " +
+      "RETURN source, rel, target", query)
+  }
+
+  @Test
+  def testRelationshipFilterComplexConditionsWithMap(): Unit = {
+    val options: java.util.Map[String, String] = new java.util.HashMap[String, String]()
+    options.put(Neo4jOptions.URL, "bolt://localhost")
+    options.put("relationship", "KNOWS")
+    options.put("relationship.nodes.map", "true")
+    options.put("relationship.source.labels", "Person")
+    options.put("relationship.target.labels", "Person:Customer")
+    val neo4jOptions: Neo4jOptions = new Neo4jOptions(options)
+
+    val filters: Array[Filter] = Array[Filter](
+      Or(Or(EqualTo("source.name", "John Doe"), EqualTo("target.name", "John Doraemon")), EqualTo("source.name", "Jane Doe")),
+      Or(EqualTo("target.age", 34), EqualTo("target.age", 18)),
+      EqualTo("rel.score", 12)
+    )
+
+    val query: String = new Neo4jQueryService(neo4jOptions, new Neo4jQueryReadStrategy(filters)).createQuery()
+
+    assertEquals("MATCH (source:`Person`) " +
+      "MATCH (target:`Person`:`Customer`) " +
+      "MATCH (source)-[rel:`KNOWS`]->(target) " +
+      "WHERE ((source.name = coalesce('John Doe', '') OR target.name = coalesce('John Doraemon', '') OR source.name = coalesce('Jane Doe', '')) " +
+      "AND (target.age = coalesce(34, '') OR target.age = coalesce(18, '')) " +
+      "AND rel.score = coalesce(12, '')) " +
+      "RETURN source, rel, target", query)
   }
 }

--- a/src/test/scala/org/neo4j/spark/Neo4jQueryServiceTest.scala
+++ b/src/test/scala/org/neo4j/spark/Neo4jQueryServiceTest.scala
@@ -14,7 +14,7 @@ class Neo4jQueryServiceTest {
     options.put(QueryType.LABELS.toString.toLowerCase, "Person")
     val neo4jOptions: Neo4jOptions = new Neo4jOptions(options)
 
-    val query: String = new Neo4jQueryService(neo4jOptions, new Neo4jQueryReadStrategy(Array[Filter]())).createQuery()
+    val query: String = new Neo4jQueryService(neo4jOptions, new Neo4jQueryReadStrategy).createQuery()
 
     assertEquals("MATCH (n:`Person`) RETURN n", query)
   }
@@ -26,7 +26,7 @@ class Neo4jQueryServiceTest {
     options.put(QueryType.LABELS.toString.toLowerCase, ":Person:Player:Midfield")
     val neo4jOptions: Neo4jOptions = new Neo4jOptions(options)
 
-    val query: String = new Neo4jQueryService(neo4jOptions, new Neo4jQueryReadStrategy(Array[Filter]())).createQuery()
+    val query: String = new Neo4jQueryService(neo4jOptions, new Neo4jQueryReadStrategy).createQuery()
 
     assertEquals("MATCH (n:`Person`:`Player`:`Midfield`) RETURN n", query)
   }
@@ -44,7 +44,7 @@ class Neo4jQueryServiceTest {
 
     val query: String = new Neo4jQueryService(neo4jOptions, new Neo4jQueryReadStrategy(filters)).createQuery()
 
-    assertEquals("MATCH (n:`Person`) WHERE n.name = 'John Doe' RETURN n", query)
+    assertEquals("MATCH (n:`Person`) WHERE n.name = coalesce('John Doe', '') RETURN n", query)
   }
 
   @Test
@@ -65,7 +65,7 @@ class Neo4jQueryServiceTest {
 
     assertEquals("MATCH (source:`Person`) " +
       "MATCH (target:`Person`) " +
-      "MATCH (source)-[rel:`KNOWS`]->(target) WHERE source.name = 'John Doe' RETURN source, rel, target", query)
+      "MATCH (source)-[rel:`KNOWS`]->(target) WHERE source.name = coalesce('John Doe', '') RETURN source, rel, target", query)
   }
 
   @Test
@@ -86,6 +86,6 @@ class Neo4jQueryServiceTest {
 
     assertEquals("MATCH (source:`Person`) " +
       "MATCH (target:`Person`) " +
-      "MATCH (source)-[rel:`KNOWS`]->(target) WHERE (source.name = 'John Doe' OR target.name = 'John Doe') RETURN source, rel, target", query)
+      "MATCH (source)-[rel:`KNOWS`]->(target) WHERE (source.name = coalesce('John Doe', '') OR target.name = coalesce('John Doe', '')) RETURN source, rel, target", query)
   }
 }

--- a/src/test/scala/org/neo4j/spark/SparkConnectorScalaBaseWithApocTSE.scala
+++ b/src/test/scala/org/neo4j/spark/SparkConnectorScalaBaseWithApocTSE.scala
@@ -58,7 +58,7 @@ class SparkConnectorScalaBaseWithApocTSE {
             val afterConnections = SparkConnectorScalaSuiteWithApocIT.getActiveConnections
             SparkConnectorScalaSuiteWithApocIT.connections == afterConnections
           }
-        }, Matchers.equalTo(true), 30, TimeUnit.SECONDS)
+        }, Matchers.equalTo(true), 45, TimeUnit.SECONDS)
       } finally {
         val afterConnections = SparkConnectorScalaSuiteWithApocIT.getActiveConnections
         if (SparkConnectorScalaSuiteWithApocIT.connections != afterConnections) { // just for debug purposes

--- a/src/test/scala/org/neo4j/spark/util/Neo4jImplicitsTest.scala
+++ b/src/test/scala/org/neo4j/spark/util/Neo4jImplicitsTest.scala
@@ -66,4 +66,16 @@ class Neo4jImplicitsTest {
     // then
     assertFalse(attribute.isDefined)
   }
+
+  @Test
+  def `should return the attribute without the entity identifier` {
+    // given
+    val filter = EqualTo("person.address.coords", 32)
+
+    // when
+    val attribute = filter.getAttributeWithoutEntityName
+
+    // then
+    assertEquals("address.coords", attribute.get)
+  }
 }

--- a/src/test/scala/org/neo4j/spark/util/Neo4jImplicitsTest.scala
+++ b/src/test/scala/org/neo4j/spark/util/Neo4jImplicitsTest.scala
@@ -1,7 +1,7 @@
 package org.neo4j.spark.util
 
+import org.apache.spark.sql.sources.{EqualTo, Not}
 import org.junit.Test
-
 import org.junit.Assert._
 import org.neo4j.spark.util.Neo4jImplicits._
 
@@ -43,5 +43,27 @@ class Neo4jImplicitsTest {
     assertEquals(value, actual)
   }
 
+  @Test
+  def `should return attribute if filter has it` {
+    // given
+    val filter = EqualTo("name", "John")
 
+    // when
+    val attribute = filter.getAttribute
+
+    // then
+    assertTrue(attribute.isDefined)
+  }
+
+  @Test
+  def `should not return attribute if filter doesn't have it` {
+    // given
+    val filter = Not(EqualTo("name", "John"))
+
+    // when
+    val attribute = filter.getAttribute
+
+    // then
+    assertFalse(attribute.isDefined)
+  }
 }

--- a/src/test/scala/org/neo4j/spark/util/Neo4jImplicitsTest.scala
+++ b/src/test/scala/org/neo4j/spark/util/Neo4jImplicitsTest.scala
@@ -1,6 +1,6 @@
 package org.neo4j.spark.util
 
-import org.apache.spark.sql.sources.{EqualTo, Not}
+import org.apache.spark.sql.sources.{And, EqualTo, Not}
 import org.junit.Test
 import org.junit.Assert._
 import org.neo4j.spark.util.Neo4jImplicits._
@@ -56,9 +56,9 @@ class Neo4jImplicitsTest {
   }
 
   @Test
-  def `should not return attribute if filter doesn't have it` {
+  def `should return an empty option if the filter doesn't have an attribute` {
     // given
-    val filter = Not(EqualTo("name", "John"))
+    val filter = And(EqualTo("name", "John"), EqualTo("age", 32))
 
     // when
     val attribute = filter.getAttribute

--- a/src/test/scala/org/neo4j/spark/util/Neo4jUtilTest.scala
+++ b/src/test/scala/org/neo4j/spark/util/Neo4jUtilTest.scala
@@ -8,5 +8,4 @@ class Neo4jUtilTest {
   def testSafetyCloseShouldNotFailWithNull(): Unit = {
     Neo4jUtil.closeSafety(null)
   }
-
 }


### PR DESCRIPTION
Fixes #161 

Added PushDownFilters support. 

Is applied just with `labels` and `relationship`, it apply with `relationship` and the `relationship.nodes.map` options set to `true`. 

When applied the filters are executed on the Cypher query, moving less data from Neo4j to Spark. When not applied the filters are executed by Spark.

It can be manually disabled setting `pushdown.filters.enabled` option to `false`.