### PR TITLE
Allow index/constraint creation

### DIFF
--- a/doc/docs/modules/ROOT/pages/quickstart_writer.adoc
+++ b/doc/docs/modules/ROOT/pages/quickstart_writer.adoc
@@ -320,3 +320,88 @@ You can specify 3 different modes to use for saving the nodes:
 * `Overwrite`: will perform a `MERGE` on that node
 * `ErrorIfExists`: will perform a `CREATE`
 * `Match`: will perform a `MATCH`
+
+
+=== Schema Optimization Operations
+
+The spark connector supports schema optimization operations via:
+
+* index
+* constraints
+* set of schema queries
+
+that will be executed *before* the import process will start in order to speed-up the import itself.
+
+You can set the optimization via `schema.optimization.type` option that takes three values:
+
+* `INDEX`: it creates only indexes on provided nodes
+* `CONSTRAINTS`: it creates only indexes on provided nodes
+* `QUERY`: it perform a series of schema queries separated by `;`
+
+and it works only when you're merging nodes.
+
+==== Index Creation
+
+Following an example of how to create indexes while you're creating nodes
+
+----
+ds.write
+      .format(classOf[DataSource].getName)
+      .mode(SaveMode.Overwrite)
+      .option("url", SparkConnectorScalaSuiteIT.server.getBoltUrl)
+      .option("labels", ":Person:Customer")
+      .option("node.keys", "surname")
+      .option("schema.optimization.type", "INDEX")
+      .save()
+----
+
+This will create, before the import starts, the following schema query:
+
+----
+CREATE INDEX ON :Person(surname)
+----
+
+*So please into consideration that the first label is used for the index creation*
+
+
+==== Constraint Creation
+
+Following an example of how to create indexes while you're creating nodes
+
+----
+ds.write
+      .format(classOf[DataSource].getName)
+      .mode(SaveMode.Overwrite)
+      .option("url", SparkConnectorScalaSuiteIT.server.getBoltUrl)
+      .option("labels", ":Person:Customer")
+      .option("node.keys", "surname")
+      .option("schema.optimization.type", "CONSTRAINT")
+      .save()
+----
+
+This will create, before the import starts, the following schema query:
+
+----
+CREATE CONSTRAINT ON (p:Person) ASSERT (p.surname) IS UNIQUE
+----
+
+*So please into consideration that the first label is used for the index creation*
+
+==== Index/Constraint Creation via schema query
+
+Following an example of how to create indexes while you're creating nodes
+
+----
+ds.write
+      .format(classOf[DataSource].getName)
+      .mode(SaveMode.Overwrite)
+      .option("url", SparkConnectorScalaSuiteIT.server.getBoltUrl)
+      .option("labels", ":Person:Customer")
+      .option("node.keys", "surname")
+      .option("schema.optimization.type", "QUERY")
+      .option("schema.optimization.query", "CREATE INDEX ON :Person(surname); CREATE CONSTRAINT ON (p:Product) ASSERT (p.name, p.sku) IS NODE KEY")
+      .save()
+----
+
+Before the import starts, the connector will use the schema query that you provided into the
+`schema.optimization.query` option.

--- a/doc/docs/modules/ROOT/pages/quickstart_writer.adoc
+++ b/doc/docs/modules/ROOT/pages/quickstart_writer.adoc
@@ -335,7 +335,7 @@ that will be executed *before* the import process will start in order to speed-u
 You can set the optimization via `schema.optimization.type` option that takes three values:
 
 * `INDEX`: it creates only indexes on provided nodes
-* `CONSTRAINTS`: it creates only indexes on provided nodes
+* `NODE_CONSTRAINTS`: it creates only indexes on provided nodes
 * `QUERY`: it perform a series of schema queries separated by `;`
 
 and it works only when you're merging nodes.
@@ -375,7 +375,7 @@ ds.write
       .option("url", SparkConnectorScalaSuiteIT.server.getBoltUrl)
       .option("labels", ":Person:Customer")
       .option("node.keys", "surname")
