### PR TITLE
fixes #163: Add support to partitioning

### DIFF
--- a/doc/docs/modules/ROOT/pages/quickstart.adoc
+++ b/doc/docs/modules/ROOT/pages/quickstart.adoc
@@ -140,6 +140,21 @@ will route the requests to the followers, otherwise to the leader.
 |``
 |Yes^*^
 
+|`query.count`
+|Query count, used only in combination with `query` option, it's a query that returns a `count`
+field like the following.
+``
+MATCH (p:Person)-[r:BOUGHT]->(pr:Product)
+WHERE pr.name = 'An Awesome Product'
+RETURN count(p) AS count
+``
+
+or *a simple number* that represents the count.
+Consider that the number passed by this value represent the volume of the data pulled of Neo4j, so please
+use it carefully.
+|``
+|No
+
 |`labels`
 |List of labels separated by `:`. First label is the primary label
 |``
@@ -182,6 +197,13 @@ every single node property as column prefixed by `source` or `target`
 |`true`
 |No
 
+|`partitions`
+|This defines the parallelization level while pulling data from Neo4j.
+N.b. As More parallelization does not mean more performances so please tune wisely in according to
+your Neo4j installation.
+|`1`
+|No
+
 |===
 
 ^*^ Just one of the options can be specified.
@@ -193,6 +215,61 @@ Reading data from a Neo4j Database can be done in 3 ways:
  * with a Cypher query
  * with a set of node Labels 
  * by specifying a relationship
+
+=== Considerations about partitioning
+
+While we're trying to pull off the data we offer the possibility to partition the extraction in order
+parallelizing it.
+
+Please consider the following job:
+```scala
+val df = spark.read.format("org.neo4j.spark.DataSource")
+        .option("url", "bolt://localhost:7687")
+        .option("labels", "Person")
+        .option("partitions", "5")
+        .load()
+```
+
+This means that if the total count of the nodes with label `Person` into Neo4j is 100 we are creating 5
+partitions and each one will manage 20 records via the `skip/limit` query.
+
+Partitioning the dataset makes sense only if you're dealing with a big dataset (>= 10M of records).
+
+==== How we parallelize the query execution
+
+Considering that we have three options
+
+1. Node extraction
+2. Relationship extraction
+3. Query extraction
+
+We adopt generally provide a general count on what you're trying to pull of and add build
+a query with the skip/limit approach over each partition.
+
+So for a dataset of 100 nodes (Person) with a partition size of 5 we'll generate these queries (one for partition):
+
+```
+MATCH (p:Person) RETURN p SKIP 0 LIMIT 20
+MATCH (p:Person) RETURN p SKIP 20 LIMIT 20
+MATCH (p:Person) RETURN p SKIP 40 LIMIT 20
+MATCH (p:Person) RETURN p SKIP 60 LIMIT 20
+MATCH (p:Person) RETURN p SKIP 80 LIMIT 20
+```
+
+While for (1) and (2) we leverage the Neo4j count store in order to retrieve the total count
+about the nodes/relationships we're trying pulling off, for the (3) we have two possible approaches:
+
+* Compute a count over the query that we're using
+* Compute a count over a second *optimized* query that leverages indexes, in this case you can pass
+it via the `.option("query.count", "<your cypher query>")` the query must always return only
+one field named `count` which is the result of the count. ie.:
+
+```cypher
+MATCH (p:Person)-[r:BOUGHT]->(pr:Product)
+WHERE pr.name = 'An Awesome Product'
+RETURN count(p) AS count
+```
+
 
 === Considerations on the schema
 

--- a/src/main/scala/org/neo4j/spark/Neo4jOptions.scala
+++ b/src/main/scala/org/neo4j/spark/Neo4jOptions.scala
@@ -128,6 +128,14 @@ class Neo4jOptions(private val parameters: java.util.Map[String, String]) extend
     Neo4jRelationshipMetadata(source, target, query.value, nodeMap)
   }
 
