### PR TITLE
fixes #150: Neo4j database error while creating nodes

### DIFF
--- a/src/main/scala/org/neo4j/spark/Neo4jConfig.scala
+++ b/src/main/scala/org/neo4j/spark/Neo4jConfig.scala
@@ -42,7 +42,6 @@ object Neo4jConfig {
     val password: Option[String] = sparkConf.getOption(s"$prefix.password")
       .orElse(sparkConf.getOption(s"$oldPrefix.password"))
     val database: Option[String] = sparkConf.getOption(s"$prefix.database")
-      .orElse(sparkConf.getOption(s"$oldPrefix.password"))
     val encryption: Boolean = sparkConf.getOption(s"$prefix.encryption")
         .map(bool => bool.toBoolean)
         .getOrElse(sparkConf.getBoolean(s"$oldPrefix.encryption", defaultValue = false))

--- a/src/test/scala/org/neo4j/spark/Neo4jConfigTest.scala
+++ b/src/test/scala/org/neo4j/spark/Neo4jConfigTest.scala
@@ -12,11 +12,13 @@ class Neo4jConfigTest {
     val user = "neo4j"
     val pass = "pass"
     val url = "neo4j://localhost"
+    val db = "db"
     val sparkConf = new SparkConf()
       .set("spark.neo4j.encryption", encryption)
       .set("spark.neo4j.user", user)
       .set("spark.neo4j.password", pass)
       .set("spark.neo4j.url", url)
+      .set("spark.neo4j.database", db)
 
     // when
     val neo4jConf = Neo4jConfig(sparkConf)
@@ -26,6 +28,7 @@ class Neo4jConfigTest {
     Assert.assertEquals(user, neo4jConf.user)
     Assert.assertEquals(pass, neo4jConf.password.get)
     Assert.assertEquals(url, neo4jConf.url)
+    Assert.assertEquals(db, neo4jConf.database.get)
   }
 
   @Test
@@ -49,6 +52,7 @@ class Neo4jConfigTest {
     Assert.assertEquals(user, neo4jConf.user)
     Assert.assertEquals(pass, neo4jConf.password.get)
     Assert.assertEquals(url, neo4jConf.url)
+    Assert.assertTrue(neo4jConf.database.isEmpty)
   }
 
 }


### PR DESCRIPTION
Fixed the bug related to the database name. If you use Neo4j `3.5` and the old config with `*.bolt.*` you can get a database name error