-      .option("schema.optimization.type", "CONSTRAINT")
+      .option("schema.optimization.type", "NODE_CONSTRAINTS")
       .save()
 ----
 

--- a/doc/docs/modules/ROOT/pages/quickstart_writer.adoc
+++ b/doc/docs/modules/ROOT/pages/quickstart_writer.adoc
@@ -387,21 +387,39 @@ CREATE CONSTRAINT ON (p:Person) ASSERT (p.surname) IS UNIQUE
 
 *So please into consideration that the first label is used for the index creation*
 
-==== Index/Constraint Creation via schema query
+=== Script Option
 
-Following an example of how to create indexes while you're creating nodes
+The script option allow you to execute a series of preparation script before Spark
+Job execution, the result of the last query can be reused in combination with the
+`query` ingestion mode as it follows
 
 ----
+val ds = Seq(SimplePerson("Andrea", "Santurbano")).toDS()
+
 ds.write
-      .format(classOf[DataSource].getName)
-      .mode(SaveMode.Overwrite)
-      .option("url", SparkConnectorScalaSuiteIT.server.getBoltUrl)
-      .option("labels", ":Person:Customer")
-      .option("node.keys", "surname")
-      .option("schema.optimization.type", "QUERY")
-      .option("schema.optimization.query", "CREATE INDEX ON :Person(surname); CREATE CONSTRAINT ON (p:Product) ASSERT (p.name, p.sku) IS NODE KEY")
-      .save()
+  .format(classOf[DataSource].getName)
+  .mode(SaveMode.ErrorIfExists)
+  .option("url", SparkConnectorScalaSuiteIT.server.getBoltUrl)
+  .option("query", "CREATE (n:Person{fullName: event.name + ' ' + event.surname, age: scriptResult[0].age})")
+  .option("script",
+    """CREATE INDEX ON :Person(surname);
+      |CREATE CONSTRAINT ON (p:Product)
+      | ASSERT (p.name, p.sku)
+      | IS NODE KEY;
+      |RETURN 36 AS age;
+      |""".stripMargin)
+  .save()
 ----
 
-Before the import starts, the connector will use the schema query that you provided into the
-`schema.optimization.query` option.
+Before the import starts, the connector will run the content of the `script` option
+and the result of the last query will be injected into the `query`; in the end the full
+query executed by the connector while is ingesting the data will be
+
+----
+WITH $scriptResult AS scriptResult
+UNWIND $events AS event
+CREATE (n:Person{fullName: event.name + ' ' + event.surname, age: scriptResult[0].age})
+----
+
+where `scriptResult` is the result from the last query contained into the `script` options
+that is `RETURN 36 AS age;`

--- a/src/main/scala/org/neo4j/spark/Neo4jOptions.scala
+++ b/src/main/scala/org/neo4j/spark/Neo4jOptions.scala
@@ -34,7 +34,12 @@ class Neo4jOptions(private val parameters: java.util.Map[String, String]) extend
   val pushdownFiltersEnabled: Boolean = getParameter(PUSHDOWN_FILTERS_ENABLED, DEFAULT_PUSHDOWN_FILTERS_ENABLED.toString).toBoolean
 
   val schemaMetadata = Neo4jSchemaMetadata(getParameter(SCHEMA_FLATTEN_LIMIT, DEFAULT_SCHEMA_FLATTEN_LIMIT.toString).toInt,
-    SchemaStrategy.withCaseInsensitiveName(getParameter(SCHEMA_STRATEGY, DEFAULT_SCHEMA_STRATEGY.toString).toUpperCase))
+    SchemaStrategy.withCaseInsensitiveName(getParameter(SCHEMA_STRATEGY, DEFAULT_SCHEMA_STRATEGY.toString).toUpperCase),
+    OptimizationType.withName(getParameter(SCHEMA_OPTIMIZATION_TYPE, DEFAULT_OPTIMIZATION_TYPE.toString).toUpperCase),
+    getParameter(SCHEMA_OPTIMIZATION_QUERY)
+      .split(";")
+      .map(_.trim)
+      .filterNot(_.isEmpty))
 
   val query: Neo4jQueryOptions = (
     getParameter(QUERY.toString.toLowerCase),
@@ -157,7 +162,7 @@ class Neo4jOptions(private val parameters: java.util.Map[String, String]) extend
   }
 }
 