+  def initNeo4jQueryMetadata(): Neo4jQueryMetadata = Neo4jQueryMetadata(
+    query.value.trim, getParameter(QUERY_COUNT, "").trim
+  )
+
+  val queryMetadata = initNeo4jQueryMetadata()
+
+  val partitions = getParameter(PARTITIONS, DEFAULT_PARTITIONS.toString).toInt
+
   def validate(validationFunction: Neo4jOptions => Unit): Neo4jOptions = {
     validationFunction(this)
     this
@@ -139,6 +147,7 @@ case class Neo4jTransactionMetadata(retries: Int, failOnTransactionCodes: Set[St
 
 case class Neo4jNodeMetadata(labels: Seq[String], nodeKeys: Map[String, String])
 case class Neo4jRelationshipMetadata(source: Neo4jNodeMetadata, target: Neo4jNodeMetadata, relationshipType: String, nodeMap: Boolean)
+case class Neo4jQueryMetadata(query: String, queryCount: String)
 
 case class Neo4jQueryOptions(queryType: QueryType.Value, value: String)
 
@@ -249,6 +258,9 @@ object Neo4jOptions {
   val SCHEMA_STRATEGY = "schema.strategy"
   val SCHEMA_FLATTEN_LIMIT = "schema.flatten.limit"
 
+  // partitions
+  val PARTITIONS = "partitions"
+
   // Node Metadata
   val NODE_KEYS = "node.keys"
   val BATCH_SIZE = "batch.size"
@@ -260,6 +272,9 @@ object Neo4jOptions {
   val RELATIONSHIP_TARGET_LABELS = s"${QueryType.RELATIONSHIP.toString.toLowerCase}.target.${QueryType.LABELS.toString.toLowerCase}"
   val RELATIONSHIP_TARGET_NODE_KEYS = s"${QueryType.RELATIONSHIP.toString.toLowerCase}.target.$NODE_KEYS"
   val RELATIONSHIP_NODES_MAP = s"${QueryType.RELATIONSHIP.toString.toLowerCase}.nodes.map"
+
+  // Query metadata
+  val QUERY_COUNT = "query.count"
 
   // Transaction Metadata
   val TRANSACTION_RETRIES = "transaction.retries"
@@ -278,6 +293,7 @@ object Neo4jOptions {
   val DEFAULT_RELATIONSHIP_NODES_MAP = true
   val DEFAULT_SCHEMA_STRATEGY = SchemaStrategy.SAMPLE
   val DEFAULT_PUSHDOWN_FILTERS_ENABLED = true
+  val DEFAULT_PARTITIONS = 1
 }
 
 object QueryType extends Enumeration {

--- a/src/main/scala/org/neo4j/spark/reader/Neo4jDataSourceReader.scala
+++ b/src/main/scala/org/neo4j/spark/reader/Neo4jDataSourceReader.scala
@@ -7,9 +7,11 @@ import org.apache.spark.sql.sources.Filter
 import org.apache.spark.sql.sources.v2.DataSourceOptions
 import org.apache.spark.sql.sources.v2.reader.{DataSourceReader, InputPartition, SupportsPushDownFilters, SupportsPushDownRequiredColumns}
 import org.apache.spark.sql.types.StructType
-import org.neo4j.spark.Neo4jOptions
+import org.neo4j.spark.{DriverCache, Neo4jOptions}
 import org.neo4j.spark.service.SchemaService
 import org.neo4j.spark.util.Validations
+
+import scala.collection.JavaConverters._
 
 class Neo4jDataSourceReader(private val options: DataSourceOptions, private val jobId: String) extends DataSourceReader
   with SupportsPushDownFilters {
@@ -19,20 +21,43 @@ class Neo4jDataSourceReader(private val options: DataSourceOptions, private val 
   private val neo4jOptions: Neo4jOptions = new Neo4jOptions(options.asMap())
     .validate(options => Validations.read(options, jobId))
 
-  override def readSchema(): StructType = {
-    val schemaService = new SchemaService(neo4jOptions, jobId)
+
+  override def readSchema(): StructType = callSchemaService { schemaService => schemaService
+    .struct() }
+
+  private def callSchemaService[T](lambda: SchemaService => T): T = {
+    val driverCache = new DriverCache(neo4jOptions.connection, jobId)
+    val schemaService = new SchemaService(neo4jOptions, driverCache)
+    var hasError = false
     try {
-      schemaService.struct()
+      lambda(schemaService)
+    } catch {
+      case e: Throwable => {
+        hasError = true
+        throw e
+      }
     } finally {
       schemaService.close()
+      if (hasError) {
+        driverCache.close()
+      }
     }
   }
 
+  private def getPartitions(): Seq[(Long, Long)] = callSchemaService { schemaService => schemaService
+    .skipLimitFromPartition() }
+
   override def planInputPartitions: util.ArrayList[InputPartition[InternalRow]] = {
     val schema = readSchema()
-    val factoryList = new java.util.ArrayList[InputPartition[InternalRow]]
-    factoryList.add(new Neo4jInputPartitionReader(neo4jOptions, filters, schema, jobId))
-    factoryList
+    val partitionSkipLimit = getPartitions()
+    val neo4jPartitions = if (partitionSkipLimit.isEmpty) {
+      Seq(new Neo4jInputPartitionReader(neo4jOptions, filters, schema, jobId))
+    } else {
+      partitionSkipLimit.zipWithIndex
+        .map(triple => new Neo4jInputPartitionReader(neo4jOptions, filters, schema, jobId, triple._2,
+          triple._1._1, triple._1._2))
+    }
+    new java.util.ArrayList[InputPartition[InternalRow]](neo4jPartitions.asJava)
   }
 
   override def pushFilters(filtersArray: Array[Filter]): Array[Filter] = {

--- a/src/main/scala/org/neo4j/spark/reader/Neo4jInputPartitionReader.scala
+++ b/src/main/scala/org/neo4j/spark/reader/Neo4jInputPartitionReader.scala
@@ -15,27 +15,37 @@ import scala.collection.JavaConverters._
 class Neo4jInputPartitionReader(private val options: Neo4jOptions,
                                 private val filters: Array[Filter],
                                 private val schema: StructType,
-                                private val jobId: String) extends InputPartition[InternalRow]
+                                private val jobId: String,
+                                private val partitionId: Int = 0,
+                                private val skip: Long = -1L,
+                                private val limit: Long = -1L) extends InputPartition[InternalRow]
   with InputPartitionReader[InternalRow]
   with Logging {
 
   private var result: Iterator[Record] = _
   private var session: Session = _
   private var transaction: Transaction = _
-  private val driverCache: DriverCache = new DriverCache(options.connection, jobId)
+  private val driverCache: DriverCache = new DriverCache(options.connection,
+    if (partitionId > 0) s"$jobId-$partitionId" else jobId)
 
-  private val query: String = new Neo4jQueryService(options, new Neo4jQueryReadStrategy(filters)).createQuery()
+  private val query: String = new Neo4jQueryService(options, new Neo4jQueryReadStrategy(filters))
+    .createQuery()
+    .concat(if (skip != -1 && limit != -1) s" SKIP $$skip LIMIT $$limit" else "")
 
   private val mappingService = new MappingService(new Neo4jReadMappingStrategy(options), options)
 
-  override def createPartitionReader(): InputPartitionReader[InternalRow] = new Neo4jInputPartitionReader(options, filters, schema, jobId)
+  override def createPartitionReader(): InputPartitionReader[InternalRow] = new Neo4jInputPartitionReader(options, filters, schema,
+    jobId, partitionId, skip, limit)
 
   def next: Boolean = {
     if (result == null) {
       session = driverCache.getOrCreate().session(options.session.toNeo4jSession)
       transaction = session.beginTransaction()
       log.info(s"Running the following query on Neo4j: $query")
-      result = transaction.run(query).asScala
+      val skipLimitParams: java.util.Map[String, AnyRef] = Map[String, AnyRef](
+        "skip" -> skip.asInstanceOf[AnyRef], "limit" -> limit.asInstanceOf[AnyRef])
+        .asJava
+      result = transaction.run(query, skipLimitParams).asScala
     }
 
     result.hasNext
@@ -44,8 +54,8 @@ class Neo4jInputPartitionReader(private val options: Neo4jOptions,
   def get: InternalRow = mappingService.convert(result.next(), schema)
 
   def close(): Unit = {
-    Neo4jUtil.closeSafety(transaction)
-    Neo4jUtil.closeSafety(session)
+    Neo4jUtil.closeSafety(transaction, log)
+    Neo4jUtil.closeSafety(session, log)
     driverCache.close()
   }
 

--- a/src/main/scala/org/neo4j/spark/service/MappingService.scala
+++ b/src/main/scala/org/neo4j/spark/service/MappingService.scala
@@ -100,7 +100,7 @@ class Neo4jReadMappingStrategy(private val options: Neo4jOptions) extends Neo4jM
       .asScala
       .map(t => (s"rel.${t._1}", t._2))
       .asJava
-    relMap.put(Neo4jUtil.INTERNAL_ID_FIELD, rel.id())
+    relMap.put(Neo4jUtil.INTERNAL_REL_ID_FIELD, rel.id())
     relMap.put(Neo4jUtil.INTERNAL_REL_TYPE_FIELD, rel.`type`())
 
     val source = record.get(Neo4jUtil.RELATIONSHIP_SOURCE_ALIAS).asNode()

--- a/src/main/scala/org/neo4j/spark/service/Neo4jQueryService.scala
+++ b/src/main/scala/org/neo4j/spark/service/Neo4jQueryService.scala
@@ -2,7 +2,8 @@ package org.neo4j.spark.service
 
 import org.apache.spark.sql.SaveMode
 import org.apache.spark.sql.sources.{And, EqualTo, Filter, IsNull, Not, Or}
-import org.neo4j.cypherdsl.core.{Condition, Conditions, Cypher, Functions, Node, PropertyContainer, Relationship, StatementBuilder}
+import org.neo4j.cypherdsl.core.StatementBuilder.{BuildableStatement, TerminalExposesLimit}
+import org.neo4j.cypherdsl.core.{Condition, Conditions, Cypher, Functions, Node, PropertyContainer, Relationship, Statement, StatementBuilder}
 import org.neo4j.cypherdsl.core.renderer.Renderer
 import org.neo4j.spark.{Neo4jOptions, QueryType}
 import org.neo4j.spark.util.Neo4jImplicits._
@@ -38,7 +39,8 @@ class Neo4jQueryWriteStrategy(private val saveMode: SaveMode) extends Neo4jQuery
   }
 }
 
-class Neo4jQueryReadStrategy(filters: Array[Filter] = Array.empty[Filter]) extends Neo4jQueryStrategy {
+class Neo4jQueryReadStrategy(filters: Array[Filter] = Array.empty[Filter],
+                             partitionSkipLimit: PartitionSkipLimit = PartitionSkipLimit(0, -1, -1)) extends Neo4jQueryStrategy {
   private val renderer: Renderer = Renderer.getDefaultRenderer
 
   override def createStatementForQuery(options: Neo4jOptions): String = options.query.value
@@ -52,7 +54,16 @@ class Neo4jQueryReadStrategy(filters: Array[Filter] = Array.empty[Filter]) exten
 
     val matchQuery: StatementBuilder.OngoingReadingWithoutWhere = filterRelationship(sourceNode, targetNode, relationship)
 
-    renderer.render(matchQuery.returning(sourceNode, relationship, targetNode).build())
+    val returning = matchQuery.returning(sourceNode, relationship, targetNode)
+    renderer.render(buildStatement(returning))
+  }
+
+  private def buildStatement(returning: StatementBuilder.OngoingReadingAndReturn) = {
+    if (partitionSkipLimit.skip != -1 && partitionSkipLimit.limit != -1) {
+      returning.skip[TerminalExposesLimit with BuildableStatement](partitionSkipLimit.skip).limit(partitionSkipLimit.limit).build()
+    } else {
+      returning.build()
+    }
   }
 
   private def filterRelationship(sourceNode: Node, targetNode: Node, relationship: Relationship) = {
@@ -116,7 +127,7 @@ class Neo4jQueryReadStrategy(filters: Array[Filter] = Array.empty[Filter]) exten
   def createStatementForNodeCount(options: Neo4jOptions): String = {
     val node = createNode(Neo4jUtil.NODE_ALIAS, options.nodeMetadata.labels)
     val matchQuery = filterNode(node)
-    renderer.render(matchQuery.returning(Functions.count(node)).build())
+    renderer.render(buildStatement(matchQuery.returning(Functions.count(node))))
   }
 
   def createStatementForRelationshipCount(options: Neo4jOptions): String = {
@@ -128,9 +139,8 @@ class Neo4jQueryReadStrategy(filters: Array[Filter] = Array.empty[Filter]) exten
 
     val matchQuery: StatementBuilder.OngoingReadingWithoutWhere = filterRelationship(sourceNode, targetNode, relationship)
 
-    renderer.render(matchQuery.returning(Functions.count(sourceNode)).build())
+    renderer.render(buildStatement(matchQuery.returning(Functions.count(sourceNode))))
   }
-
 
   private def assembleConditionQuery(matchQuery: StatementBuilder.OngoingReadingWithoutWhere, filters: Array[Condition]): StatementBuilder.OngoingReadingWithWhere = {
     matchQuery.where(
@@ -164,8 +174,7 @@ class Neo4jQueryService(private val options: Neo4jOptions,
     case QueryType.LABELS => strategy.createStatementForNodes(options)
     case QueryType.RELATIONSHIP => strategy.createStatementForRelationships(options)
     case QueryType.QUERY => strategy.createStatementForQuery(options)
-    case _ => throw new UnsupportedOperationException(
-      s"""Query Type not supported.
+    case _ => throw new UnsupportedOperationException(s"""Query Type not supported.
          |You provided ${options.query.queryType},
          |supported types: ${QueryType.values.mkString(",")}""".stripMargin)
   }

--- a/src/main/scala/org/neo4j/spark/util/Neo4jUtil.scala
+++ b/src/main/scala/org/neo4j/spark/util/Neo4jUtil.scala
@@ -56,7 +56,7 @@ object Neo4jUtil {
       }
     } catch {
       case t: Throwable => if (logger != null) logger
-        .error(s"Cannot close ${autoCloseable.getClass.getSimpleName} because of the following exception:", t)
+        .warn(s"Cannot close ${autoCloseable.getClass.getSimpleName} because of the following exception:", t)
     }
   }
 

--- a/src/main/scala/org/neo4j/spark/writer/Neo4jDataWriter.scala
+++ b/src/main/scala/org/neo4j/spark/writer/Neo4jDataWriter.scala
@@ -109,7 +109,7 @@ class Neo4jDataWriter(jobId: String,
   }
 
   private def close = {
-    closeSafety(transaction)
-    closeSafety(session)
+    closeSafety(transaction, log)
+    closeSafety(session, log)
   }
 }

--- a/src/test/scala/org/neo4j/spark/service/SchemaServiceTSE.scala
+++ b/src/test/scala/org/neo4j/spark/service/SchemaServiceTSE.scala
@@ -207,7 +207,7 @@ class SchemaServiceTSE extends SparkConnectorScalaBaseTSE {
     val neo4jOptions: Neo4jOptions = new Neo4jOptions(options)
     val uuid: String = UUID.randomUUID().toString
 
-    val schemaService: SchemaService = new SchemaService(neo4jOptions, uuid)
+    val schemaService: SchemaService = new SchemaService(neo4jOptions, new DriverCache(neo4jOptions.connection, uuid))
 
     val schema: StructType = schemaService.struct()
     schemaService.close()

--- a/src/test/scala/org/neo4j/spark/service/SchemaServiceWithApocTSE.scala
+++ b/src/test/scala/org/neo4j/spark/service/SchemaServiceWithApocTSE.scala
@@ -207,12 +207,13 @@ class SchemaServiceWithApocTSE extends SparkConnectorScalaBaseWithApocTSE {
     val neo4jOptions: Neo4jOptions = new Neo4jOptions(options)
     val uuid: String = UUID.randomUUID().toString
 
-    val schemaService: SchemaService = new SchemaService(neo4jOptions, uuid)
+    val driverCache = new DriverCache(neo4jOptions.connection, uuid)
+    val schemaService: SchemaService = new SchemaService(neo4jOptions, driverCache)
 
     val schema: StructType = schemaService.struct()
     schemaService.close()
+    driverCache.close()
 
-    new DriverCache(neo4jOptions.connection, uuid).close()
 
     schema
   }


### PR DESCRIPTION
fixes #163 

We support partitions via skip/limit queries. In order to do so, we compute the total count, for nodes/relationships we leverage the Neo4j count store in order to retrieve the total count about the nodes/relationships we're trying pulling off, for the query we have two possible approaches:

* Compute a count over the query that we're using
* Compute a count over a second *optimized* query that leverages indexes, in this case, you can pass
it via the `.option("query.count", "<your cypher query>")` the query must always return only
one field named `count` which is the result of the count. ie.:

```cypher
MATCH (p:Person)-[r:BOUGHT]->(pr:Product)
WHERE pr.name = 'An Awesome Product'
RETUNR count(p) AS count
```