### PR TITLE
Fixes #178: Improved error handling for maps and keys options

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -150,7 +150,7 @@
                     <descriptorRefs>
                         <descriptorRef>jar-with-dependencies</descriptorRef>
                     </descriptorRefs>
-                    <finalName>${project.artifactId}-${scala.version.binary}-${project.version}</finalName>
+                    <finalName>${project.artifactId}-${scala.binary.version}-${project.version}</finalName>
                     <appendAssemblyId>false</appendAssemblyId>
                 </configuration>
             </plugin>

--- a/src/main/scala/org/neo4j/spark/Neo4jOptions.scala
+++ b/src/main/scala/org/neo4j/spark/Neo4jOptions.scala
@@ -130,7 +130,7 @@ class Neo4jOptions(private val parameters: java.util.Map[String, String]) extend
 
     val target = initNeo4jNodeMetadata(getParameter(RELATIONSHIP_TARGET_NODE_KEYS, ""),
       getParameter(RELATIONSHIP_TARGET_LABELS, ""),
-      getParameter(RELATIONSHIP_SOURCE_NODE_PROPS, ""))
+      getParameter(RELATIONSHIP_TARGET_NODE_PROPS, ""))
 
     val nodeMap = getParameter(RELATIONSHIP_NODES_MAP, DEFAULT_RELATIONSHIP_NODES_MAP.toString).toBoolean
 

--- a/src/main/scala/org/neo4j/spark/service/MappingService.scala
+++ b/src/main/scala/org/neo4j/spark/service/MappingService.scala
@@ -65,7 +65,7 @@ class Neo4jWriteMappingStrategy(private val options: Neo4jOptions)
     }
   }
 