-case class Neo4jSchemaMetadata(flattenLimit: Int, strategy: SchemaStrategy.Value)
+case class Neo4jSchemaMetadata(flattenLimit: Int, strategy: SchemaStrategy.Value, optimizationType: OptimizationType.Value, optimizationQuery: Seq[String])
 case class Neo4jTransactionMetadata(retries: Int, failOnTransactionCodes: Set[String], batchSize: Int)
 
 case class Neo4jNodeMetadata(labels: Seq[String], nodeKeys: Map[String, String], nodeProps: Map[String, String])
@@ -282,6 +287,8 @@ object Neo4jOptions {
   // schema options
   val SCHEMA_STRATEGY = "schema.strategy"
   val SCHEMA_FLATTEN_LIMIT = "schema.flatten.limit"
+  val SCHEMA_OPTIMIZATION_TYPE = "schema.optimization.type"
+  val SCHEMA_OPTIMIZATION_QUERY = "schema.optimization.query"
 
   // partitions
   val PARTITIONS = "partitions"
@@ -289,6 +296,7 @@ object Neo4jOptions {
   // Node Metadata
   val NODE_KEYS = "node.keys"
   val NODE_PROPS = "node.properties"
+
   val BATCH_SIZE = "batch.size"
   val SUPPORTED_SAVE_MODES = Seq(SaveMode.Overwrite, SaveMode.ErrorIfExists, SaveMode.Append)
 
@@ -329,6 +337,7 @@ object Neo4jOptions {
   val DEFAULT_RELATIONSHIP_TARGET_SAVE_MODE: NodeSaveMode.Value = NodeSaveMode.Match
   val DEFAULT_PUSHDOWN_FILTERS_ENABLED = true
   val DEFAULT_PARTITIONS = 1
+  val DEFAULT_OPTIMIZATION_TYPE = OptimizationType.NONE
 }
 
 class CaseInsensitiveEnumeration extends Enumeration {
@@ -360,4 +369,8 @@ object NodeSaveMode extends CaseInsensitiveEnumeration {
 
 object SchemaStrategy extends CaseInsensitiveEnumeration {
   val STRING, SAMPLE = Value
+}
+
+object OptimizationType extends Enumeration {
+  val INDEX, CONSTRAINT, QUERY, NONE = Value
 }

--- a/src/main/scala/org/neo4j/spark/Neo4jOptions.scala
+++ b/src/main/scala/org/neo4j/spark/Neo4jOptions.scala
@@ -35,11 +35,7 @@ class Neo4jOptions(private val parameters: java.util.Map[String, String]) extend
 
   val schemaMetadata = Neo4jSchemaMetadata(getParameter(SCHEMA_FLATTEN_LIMIT, DEFAULT_SCHEMA_FLATTEN_LIMIT.toString).toInt,
     SchemaStrategy.withCaseInsensitiveName(getParameter(SCHEMA_STRATEGY, DEFAULT_SCHEMA_STRATEGY.toString).toUpperCase),
-    OptimizationType.withCaseInsensitiveName(getParameter(SCHEMA_OPTIMIZATION_TYPE, DEFAULT_OPTIMIZATION_TYPE.toString).toUpperCase),
-    getParameter(SCHEMA_OPTIMIZATION_QUERY)
-      .split(";")
-      .map(_.trim)
-      .filterNot(_.isEmpty))
+    OptimizationType.withCaseInsensitiveName(getParameter(SCHEMA_OPTIMIZATION_TYPE, DEFAULT_OPTIMIZATION_TYPE.toString).toUpperCase))
 
   val query: Neo4jQueryOptions = (
     getParameter(QUERY.toString.toLowerCase),
@@ -115,6 +111,11 @@ class Neo4jOptions(private val parameters: java.util.Map[String, String]) extend
 
   val transactionMetadata = initNeo4jTransactionMetadata()
 
+  val script = getParameter(SCRIPT)
+    .split(";")
+    .map(_.trim)
+    .filterNot(_.isEmpty)
+
   private def initNeo4jTransactionMetadata(): Neo4jTransactionMetadata = {
     val retries = getParameter(TRANSACTION_RETRIES, DEFAULT_TRANSACTION_RETRIES.toString).toInt
     val failOnTransactionCodes = getParameter(TRANSACTION_CODES_FAIL, DEFAULT_EMPTY)
@@ -162,7 +163,7 @@ class Neo4jOptions(private val parameters: java.util.Map[String, String]) extend
   }
 }
 
-case class Neo4jSchemaMetadata(flattenLimit: Int, strategy: SchemaStrategy.Value, optimizationType: OptimizationType.Value, optimizationQuery: Seq[String])
+case class Neo4jSchemaMetadata(flattenLimit: Int, strategy: SchemaStrategy.Value, optimizationType: OptimizationType.Value)
 case class Neo4jTransactionMetadata(retries: Int, failOnTransactionCodes: Set[String], batchSize: Int)
 
 case class Neo4jNodeMetadata(labels: Seq[String], nodeKeys: Map[String, String], nodeProps: Map[String, String])
@@ -288,7 +289,6 @@ object Neo4jOptions {
   val SCHEMA_STRATEGY = "schema.strategy"
   val SCHEMA_FLATTEN_LIMIT = "schema.flatten.limit"
   val SCHEMA_OPTIMIZATION_TYPE = "schema.optimization.type"
-  val SCHEMA_OPTIMIZATION_QUERY = "schema.optimization.query"
 
   // partitions
   val PARTITIONS = "partitions"
@@ -319,6 +319,8 @@ object Neo4jOptions {
   // Transaction Metadata
   val TRANSACTION_RETRIES = "transaction.retries"
   val TRANSACTION_CODES_FAIL = "transaction.codes.fail"
+
+  val SCRIPT = "script"
 
   // defaults
   val DEFAULT_EMPTY = ""
@@ -372,5 +374,5 @@ object SchemaStrategy extends CaseInsensitiveEnumeration {
 }
 
 object OptimizationType extends CaseInsensitiveEnumeration {
-  val INDEX, NODE_CONSTRAINTS, QUERY, NONE = Value
+  val INDEX, NODE_CONSTRAINTS, NONE = Value
 }

--- a/src/main/scala/org/neo4j/spark/Neo4jOptions.scala
+++ b/src/main/scala/org/neo4j/spark/Neo4jOptions.scala
@@ -35,7 +35,7 @@ class Neo4jOptions(private val parameters: java.util.Map[String, String]) extend
 
   val schemaMetadata = Neo4jSchemaMetadata(getParameter(SCHEMA_FLATTEN_LIMIT, DEFAULT_SCHEMA_FLATTEN_LIMIT.toString).toInt,
     SchemaStrategy.withCaseInsensitiveName(getParameter(SCHEMA_STRATEGY, DEFAULT_SCHEMA_STRATEGY.toString).toUpperCase),
-    OptimizationType.withName(getParameter(SCHEMA_OPTIMIZATION_TYPE, DEFAULT_OPTIMIZATION_TYPE.toString).toUpperCase),
+    OptimizationType.withCaseInsensitiveName(getParameter(SCHEMA_OPTIMIZATION_TYPE, DEFAULT_OPTIMIZATION_TYPE.toString).toUpperCase),
     getParameter(SCHEMA_OPTIMIZATION_QUERY)
       .split(";")
       .map(_.trim)
@@ -371,6 +371,6 @@ object SchemaStrategy extends CaseInsensitiveEnumeration {
   val STRING, SAMPLE = Value
 }
 
-object OptimizationType extends Enumeration {
-  val INDEX, CONSTRAINT, QUERY, NONE = Value
+object OptimizationType extends CaseInsensitiveEnumeration {
+  val INDEX, NODE_CONSTRAINTS, QUERY, NONE = Value
 }

--- a/src/main/scala/org/neo4j/spark/util/ValidationUtil.scala
+++ b/src/main/scala/org/neo4j/spark/util/ValidationUtil.scala
@@ -25,4 +25,6 @@ object ValidationUtil {
   def isFalse(boolean: Boolean, message: String) = if (boolean) {
     throw new IllegalArgumentException(message)
   }
+
+  def isNotValid(message: String) = throw new IllegalArgumentException(message)
 }

--- a/src/main/scala/org/neo4j/spark/util/Validations.scala
+++ b/src/main/scala/org/neo4j/spark/util/Validations.scala
@@ -3,9 +3,9 @@ package org.neo4j.spark.util
 import org.apache.spark.sql.SaveMode
 import org.apache.spark.sql.types.StructType
 import org.neo4j.driver.AccessMode
-import org.neo4j.spark.service.SchemaService
+import org.neo4j.spark.service.{Neo4jQueryStrategy, SchemaService}
 import org.neo4j.spark.util.Neo4jImplicits.StructTypeImplicit
-import org.neo4j.spark.{DriverCache, Neo4jOptions, OptimizationType, QueryType}
+import org.neo4j.spark._
 
 object Validations {
 
@@ -17,15 +17,18 @@ object Validations {
     try {
       neo4jOptions.query.queryType match {
         case QueryType.QUERY => {
-          ValidationUtil.isTrue(schemaService.isQueryType(s"WITH {} AS event ${neo4jOptions.query.value}",
+          ValidationUtil.isTrue(schemaService.isValidQuery(
+            s"""WITH {} AS ${Neo4jQueryStrategy.VARIABLE_EVENT}, [] as ${Neo4jQueryStrategy.VARIABLE_SCRIPT_RESULT}
+               |${neo4jOptions.query.value}
+               |""".stripMargin,
             org.neo4j.driver.summary.QueryType.WRITE_ONLY, org.neo4j.driver.summary.QueryType.READ_WRITE),
             "Please provide a valid WRITE query")
           neo4jOptions.schemaMetadata.optimizationType match {
-            case OptimizationType.QUERY | OptimizationType.NONE => // are valid
+            case OptimizationType.NONE => // are valid
             case _ => ValidationUtil.isNotValid(
               s"""With Query Type ${neo4jOptions.query.queryType} you can
                  |only use `${Neo4jOptions.SCHEMA_OPTIMIZATION_TYPE}`
-                 |`${OptimizationType.QUERY}` or `${OptimizationType.NONE}`
+                 |`${OptimizationType.NONE}`
                  |""".stripMargin)
           }
         }
@@ -46,15 +49,19 @@ object Validations {
         }
       }
       neo4jOptions.schemaMetadata.optimizationType match {
-        case OptimizationType.QUERY => neo4jOptions.schemaMetadata.optimizationQuery.foreach(query =>
-          ValidationUtil.isTrue(schemaService.isQueryType(query, org.neo4j.driver.summary.QueryType.SCHEMA_WRITE),
-            "Please provide a valid SCHEMA WRITE query"))
         case OptimizationType.NONE => // skip it
         case _ => neo4jOptions.query.queryType match {
           case QueryType.LABELS => ValidationUtil.isTrue(saveMode == SaveMode.Overwrite, "This works only with `mode` `SaveMode.Overwrite`")
-          case QueryType.RELATIONSHIP => // TODO implement it
+          case QueryType.RELATIONSHIP => {
+            ValidationUtil.isTrue(neo4jOptions.relationshipMetadata.sourceSaveMode == NodeSaveMode.Overwrite,
+              s"This works only with `${Neo4jOptions.RELATIONSHIP_SOURCE_SAVE_MODE}` `Overwrite`")
+            ValidationUtil.isTrue(neo4jOptions.relationshipMetadata.targetSaveMode == NodeSaveMode.Overwrite,
+              s"This works only with `${Neo4jOptions.RELATIONSHIP_TARGET_SAVE_MODE}` `Overwrite`")
+          }
         }
       }
+      neo4jOptions.script.foreach(query => ValidationUtil.isTrue(schemaService.isValidQuery(query),
+        s"The following query inside the `${Neo4jOptions.SCRIPT}` is not valid, please check the syntax: $query"))
     } finally {
       schemaService.close()
       cache.close()
@@ -103,7 +110,7 @@ object Validations {
             s"You need to set the ${Neo4jOptions.RELATIONSHIP_TARGET_LABELS} option")
         }
         case QueryType.QUERY => {
-          ValidationUtil.isTrue(schemaService.isQueryType(neo4jOptions.query.value, org.neo4j.driver.summary.QueryType.READ_ONLY),
+          ValidationUtil.isTrue(schemaService.isValidQuery(neo4jOptions.query.value, org.neo4j.driver.summary.QueryType.READ_ONLY),
             "Please provide a valid READ query")
           if (neo4jOptions.queryMetadata.queryCount.nonEmpty) {
             if (!Neo4jUtil.isLong(neo4jOptions.queryMetadata.queryCount)) {

--- a/src/main/scala/org/neo4j/spark/writer/Neo4jDataSourceWriter.scala
+++ b/src/main/scala/org/neo4j/spark/writer/Neo4jDataSourceWriter.scala
@@ -26,8 +26,9 @@ class Neo4jDataSourceWriter(jobId: String,
   override def createWriterFactory(): DataWriterFactory[InternalRow] = {
     val schemaService = new SchemaService(neo4jOptions, driverCache)
     schemaService.createOptimizations()
+    val scriptResult = schemaService.execute(neo4jOptions.script)
     schemaService.close()
-    new Neo4jDataWriterFactory(jobId, structType, saveMode, neo4jOptions)
+    new Neo4jDataWriterFactory(jobId, structType, saveMode, neo4jOptions, scriptResult)
   }
 
   override def commit(messages: Array[WriterCommitMessage]): Unit = {

--- a/src/main/scala/org/neo4j/spark/writer/Neo4jWriterFactory.scala
+++ b/src/main/scala/org/neo4j/spark/writer/Neo4jWriterFactory.scala
@@ -9,6 +9,7 @@ import org.neo4j.spark.Neo4jOptions
 class Neo4jDataWriterFactory(jobId: String,
                              structType: StructType,
                              saveMode: SaveMode,
-                             options: Neo4jOptions) extends DataWriterFactory[InternalRow] {
-  override def createDataWriter(partitionId: Int, taskId: Long, epochId: Long): DataWriter[InternalRow] = new Neo4jDataWriter(jobId, partitionId, structType, saveMode, options)
+                             options: Neo4jOptions,
+                             scriptResult: java.util.List[java.util.Map[String, AnyRef]]) extends DataWriterFactory[InternalRow] {
+  override def createDataWriter(partitionId: Int, taskId: Long, epochId: Long): DataWriter[InternalRow] = new Neo4jDataWriter(jobId, partitionId, structType, saveMode, options, scriptResult)
 }


### PR DESCRIPTION
This addresses part of #159 

The user can set the optimization via `schema.optimization.type` option that takes three values:

* `INDEX`: it creates only indexes on provided nodes
* `CONSTRAINTS`: it creates only indexes on provided nodes
* `QUERY`: it perform a series of schema queries separated by `;`