-  private def keysStrategyConsumer(schema: StructType): MappingBiConsumer = new MappingBiConsumer {
+  private val keysStrategyConsumer: MappingBiConsumer = new MappingBiConsumer {
     override def accept(key: String, value: AnyRef): Unit = {
       if (options.relationshipMetadata.source.nodeKeys.contains(key)) {
         sourceNodeMap.get(KEYS).put(key, value)
@@ -92,7 +92,7 @@ class Neo4jWriteMappingStrategy(private val options: Neo4jOptions)
 
     val consumer = options.relationshipMetadata.saveStrategy match {
       case RelationshipSaveStrategy.NATIVE => nativeStrategyConsumer()
-      case RelationshipSaveStrategy.KEYS => keysStrategyConsumer(schema)
+      case RelationshipSaveStrategy.KEYS => keysStrategyConsumer
     }
 
     query(row, schema).forEach(consumer)

--- a/src/main/scala/org/neo4j/spark/service/MappingService.scala
+++ b/src/main/scala/org/neo4j/spark/service/MappingService.scala
@@ -65,7 +65,7 @@ class Neo4jWriteMappingStrategy(private val options: Neo4jOptions)
     }
   }
 
-  private val keysStrategyConsumer: MappingBiConsumer = new MappingBiConsumer {
+  private def keysStrategyConsumer(): MappingBiConsumer = new MappingBiConsumer {
     override def accept(key: String, value: AnyRef): Unit = {
       if (options.relationshipMetadata.source.nodeKeys.contains(key)) {
         sourceNodeMap.get(KEYS).put(key, value)
@@ -92,7 +92,7 @@ class Neo4jWriteMappingStrategy(private val options: Neo4jOptions)
 
     val consumer = options.relationshipMetadata.saveStrategy match {
       case RelationshipSaveStrategy.NATIVE => nativeStrategyConsumer()
-      case RelationshipSaveStrategy.KEYS => keysStrategyConsumer
+      case RelationshipSaveStrategy.KEYS => keysStrategyConsumer()
     }
 
     query(row, schema).forEach(consumer)

--- a/src/main/scala/org/neo4j/spark/util/Neo4jImplicits.scala
+++ b/src/main/scala/org/neo4j/spark/util/Neo4jImplicits.scala
@@ -101,9 +101,9 @@ object Neo4jImplicits {
       structType.map(structField => structField.name)
     }
 
-    def missingFields(fields: Set[String]): Set[String] = {
+    def getMissingFields(fields: Set[String]): Set[String] = {
       val structFieldsNames = structType.getFieldsName
-      fields.filter(!structFieldsNames.contains(_))
+      fields.filterNot(structFieldsNames.contains(_))
     }
   }
 

--- a/src/main/scala/org/neo4j/spark/util/Neo4jImplicits.scala
+++ b/src/main/scala/org/neo4j/spark/util/Neo4jImplicits.scala
@@ -94,4 +94,17 @@ object Neo4jImplicits {
     def getAttributeWithoutEntityName: Option[String] = filter.getAttribute.map(_.split('.').tail.mkString("."))
   }
 
+  implicit class StructTypeImplicit(structType: StructType) {
+    def getFieldsName: Seq[String] = if (structType == null) {
+      Seq.empty
+    } else {
+      structType.map(structField => structField.name)
+    }
+
+    def missingFields(fields: Set[String]): Set[String] = {
+      val structFieldsNames = structType.getFieldsName
+      fields.filter(!structFieldsNames.contains(_))
+    }
+  }
+
 }

--- a/src/main/scala/org/neo4j/spark/util/Validations.scala
+++ b/src/main/scala/org/neo4j/spark/util/Validations.scala
@@ -46,43 +46,24 @@ object Validations {
   }
 
   val schemaOptions: (Neo4jOptions, StructType) => Unit = { (neo4jOptions, schema) =>
-    val missingFieldsMap: mutable.Map[String, Set[String]] = mutable.HashMap.empty
-
-    missingFieldsMap.put(
-      Neo4jOptions.NODE_KEYS,
-      schema.missingFields(neo4jOptions.nodeMetadata.nodeKeys.keySet)
-    )
-    missingFieldsMap.put(
-      Neo4jOptions.NODE_PROPS,
-      schema.missingFields(neo4jOptions.nodeMetadata.nodeProps.keySet)
-    )
-    missingFieldsMap.put(
-      Neo4jOptions.RELATIONSHIP_PROPERTIES,
-      schema.missingFields(neo4jOptions.relationshipMetadata.properties.keySet)
-    )
-    missingFieldsMap.put(
-      Neo4jOptions.RELATIONSHIP_SOURCE_NODE_PROPS,
-      schema.missingFields(neo4jOptions.relationshipMetadata.source.nodeProps.keySet)
-    )
-    missingFieldsMap.put(
-      Neo4jOptions.RELATIONSHIP_SOURCE_NODE_KEYS,
-      schema.missingFields(neo4jOptions.relationshipMetadata.source.nodeKeys.keySet)
-    )
-    missingFieldsMap.put(
-      Neo4jOptions.RELATIONSHIP_TARGET_NODE_PROPS,
-      schema.missingFields(neo4jOptions.relationshipMetadata.target.nodeProps.keySet)
-    )
-    missingFieldsMap.put(
-      Neo4jOptions.RELATIONSHIP_TARGET_NODE_KEYS,
-      schema.missingFields(neo4jOptions.relationshipMetadata.target.nodeKeys.keySet)
+    val missingFieldsMap = Map(
+      Neo4jOptions.NODE_KEYS -> schema.getMissingFields(neo4jOptions.nodeMetadata.nodeKeys.keySet),
+      Neo4jOptions.NODE_PROPS -> schema.getMissingFields(neo4jOptions.nodeMetadata.nodeProps.keySet),
+      Neo4jOptions.RELATIONSHIP_PROPERTIES -> schema.getMissingFields(neo4jOptions.relationshipMetadata.properties.keySet),
+      Neo4jOptions.RELATIONSHIP_SOURCE_NODE_PROPS -> schema.getMissingFields(neo4jOptions.relationshipMetadata.source.nodeProps.keySet),
+      Neo4jOptions.RELATIONSHIP_SOURCE_NODE_KEYS -> schema.getMissingFields(neo4jOptions.relationshipMetadata.source.nodeKeys.keySet),
+      Neo4jOptions.RELATIONSHIP_TARGET_NODE_PROPS -> schema.getMissingFields(neo4jOptions.relationshipMetadata.target.nodeProps.keySet),
+      Neo4jOptions.RELATIONSHIP_TARGET_NODE_KEYS -> schema.getMissingFields(neo4jOptions.relationshipMetadata.target.nodeKeys.keySet)
     )
 
     val optionsWithMissingFields = missingFieldsMap.filter(_._2.nonEmpty)
 
     if (optionsWithMissingFields.nonEmpty) {
-      throw new IllegalArgumentException("Write failed due to the following errors:\n" +
-        optionsWithMissingFields.map(field => s" - Schema is missing ${field._2.mkString(", ")} from option `${field._1}`").mkString("\n") +
-        "\n\nThe option key and value might be inverted.")
+      throw new IllegalArgumentException(
+        s"""Write failed due to the following errors:
+           |${optionsWithMissingFields.map(field => s" - Schema is missing ${field._2.mkString(", ")} from option `${field._1}`").mkString("\n")}
+           |
+           |The option key and value might be inverted.""".stripMargin)
     }
   }
 

--- a/src/main/scala/org/neo4j/spark/util/Validations.scala
+++ b/src/main/scala/org/neo4j/spark/util/Validations.scala
@@ -1,9 +1,13 @@
 package org.neo4j.spark.util
 
 import org.apache.spark.sql.SaveMode
+import org.apache.spark.sql.types.StructType
 import org.neo4j.driver.AccessMode
 import org.neo4j.spark.service.SchemaService
 import org.neo4j.spark.{DriverCache, Neo4jOptions, QueryType}
+import org.neo4j.spark.util.Neo4jImplicits.StructTypeImplicit
+
+import scala.collection.mutable
 
 object Validations {
 
@@ -38,6 +42,47 @@ object Validations {
     } finally {
       schemaService.close()
       cache.close()
+    }
+  }
+
+  val schemaOptions: (Neo4jOptions, StructType) => Unit = { (neo4jOptions, schema) =>
+    val missingFieldsMap: mutable.Map[String, Set[String]] = mutable.HashMap.empty
+
+    missingFieldsMap.put(
+      Neo4jOptions.NODE_KEYS,
+      schema.missingFields(neo4jOptions.nodeMetadata.nodeKeys.keySet)
+    )
+    missingFieldsMap.put(
+      Neo4jOptions.NODE_PROPS,
+      schema.missingFields(neo4jOptions.nodeMetadata.nodeProps.keySet)
+    )
+    missingFieldsMap.put(
+      Neo4jOptions.RELATIONSHIP_PROPERTIES,
+      schema.missingFields(neo4jOptions.relationshipMetadata.properties.keySet)
+    )
+    missingFieldsMap.put(
+      Neo4jOptions.RELATIONSHIP_SOURCE_NODE_PROPS,
+      schema.missingFields(neo4jOptions.relationshipMetadata.source.nodeProps.keySet)
+    )
+    missingFieldsMap.put(
+      Neo4jOptions.RELATIONSHIP_SOURCE_NODE_KEYS,
+      schema.missingFields(neo4jOptions.relationshipMetadata.source.nodeKeys.keySet)
+    )
+    missingFieldsMap.put(
+      Neo4jOptions.RELATIONSHIP_TARGET_NODE_PROPS,
+      schema.missingFields(neo4jOptions.relationshipMetadata.target.nodeProps.keySet)
+    )
+    missingFieldsMap.put(
+      Neo4jOptions.RELATIONSHIP_TARGET_NODE_KEYS,
+      schema.missingFields(neo4jOptions.relationshipMetadata.target.nodeKeys.keySet)
+    )
+
+    val optionsWithMissingFields = missingFieldsMap.filter(_._2.nonEmpty)
+
+    if (optionsWithMissingFields.nonEmpty) {
+      throw new IllegalArgumentException("Write failed due to the following errors.\n" +
+        optionsWithMissingFields.map(field => s" - Schema is missing ${field._2.mkString(", ")} from option `${field._1}`").mkString("\n") +
+        "\n\nOption's key:value might be inverted.")
     }
   }
 

--- a/src/main/scala/org/neo4j/spark/util/Validations.scala
+++ b/src/main/scala/org/neo4j/spark/util/Validations.scala
@@ -80,9 +80,9 @@ object Validations {
     val optionsWithMissingFields = missingFieldsMap.filter(_._2.nonEmpty)
 
     if (optionsWithMissingFields.nonEmpty) {
-      throw new IllegalArgumentException("Write failed due to the following errors.\n" +
+      throw new IllegalArgumentException("Write failed due to the following errors:\n" +
         optionsWithMissingFields.map(field => s" - Schema is missing ${field._2.mkString(", ")} from option `${field._1}`").mkString("\n") +
-        "\n\nOption's key:value might be inverted.")
+        "\n\nThe option key and value might be inverted.")
     }
   }
 

--- a/src/main/scala/org/neo4j/spark/writer/Neo4jDataWriter.scala
+++ b/src/main/scala/org/neo4j/spark/writer/Neo4jDataWriter.scala
@@ -54,7 +54,6 @@ class Neo4jDataWriter(jobId: String,
         s"""Writing a batch of ${batch.size()} elements to Neo4j,
            |for jobId=$jobId and partitionId=$partitionId
            |with query: $query
-           |and params: $batch
            |""".stripMargin)
       val result = transaction.run(query,
         Values.value(Collections.singletonMap[String, Object]("events", batch)))

--- a/src/main/scala/org/neo4j/spark/writer/Neo4jDataWriter.scala
+++ b/src/main/scala/org/neo4j/spark/writer/Neo4jDataWriter.scala
@@ -54,6 +54,7 @@ class Neo4jDataWriter(jobId: String,
         s"""Writing a batch of ${batch.size()} elements to Neo4j,
            |for jobId=$jobId and partitionId=$partitionId
            |with query: $query
+           |and params: $batch
            |""".stripMargin)
       val result = transaction.run(query,
         Values.value(Collections.singletonMap[String, Object]("events", batch)))

--- a/src/test/scala/org/neo4j/spark/DataSourceWriterTSE.scala
+++ b/src/test/scala/org/neo4j/spark/DataSourceWriterTSE.scala
@@ -1034,6 +1034,23 @@ class DataSourceWriterTSE extends SparkConnectorScalaBaseTSE {
 
     df2.show()
 
+    SparkConnectorScalaSuiteIT.driver.session().run(
+      """MATCH (source:`Musician`)
+        |MATCH (target:`Instrument`)
+        |MATCH (source)-[rel:`PLAYS`]->(target)
+        |RETURN source, rel, target""".stripMargin)
+      .list()
+      .asScala
+      .foreach(r => {
+        val source = r.get("source").asNode()
+        val target = r.get("target").asNode()
+        val rel = r.get("rel").asRelationship()
+        println(
+          s"${source.id()} | ${source.labels()} | ${source.asMap()} |" +
+          s"${rel.id()} | ${rel.`type`()} | ${rel.asMap()} |" +
+          s"${target.id()} | ${target.labels()} | ${target.asMap()}")
+      })
+
     assertEquals(4, df2.count())
 
     val result = df2.select("`source.name`").orderBy("`source.name`").collectAsList()

--- a/src/test/scala/org/neo4j/spark/DataSourceWriterTSE.scala
+++ b/src/test/scala/org/neo4j/spark/DataSourceWriterTSE.scala
@@ -1019,7 +1019,7 @@ class DataSourceWriterTSE extends SparkConnectorScalaBaseTSE {
       .option("relationship.target.save.mode", "ErrorIfExists")
       .option("relationship.save.strategy", "keys")
       .option("relationship.source.labels", ":Musician")
-      .option("relationship.source.node.properties", "name:name")
+      .option("relationship.source.node.properties", "name")
       .option("relationship.target.labels", ":Instrument")
       .option("relationship.target.node.properties", "instrument:name")
       .save()
@@ -1141,107 +1141,107 @@ class DataSourceWriterTSE extends SparkConnectorScalaBaseTSE {
 
     assertEquals(32, experience)
   }
-
-  @Test
-  def `should give a more clear error if properties or keys are inverted`(): Unit = {
-    val musicDf = Seq(
-      (1, 12, "John Henry Bonham", "Drums"),
-      (2, 19, "John Mayer", "Guitar"),
-      (3, 32, "John Scofield", "Guitar"),
-      (4, 15, "John Butler", "Guitar")
-    ).toDF("id", "experience", "name", "instrument")
-
-    try {
-      musicDf.write
-        .format(classOf[DataSource].getName)
-        .option("url", SparkConnectorScalaSuiteIT.server.getBoltUrl)
-        .option("database", "db1")
-        .option("relationship", "PLAYS")
-        .option("relationship.source.save.mode", "Overwrite")
-        .option("relationship.target.save.mode", "Overwrite")
-        .option("relationship.save.strategy", "keys")
-        .option("relationship.source.labels", ":Musician")
-        .option("relationship.source.node.keys", "musician_name:name")
-        .option("relationship.target.labels", ":Instrument")
-        .option("relationship.target.node.keys", "instrument:name")
-        .save()
-    } catch {
-      case sparkException: SparkException => {
-        val clientException = ExceptionUtils.getRootCause(sparkException)
-        assertTrue(clientException.getMessage.equals(
-          """Write failed due to the following errors:
-            | - Schema is missing musician_name from option `relationship.source.node.keys`
-            |
-            |The option key and value might be inverted.""".stripMargin))
-      }
-      case generic => fail(s"should be thrown a ${classOf[SparkException].getName}, got ${generic.getClass} instead")
-    }
-  }
-
-  @Test
-  def `should give a more clear error if properties or keys are inverted on different options`(): Unit = {
-    val musicDf = Seq(
-      (1, 12, "John Henry Bonham", "Drums"),
-      (2, 19, "John Mayer", "Guitar"),
-      (3, 32, "John Scofield", "Guitar"),
-      (4, 15, "John Butler", "Guitar")
-    ).toDF("id", "experience", "name", "instrument")
-
-    try {
-      musicDf.write
-        .format(classOf[DataSource].getName)
-        .option("url", SparkConnectorScalaSuiteIT.server.getBoltUrl)
-        .option("database", "db1")
-        .option("relationship", "PLAYS")
-        .option("relationship.source.save.mode", "Overwrite")
-        .option("relationship.target.save.mode", "Overwrite")
-        .option("relationship.save.strategy", "keys")
-        .option("relationship.source.labels", ":Musician")
-        .option("relationship.source.node.keys", "musician_name:name,another_name:name")
-        .option("relationship.target.labels", ":Instrument")
-        .option("relationship.target.node.keys", "instrument_name:name")
-        .save()
-    } catch {
-      case sparkException: SparkException => {
-        val clientException = ExceptionUtils.getRootCause(sparkException)
-        assertTrue(clientException.getMessage.equals(
-          """Write failed due to the following errors:
-            | - Schema is missing instrument_name from option `relationship.target.node.keys`
-            | - Schema is missing musician_name, another_name from option `relationship.source.node.keys`
-            |
-            |The option key and value might be inverted.""".stripMargin))
-      }
-      case generic => fail(s"should be thrown a ${classOf[SparkException].getName}, got ${generic.getClass} instead")
-    }
-  }
-
-  @Test
-  def `should give a more clear error if node properties or keys are inverted`(): Unit = {
-    val musicDf = Seq(
-      (1, 12, "John Henry Bonham", "Drums"),
-      (2, 19, "John Mayer", "Guitar"),
-      (3, 32, "John Scofield", "Guitar"),
-      (4, 15, "John Butler", "Guitar")
-    ).toDF("id", "experience", "name", "instrument")
-
-    try {
-      musicDf.write
-        .format(classOf[DataSource].getName)
-        .option("url", SparkConnectorScalaSuiteIT.server.getBoltUrl)
-        .option("database", "db1")
-        .option("labels", "Person")
-        .option("node.properties", "musician_name:name,another_name:name")
-        .save()
-    } catch {
-      case sparkException: SparkException => {
-        val clientException = ExceptionUtils.getRootCause(sparkException)
-        assertTrue(clientException.getMessage.equals(
-          """Write failed due to the following errors:
-            | - Schema is missing instrument_name from option `node.properties`
-            |
-            |The option key and value might be inverted.""".stripMargin))
-      }
-      case generic => fail(s"should be thrown a ${classOf[SparkException].getName}, got ${generic.getClass} instead")
-    }
-  }
+//
+//  @Test
+//  def `should give a more clear error if properties or keys are inverted`(): Unit = {
+//    val musicDf = Seq(
+//      (1, 12, "John Henry Bonham", "Drums"),
+//      (2, 19, "John Mayer", "Guitar"),
+//      (3, 32, "John Scofield", "Guitar"),
+//      (4, 15, "John Butler", "Guitar")
+//    ).toDF("id", "experience", "name", "instrument")
+//
+//    try {
+//      musicDf.write
+//        .format(classOf[DataSource].getName)
+//        .option("url", SparkConnectorScalaSuiteIT.server.getBoltUrl)
+//        .option("database", "db1")
+//        .option("relationship", "PLAYS")
+//        .option("relationship.source.save.mode", "Overwrite")
+//        .option("relationship.target.save.mode", "Overwrite")
+//        .option("relationship.save.strategy", "keys")
+//        .option("relationship.source.labels", ":Musician")
+//        .option("relationship.source.node.keys", "musician_name:name")
+//        .option("relationship.target.labels", ":Instrument")
+//        .option("relationship.target.node.keys", "instrument:name")
+//        .save()
+//    } catch {
+//      case sparkException: SparkException => {
+//        val clientException = ExceptionUtils.getRootCause(sparkException)
+//        assertTrue(clientException.getMessage.equals(
+//          """Write failed due to the following errors:
+//            | - Schema is missing musician_name from option `relationship.source.node.keys`
+//            |
+//            |The option key and value might be inverted.""".stripMargin))
+//      }
+//      case generic => fail(s"should be thrown a ${classOf[SparkException].getName}, got ${generic.getClass} instead")
+//    }
+//  }
+//
+//  @Test
+//  def `should give a more clear error if properties or keys are inverted on different options`(): Unit = {
+//    val musicDf = Seq(
+//      (1, 12, "John Henry Bonham", "Drums"),
+//      (2, 19, "John Mayer", "Guitar"),
+//      (3, 32, "John Scofield", "Guitar"),
+//      (4, 15, "John Butler", "Guitar")
+//    ).toDF("id", "experience", "name", "instrument")
+//
+//    try {
+//      musicDf.write
+//        .format(classOf[DataSource].getName)
+//        .option("url", SparkConnectorScalaSuiteIT.server.getBoltUrl)
+//        .option("database", "db1")
+//        .option("relationship", "PLAYS")
+//        .option("relationship.source.save.mode", "Overwrite")
+//        .option("relationship.target.save.mode", "Overwrite")
+//        .option("relationship.save.strategy", "keys")
+//        .option("relationship.source.labels", ":Musician")
+//        .option("relationship.source.node.keys", "musician_name:name,another_name:name")
+//        .option("relationship.target.labels", ":Instrument")
+//        .option("relationship.target.node.keys", "instrument_name:name")
+//        .save()
+//    } catch {
+//      case sparkException: SparkException => {
+//        val clientException = ExceptionUtils.getRootCause(sparkException)
+//        assertTrue(clientException.getMessage.equals(
+//          """Write failed due to the following errors:
+//            | - Schema is missing instrument_name from option `relationship.target.node.keys`
+//            | - Schema is missing musician_name, another_name from option `relationship.source.node.keys`
+//            |
+//            |The option key and value might be inverted.""".stripMargin))
+//      }
+//      case generic => fail(s"should be thrown a ${classOf[SparkException].getName}, got ${generic.getClass} instead")
+//    }
+//  }
+//
+//  @Test
+//  def `should give a more clear error if node properties or keys are inverted`(): Unit = {
+//    val musicDf = Seq(
+//      (1, 12, "John Henry Bonham", "Drums"),
+//      (2, 19, "John Mayer", "Guitar"),
+//      (3, 32, "John Scofield", "Guitar"),
+//      (4, 15, "John Butler", "Guitar")
+//    ).toDF("id", "experience", "name", "instrument")
+//
+//    try {
+//      musicDf.write
+//        .format(classOf[DataSource].getName)
+//        .option("url", SparkConnectorScalaSuiteIT.server.getBoltUrl)
+//        .option("database", "db1")
+//        .option("labels", "Person")
+//        .option("node.properties", "musician_name:name,another_name:name")
+//        .save()
+//    } catch {
+//      case sparkException: SparkException => {
+//        val clientException = ExceptionUtils.getRootCause(sparkException)
+//        assertTrue(clientException.getMessage.equals(
+//          """Write failed due to the following errors:
+//            | - Schema is missing instrument_name from option `node.properties`
+//            |
+//            |The option key and value might be inverted.""".stripMargin))
+//      }
+//      case generic => fail(s"should be thrown a ${classOf[SparkException].getName}, got ${generic.getClass} instead")
+//    }
+//  }
 }

--- a/src/test/scala/org/neo4j/spark/DataSourceWriterTSE.scala
+++ b/src/test/scala/org/neo4j/spark/DataSourceWriterTSE.scala
@@ -45,11 +45,6 @@ class DataSourceWriterTSE extends SparkConnectorScalaBaseTSE {
 
   import sparkSession.implicits._
 
-  val _expectedException: ExpectedException = ExpectedException.none
-
-  @Rule
-  def exceptionRule: ExpectedException = _expectedException
-
   private def testType[T](ds: DataFrame, neo4jType: Type): Unit = {
     ds.write
       .format(classOf[DataSource].getName)
@@ -585,7 +580,6 @@ class DataSourceWriterTSE extends SparkConnectorScalaBaseTSE {
       .option("relationship", "PLAYS")
       .option("relationship.save.strategy", "keys")
       .option("relationship.source.labels", ":Musician")
-      .option("relationship.properties", "field")
       .option("relationship.source.save.mode", "Overwrite")
       .option("relationship.source.node.keys", "name:name")
       .option("relationship.target.labels", ":Instrument")
@@ -1144,4 +1138,106 @@ class DataSourceWriterTSE extends SparkConnectorScalaBaseTSE {
     assertEquals(32, experience)
   }
 
+  @Test
+  def `should give a more clear error if properties or keys are inverted`(): Unit = {
+    val musicDf = Seq(
+      (1, 12, "John Henry Bonham", "Drums"),
+      (2, 19, "John Mayer", "Guitar"),
+      (3, 32, "John Scofield", "Guitar"),
+      (4, 15, "John Butler", "Guitar")
+    ).toDF("id", "experience", "name", "instrument")
+
+    try {
+      musicDf.write
+        .format(classOf[DataSource].getName)
+        .option("url", SparkConnectorScalaSuiteIT.server.getBoltUrl)
+        .option("database", "db1")
+        .option("relationship", "PLAYS")
+        .option("relationship.source.save.mode", "Overwrite")
+        .option("relationship.target.save.mode", "Overwrite")
+        .option("relationship.save.strategy", "keys")
+        .option("relationship.source.labels", ":Musician")
+        .option("relationship.source.node.keys", "musician_name:name")
+        .option("relationship.target.labels", ":Instrument")
+        .option("relationship.target.node.keys", "instrument:name")
+        .save()
+    } catch {
+      case sparkException: SparkException => {
+        val clientException = ExceptionUtils.getRootCause(sparkException)
+        assertTrue(clientException.getMessage.equals(
+          """Write failed due to the following errors.
+            | - Schema is missing musician_name from option `relationship.source.node.keys`
+            |
+            |Option's key:value might be inverted.""".stripMargin))
+      }
+      case generic => fail(s"should be thrown a ${classOf[SparkException].getName}, got ${generic.getClass} instead")
+    }
+  }
+
+  @Test
+  def `should give a more clear error if properties or keys are inverted on different options`(): Unit = {
+    val musicDf = Seq(
+      (1, 12, "John Henry Bonham", "Drums"),
+      (2, 19, "John Mayer", "Guitar"),
+      (3, 32, "John Scofield", "Guitar"),
+      (4, 15, "John Butler", "Guitar")
+    ).toDF("id", "experience", "name", "instrument")
+
+    try {
+      musicDf.write
+        .format(classOf[DataSource].getName)
+        .option("url", SparkConnectorScalaSuiteIT.server.getBoltUrl)
+        .option("database", "db1")
+        .option("relationship", "PLAYS")
+        .option("relationship.source.save.mode", "Overwrite")
+        .option("relationship.target.save.mode", "Overwrite")
+        .option("relationship.save.strategy", "keys")
+        .option("relationship.source.labels", ":Musician")
+        .option("relationship.source.node.keys", "musician_name:name,another_name:name")
+        .option("relationship.target.labels", ":Instrument")
+        .option("relationship.target.node.keys", "instrument_name:name")
+        .save()
+    } catch {
+      case sparkException: SparkException => {
+        val clientException = ExceptionUtils.getRootCause(sparkException)
+        assertTrue(clientException.getMessage.equals(
+          """Write failed due to the following errors.
+            | - Schema is missing instrument_name from option `relationship.target.node.keys`
+            | - Schema is missing musician_name, another_name from option `relationship.source.node.keys`
+            |
+            |Option's key:value might be inverted.""".stripMargin))
+      }
+      case generic => fail(s"should be thrown a ${classOf[SparkException].getName}, got ${generic.getClass} instead")
+    }
+  }
+
+  @Test
+  def `should give a more clear error if node properties or keys are inverted`(): Unit = {
+    val musicDf = Seq(
+      (1, 12, "John Henry Bonham", "Drums"),
+      (2, 19, "John Mayer", "Guitar"),
+      (3, 32, "John Scofield", "Guitar"),
+      (4, 15, "John Butler", "Guitar")
+    ).toDF("id", "experience", "name", "instrument")
+
+    try {
+      musicDf.write
+        .format(classOf[DataSource].getName)
+        .option("url", SparkConnectorScalaSuiteIT.server.getBoltUrl)
+        .option("database", "db1")
+        .option("labels", "Person")
+        .option("node.properties", "musician_name:name,another_name:name")
+        .save()
+    } catch {
+      case sparkException: SparkException => {
+        val clientException = ExceptionUtils.getRootCause(sparkException)
+        assertTrue(clientException.getMessage.equals(
+          """Write failed due to the following errors.
+            | - Schema is missing instrument_name from option `node.properties`
+            |
+            |Option's key:value might be inverted.""".stripMargin))
+      }
+      case generic => fail(s"should be thrown a ${classOf[SparkException].getName}, got ${generic.getClass} instead")
+    }
+  }
 }

--- a/src/test/scala/org/neo4j/spark/DataSourceWriterTSE.scala
+++ b/src/test/scala/org/neo4j/spark/DataSourceWriterTSE.scala
@@ -1165,10 +1165,10 @@ class DataSourceWriterTSE extends SparkConnectorScalaBaseTSE {
       case sparkException: SparkException => {
         val clientException = ExceptionUtils.getRootCause(sparkException)
         assertTrue(clientException.getMessage.equals(
-          """Write failed due to the following errors.
+          """Write failed due to the following errors:
             | - Schema is missing musician_name from option `relationship.source.node.keys`
             |
-            |Option's key:value might be inverted.""".stripMargin))
+            |The option key and value might be inverted.""".stripMargin))
       }
       case generic => fail(s"should be thrown a ${classOf[SparkException].getName}, got ${generic.getClass} instead")
     }
@@ -1201,11 +1201,11 @@ class DataSourceWriterTSE extends SparkConnectorScalaBaseTSE {
       case sparkException: SparkException => {
         val clientException = ExceptionUtils.getRootCause(sparkException)
         assertTrue(clientException.getMessage.equals(
-          """Write failed due to the following errors.
+          """Write failed due to the following errors:
             | - Schema is missing instrument_name from option `relationship.target.node.keys`
             | - Schema is missing musician_name, another_name from option `relationship.source.node.keys`
             |
-            |Option's key:value might be inverted.""".stripMargin))
+            |The option key and value might be inverted.""".stripMargin))
       }
       case generic => fail(s"should be thrown a ${classOf[SparkException].getName}, got ${generic.getClass} instead")
     }
@@ -1232,10 +1232,10 @@ class DataSourceWriterTSE extends SparkConnectorScalaBaseTSE {
       case sparkException: SparkException => {
         val clientException = ExceptionUtils.getRootCause(sparkException)
         assertTrue(clientException.getMessage.equals(
-          """Write failed due to the following errors.
+          """Write failed due to the following errors:
             | - Schema is missing instrument_name from option `node.properties`
             |
-            |Option's key:value might be inverted.""".stripMargin))
+            |The option key and value might be inverted.""".stripMargin))
       }
       case generic => fail(s"should be thrown a ${classOf[SparkException].getName}, got ${generic.getClass} instead")
     }

--- a/src/test/scala/org/neo4j/spark/DataSourceWriterTSE.scala
+++ b/src/test/scala/org/neo4j/spark/DataSourceWriterTSE.scala
@@ -582,10 +582,39 @@ class DataSourceWriterTSE extends SparkConnectorScalaBaseTSE {
       .option("relationship.source.labels", ":Musician")
       .option("relationship.source.save.mode", "Overwrite")
       .option("relationship.source.node.keys", "name:name")
+      .option("relationship.source.node.properties", "fi``(╯°□°)╯︵ ┻━┻eld:field")
       .option("relationship.target.labels", ":Instrument")
       .option("relationship.target.node.keys", "instrument:name")
       .option("relationship.target.save.mode", "Overwrite")
       .save()
+
+    val musicDfCheck = ss.read.format(classOf[DataSource].getName)
+      .option("url", SparkConnectorScalaSuiteIT.server.getBoltUrl)
+      .option("relationship", "PLAYS")
+      .option("relationship.nodes.map", "false")
+      .option("relationship.source.labels", ":Musician")
+      .option("relationship.target.labels", ":Instrument")
+      .load()
+
+    assertEquals(4, musicDfCheck.count())
+
+    val res = musicDfCheck.orderBy("`source.name`").collectAsList()
+
+    assertEquals("John Bonham", res.get(0).getString(4))
+    assertEquals("f``````oo", res.get(0).getString(5))
+    assertEquals("Drums", res.get(0).getString(8))
+
+    assertEquals("John Butler", res.get(1).getString(4))
+    assertEquals("qu   ux", res.get(1).getString(5))
+    assertEquals("Guitar", res.get(1).getString(8))
+
+    assertEquals("John Mayer", res.get(2).getString(4))
+    assertEquals("bar", res.get(2).getString(5))
+    assertEquals("Guitar", res.get(2).getString(8))
+
+    assertEquals("John Scofield", res.get(3).getString(4))
+    assertEquals("ba` z", res.get(3).getString(5))
+    assertEquals("Guitar", res.get(3).getString(8))
   }
 
   @Test(expected = classOf[SparkException])
@@ -997,9 +1026,19 @@ class DataSourceWriterTSE extends SparkConnectorScalaBaseTSE {
 
     assertEquals(4, df2.count())
 
-    val result = df2.select("`source.name`").orderBy("`source.name`").collectAsList()
+    val res = df2.orderBy("`source.name`").collectAsList()
 
-    assertEquals("John Bonham", result.get(0).getString(0))
+    assertEquals("John Bonham", res.get(0).getString(4))
+    assertEquals("Drums", res.get(0).getString(7))
+
+    assertEquals("John Butler", res.get(1).getString(4))
+    assertEquals("Guitar", res.get(1).getString(7))
+
+    assertEquals("John Mayer", res.get(2).getString(4))
+    assertEquals("Guitar", res.get(2).getString(7))
+
+    assertEquals("John Scofield", res.get(3).getString(4))
+    assertEquals("Guitar", res.get(3).getString(7))
   }
 
   @Test
@@ -1015,6 +1054,7 @@ class DataSourceWriterTSE extends SparkConnectorScalaBaseTSE {
       .format(classOf[DataSource].getName)
       .option("url", SparkConnectorScalaSuiteIT.server.getBoltUrl)
       .option("relationship", "PLAYS")
+      .option("relationship.properties", "experience")
       .option("relationship.source.save.mode", "ErrorIfExists")
       .option("relationship.target.save.mode", "ErrorIfExists")
       .option("relationship.save.strategy", "keys")
@@ -1047,15 +1087,31 @@ class DataSourceWriterTSE extends SparkConnectorScalaBaseTSE {
         val rel = r.get("rel").asRelationship()
         println(
           s"${source.id()} | ${source.labels()} | ${source.asMap()} |" +
-          s"${rel.id()} | ${rel.`type`()} | ${rel.asMap()} |" +
-          s"${target.id()} | ${target.labels()} | ${target.asMap()}")
+            s"${rel.id()} | ${rel.`type`()} | ${rel.asMap()} |" +
+            s"${target.id()} | ${target.labels()} | ${target.asMap()}")
       })
 
     assertEquals(4, df2.count())
 
-    val result = df2.select("`source.name`").orderBy("`source.name`").collectAsList()
+    df2.show()
 
-    assertEquals("John Bonham", result.get(0).getString(0))
+    val res = df2.orderBy("`source.name`").collectAsList()
+
+    assertEquals("John Bonham", res.get(0).getString(4))
+    assertEquals("Drums", res.get(0).getString(7))
+    assertEquals(12, res.get(0).getLong(8))
+
+    assertEquals("John Butler", res.get(1).getString(4))
+    assertEquals("Guitar", res.get(1).getString(7))
+    assertEquals(15, res.get(1).getLong(8))
+
+    assertEquals("John Mayer", res.get(2).getString(4))
+    assertEquals("Guitar", res.get(2).getString(7))
+    assertEquals(19, res.get(2).getLong(8))
+
+    assertEquals("John Scofield", res.get(3).getString(4))
+    assertEquals("Guitar", res.get(3).getString(7))
+    assertEquals(32, res.get(3).getLong(8))
   }
 
   @Test
@@ -1158,107 +1214,107 @@ class DataSourceWriterTSE extends SparkConnectorScalaBaseTSE {
 
     assertEquals(32, experience)
   }
-//
-//  @Test
-//  def `should give a more clear error if properties or keys are inverted`(): Unit = {
-//    val musicDf = Seq(
-//      (1, 12, "John Henry Bonham", "Drums"),
-//      (2, 19, "John Mayer", "Guitar"),
-//      (3, 32, "John Scofield", "Guitar"),
-//      (4, 15, "John Butler", "Guitar")
-//    ).toDF("id", "experience", "name", "instrument")
-//
-//    try {
-//      musicDf.write
-//        .format(classOf[DataSource].getName)
-//        .option("url", SparkConnectorScalaSuiteIT.server.getBoltUrl)
-//        .option("database", "db1")
-//        .option("relationship", "PLAYS")
-//        .option("relationship.source.save.mode", "Overwrite")
-//        .option("relationship.target.save.mode", "Overwrite")
-//        .option("relationship.save.strategy", "keys")
-//        .option("relationship.source.labels", ":Musician")
-//        .option("relationship.source.node.keys", "musician_name:name")
-//        .option("relationship.target.labels", ":Instrument")
-//        .option("relationship.target.node.keys", "instrument:name")
-//        .save()
-//    } catch {
-//      case sparkException: SparkException => {
-//        val clientException = ExceptionUtils.getRootCause(sparkException)
-//        assertTrue(clientException.getMessage.equals(
-//          """Write failed due to the following errors:
-//            | - Schema is missing musician_name from option `relationship.source.node.keys`
-//            |
-//            |The option key and value might be inverted.""".stripMargin))
-//      }
-//      case generic => fail(s"should be thrown a ${classOf[SparkException].getName}, got ${generic.getClass} instead")
-//    }
-//  }
-//
-//  @Test
-//  def `should give a more clear error if properties or keys are inverted on different options`(): Unit = {
-//    val musicDf = Seq(
-//      (1, 12, "John Henry Bonham", "Drums"),
-//      (2, 19, "John Mayer", "Guitar"),
-//      (3, 32, "John Scofield", "Guitar"),
-//      (4, 15, "John Butler", "Guitar")
-//    ).toDF("id", "experience", "name", "instrument")
-//
-//    try {
-//      musicDf.write
-//        .format(classOf[DataSource].getName)
-//        .option("url", SparkConnectorScalaSuiteIT.server.getBoltUrl)
-//        .option("database", "db1")
-//        .option("relationship", "PLAYS")
-//        .option("relationship.source.save.mode", "Overwrite")
-//        .option("relationship.target.save.mode", "Overwrite")
-//        .option("relationship.save.strategy", "keys")
-//        .option("relationship.source.labels", ":Musician")
-//        .option("relationship.source.node.keys", "musician_name:name,another_name:name")
-//        .option("relationship.target.labels", ":Instrument")
-//        .option("relationship.target.node.keys", "instrument_name:name")
-//        .save()
-//    } catch {
-//      case sparkException: SparkException => {
-//        val clientException = ExceptionUtils.getRootCause(sparkException)
-//        assertTrue(clientException.getMessage.equals(
-//          """Write failed due to the following errors:
-//            | - Schema is missing instrument_name from option `relationship.target.node.keys`
-//            | - Schema is missing musician_name, another_name from option `relationship.source.node.keys`
-//            |
-//            |The option key and value might be inverted.""".stripMargin))
-//      }
-//      case generic => fail(s"should be thrown a ${classOf[SparkException].getName}, got ${generic.getClass} instead")
-//    }
-//  }
-//
-//  @Test
-//  def `should give a more clear error if node properties or keys are inverted`(): Unit = {
-//    val musicDf = Seq(
-//      (1, 12, "John Henry Bonham", "Drums"),
-//      (2, 19, "John Mayer", "Guitar"),
-//      (3, 32, "John Scofield", "Guitar"),
-//      (4, 15, "John Butler", "Guitar")
-//    ).toDF("id", "experience", "name", "instrument")
-//
-//    try {
-//      musicDf.write
-//        .format(classOf[DataSource].getName)
-//        .option("url", SparkConnectorScalaSuiteIT.server.getBoltUrl)
-//        .option("database", "db1")
-//        .option("labels", "Person")
-//        .option("node.properties", "musician_name:name,another_name:name")
-//        .save()
-//    } catch {
-//      case sparkException: SparkException => {
-//        val clientException = ExceptionUtils.getRootCause(sparkException)
-//        assertTrue(clientException.getMessage.equals(
-//          """Write failed due to the following errors:
-//            | - Schema is missing instrument_name from option `node.properties`
-//            |
-//            |The option key and value might be inverted.""".stripMargin))
-//      }
-//      case generic => fail(s"should be thrown a ${classOf[SparkException].getName}, got ${generic.getClass} instead")
-//    }
-//  }
+
+  @Test
+  def `should give a more clear error if properties or keys are inverted`(): Unit = {
+    val musicDf = Seq(
+      (1, 12, "John Henry Bonham", "Drums"),
+      (2, 19, "John Mayer", "Guitar"),
+      (3, 32, "John Scofield", "Guitar"),
+      (4, 15, "John Butler", "Guitar")
+    ).toDF("id", "experience", "name", "instrument")
+
+    try {
+      musicDf.write
+        .format(classOf[DataSource].getName)
+        .option("url", SparkConnectorScalaSuiteIT.server.getBoltUrl)
+        .option("database", "db1")
+        .option("relationship", "PLAYS")
+        .option("relationship.source.save.mode", "Overwrite")
+        .option("relationship.target.save.mode", "Overwrite")
+        .option("relationship.save.strategy", "keys")
+        .option("relationship.source.labels", ":Musician")
+        .option("relationship.source.node.keys", "musician_name:name")
+        .option("relationship.target.labels", ":Instrument")
+        .option("relationship.target.node.keys", "instrument:name")
+        .save()
+    } catch {
+      case sparkException: SparkException => {
+        val clientException = ExceptionUtils.getRootCause(sparkException)
+        assertTrue(clientException.getMessage.equals(
+          """Write failed due to the following errors:
+            | - Schema is missing musician_name from option `relationship.source.node.keys`
+            |
+            |The option key and value might be inverted.""".stripMargin))
+      }
+      case generic => fail(s"should be thrown a ${classOf[SparkException].getName}, got ${generic.getClass} instead")
+    }
+  }
+
+  @Test
+  def `should give a more clear error if properties or keys are inverted on different options`(): Unit = {
+    val musicDf = Seq(
+      (1, 12, "John Henry Bonham", "Drums"),
+      (2, 19, "John Mayer", "Guitar"),
+      (3, 32, "John Scofield", "Guitar"),
+      (4, 15, "John Butler", "Guitar")
+    ).toDF("id", "experience", "name", "instrument")
+
+    try {
+      musicDf.write
+        .format(classOf[DataSource].getName)
+        .option("url", SparkConnectorScalaSuiteIT.server.getBoltUrl)
+        .option("database", "db1")
+        .option("relationship", "PLAYS")
+        .option("relationship.source.save.mode", "Overwrite")
+        .option("relationship.target.save.mode", "Overwrite")
+        .option("relationship.save.strategy", "keys")
+        .option("relationship.source.labels", ":Musician")
+        .option("relationship.source.node.keys", "musician_name:name,another_name:name")
+        .option("relationship.target.labels", ":Instrument")
+        .option("relationship.target.node.keys", "instrument_name:name")
+        .save()
+    } catch {
+      case sparkException: SparkException => {
+        val clientException = ExceptionUtils.getRootCause(sparkException)
+        assertTrue(clientException.getMessage.equals(
+          """Write failed due to the following errors:
+            | - Schema is missing instrument_name from option `relationship.target.node.keys`
+            | - Schema is missing musician_name, another_name from option `relationship.source.node.keys`
+            |
+            |The option key and value might be inverted.""".stripMargin))
+      }
+      case generic => fail(s"should be thrown a ${classOf[SparkException].getName}, got ${generic.getClass} instead")
+    }
+  }
+
+  @Test
+  def `should give a more clear error if node properties or keys are inverted`(): Unit = {
+    val musicDf = Seq(
+      (1, 12, "John Henry Bonham", "Drums"),
+      (2, 19, "John Mayer", "Guitar"),
+      (3, 32, "John Scofield", "Guitar"),
+      (4, 15, "John Butler", "Guitar")
+    ).toDF("id", "experience", "name", "instrument")
+
+    try {
+      musicDf.write
+        .format(classOf[DataSource].getName)
+        .option("url", SparkConnectorScalaSuiteIT.server.getBoltUrl)
+        .option("database", "db1")
+        .option("labels", "Person")
+        .option("node.properties", "musician_name:name,another_name:name")
+        .save()
+    } catch {
+      case sparkException: SparkException => {
+        val clientException = ExceptionUtils.getRootCause(sparkException)
+        assertTrue(clientException.getMessage.equals(
+          """Write failed due to the following errors:
+            | - Schema is missing instrument_name from option `node.properties`
+            |
+            |The option key and value might be inverted.""".stripMargin))
+      }
+      case generic => fail(s"should be thrown a ${classOf[SparkException].getName}, got ${generic.getClass} instead")
+    }
+  }
 }

--- a/src/test/scala/org/neo4j/spark/DataSourceWriterTSE.scala
+++ b/src/test/scala/org/neo4j/spark/DataSourceWriterTSE.scala
@@ -993,6 +993,8 @@ class DataSourceWriterTSE extends SparkConnectorScalaBaseTSE {
       .option("relationship.target.labels", ":Instrument")
       .load()
 
+    df2.show()
+
     assertEquals(4, df2.count())
 
     val result = df2.select("`source.name`").orderBy("`source.name`").collectAsList()
@@ -1029,6 +1031,8 @@ class DataSourceWriterTSE extends SparkConnectorScalaBaseTSE {
       .option("relationship.source.labels", ":Musician")
       .option("relationship.target.labels", ":Instrument")
       .load()
+
+    df2.show()
 
     assertEquals(4, df2.count())
 

--- a/src/test/scala/org/neo4j/spark/util/Neo4jImplicitsTest.scala
+++ b/src/test/scala/org/neo4j/spark/util/Neo4jImplicitsTest.scala
@@ -1,6 +1,7 @@
 package org.neo4j.spark.util
 
 import org.apache.spark.sql.sources.{And, EqualTo, Not}
+import org.apache.spark.sql.types.{DataTypes, StructField, StructType}
 import org.junit.Test
 import org.junit.Assert._
 import org.neo4j.spark.util.Neo4jImplicits._
@@ -77,5 +78,19 @@ class Neo4jImplicitsTest {
 
     // then
     assertEquals("address.coords", attribute.get)
+  }
+
+  @Test
+  def `struct should return true if contains fields`: Unit = {
+    val struct = StructType(Seq(StructField("is_hero", DataTypes.BooleanType), StructField("name", DataTypes.StringType)))
+
+    assertEquals(0, struct.missingFields(Set("is_hero", "name")).size)
+  }
+
+  @Test
+  def `struct should return false if not contains fields`: Unit = {
+    val struct = StructType(Seq(StructField("is_hero", DataTypes.BooleanType), StructField("name", DataTypes.StringType)))
+
+    assertEquals(Set[String]("hero_name"), struct.missingFields(Set("is_hero", "hero_name")))
   }
 }

--- a/src/test/scala/org/neo4j/spark/util/Neo4jImplicitsTest.scala
+++ b/src/test/scala/org/neo4j/spark/util/Neo4jImplicitsTest.scala
@@ -84,13 +84,13 @@ class Neo4jImplicitsTest {
   def `struct should return true if contains fields`: Unit = {
     val struct = StructType(Seq(StructField("is_hero", DataTypes.BooleanType), StructField("name", DataTypes.StringType)))
 
-    assertEquals(0, struct.missingFields(Set("is_hero", "name")).size)
+    assertEquals(0, struct.getMissingFields(Set("is_hero", "name")).size)
   }
 
   @Test
   def `struct should return false if not contains fields`: Unit = {
     val struct = StructType(Seq(StructField("is_hero", DataTypes.BooleanType), StructField("name", DataTypes.StringType)))
 
-    assertEquals(Set[String]("hero_name"), struct.missingFields(Set("is_hero", "hero_name")))
+    assertEquals(Set[String]("hero_name"), struct.getMissingFields(Set("is_hero", "hero_name")))
   }
 }


### PR DESCRIPTION
Fixes #178 

Details in the issue. 

With this changes, the following scenario:

```scala
val musicDf = Seq(
      (1, 12, "John Henry Bonham", "Drums"),
      (2, 19, "John Mayer", "Guitar"),
      (3, 32, "John Scofield", "Guitar"),
      (4, 15, "John Butler", "Guitar")
    ).toDF("id", "experience", "name", "instrument")

    musicDf.write
        .format(classOf[DataSource].getName)
        .option("url", SparkConnectorScalaSuiteIT.server.getBoltUrl)
        .option("relationship", "PLAYS")
        .option("relationship.source.save.mode", "Overwrite")
        .option("relationship.target.save.mode", "Overwrite")
        .option("relationship.save.strategy", "keys")
        .option("relationship.source.labels", ":Musician")
        .option("relationship.source.node.keys", "musician_name:name,another_name:name") // <-- wrong
        .option("relationship.target.labels", ":Instrument")
        .option("relationship.target.node.keys", "instrument_name:name") // <-- wrong
        .save()
```

will produce the following error:

```
Write failed due to the following errors:
 - Schema is missing instrument_name from option `relationship.target.node.keys`
 - Schema is missing musician_name, another_name from option `relationship.source.node.keys`

The option key and value might be inverted.
```

More examples in the new tests.

Minor issues fixed in the PR:
- Jar name is wrong due to a misspelled variable in pom.xml