### PR TITLE
Fixes #179: Error writing node query generation with compound key

### DIFF
--- a/src/main/scala/org/neo4j/spark/service/MappingService.scala
+++ b/src/main/scala/org/neo4j/spark/service/MappingService.scala
@@ -68,19 +68,19 @@ class Neo4jWriteMappingStrategy(private val options: Neo4jOptions)
   private def keysStrategyConsumer(): MappingBiConsumer = new MappingBiConsumer {
     override def accept(key: String, value: AnyRef): Unit = {
       if (options.relationshipMetadata.source.nodeKeys.contains(key)) {
-        sourceNodeMap.get(KEYS).put(key, value)
+        sourceNodeMap.get(KEYS).put(options.relationshipMetadata.source.nodeKeys.getOrElse(key, key), value)
       }
       else if (options.relationshipMetadata.source.nodeProps.contains(key)) {
-        sourceNodeMap.get(PROPERTIES).put(key, value)
+        sourceNodeMap.get(PROPERTIES).put(options.relationshipMetadata.source.nodeProps.getOrElse(key, key), value)
       }
       else if (options.relationshipMetadata.target.nodeKeys.contains(key)) {
-        targetNodeMap.get(KEYS).put(key, value)
+        targetNodeMap.get(KEYS).put(options.relationshipMetadata.target.nodeKeys.getOrElse(key, key), value)
       }
       else if (options.relationshipMetadata.target.nodeProps.contains(key)) {
-        targetNodeMap.get(PROPERTIES).put(key, value)
+        targetNodeMap.get(PROPERTIES).put(options.relationshipMetadata.target.nodeProps.getOrElse(key, key), value)
       }
       else if (options.relationshipMetadata.properties.contains(key)) {
-        relMap.get(PROPERTIES).put(key, value)
+        relMap.get(PROPERTIES).put(options.relationshipMetadata.properties.getOrElse(key, key), value)
       }
     }
   }

--- a/src/main/scala/org/neo4j/spark/service/MappingService.scala
+++ b/src/main/scala/org/neo4j/spark/service/MappingService.scala
@@ -67,19 +67,22 @@ class Neo4jWriteMappingStrategy(private val options: Neo4jOptions)
 
   private def keysStrategyConsumer(): MappingBiConsumer = new MappingBiConsumer {
     override def accept(key: String, value: AnyRef): Unit = {
-      if (options.relationshipMetadata.source.nodeKeys.contains(key)) {
-        sourceNodeMap.get(KEYS).put(options.relationshipMetadata.source.nodeKeys.getOrElse(key, key), value)
+      val source = options.relationshipMetadata.source
+      val target = options.relationshipMetadata.target
+
+      if (source.nodeKeys.contains(key)) {
+        sourceNodeMap.get(KEYS).put(source.nodeKeys.getOrElse(key, key), value)
       }
-      else if (options.relationshipMetadata.source.nodeProps.contains(key)) {
-        sourceNodeMap.get(PROPERTIES).put(options.relationshipMetadata.source.nodeProps.getOrElse(key, key), value)
+      if (source.nodeProps.contains(key)) {
+        sourceNodeMap.get(PROPERTIES).put(source.nodeProps.getOrElse(key, key), value)
       }
-      else if (options.relationshipMetadata.target.nodeKeys.contains(key)) {
-        targetNodeMap.get(KEYS).put(options.relationshipMetadata.target.nodeKeys.getOrElse(key, key), value)
+      if (target.nodeKeys.contains(key)) {
+        targetNodeMap.get(KEYS).put(target.nodeKeys.getOrElse(key, key), value)
       }
-      else if (options.relationshipMetadata.target.nodeProps.contains(key)) {
-        targetNodeMap.get(PROPERTIES).put(options.relationshipMetadata.target.nodeProps.getOrElse(key, key), value)
+      if (target.nodeProps.contains(key)) {
+        targetNodeMap.get(PROPERTIES).put(target.nodeProps.getOrElse(key, key), value)
       }
-      else if (options.relationshipMetadata.properties.contains(key)) {
+      if (options.relationshipMetadata.properties.contains(key)) {
         relMap.get(PROPERTIES).put(options.relationshipMetadata.properties.getOrElse(key, key), value)
       }
     }

--- a/src/main/scala/org/neo4j/spark/service/MappingService.scala
+++ b/src/main/scala/org/neo4j/spark/service/MappingService.scala
@@ -11,7 +11,7 @@ import org.neo4j.driver.types.Node
 import org.neo4j.driver.{Record, Value, Values}
 import org.neo4j.spark.service.Neo4jWriteMappingStrategy.{KEYS, PROPERTIES}
 import org.neo4j.spark.util.{Neo4jUtil, Validations}
-import org.neo4j.spark.{Neo4jOptions, QueryType, RelationshipSaveStrategy}
+import org.neo4j.spark.{Neo4jNodeMetadata, Neo4jOptions, QueryType, RelationshipSaveStrategy}
 
 import scala.collection.JavaConverters._
 import scala.collection.mutable
@@ -65,23 +65,23 @@ class Neo4jWriteMappingStrategy(private val options: Neo4jOptions)
     }
   }
 
+  private def addToNodeMap(nodeMap: util.Map[String, util.Map[String, AnyRef]], nodeMetadata: Neo4jNodeMetadata, key: String, value: AnyRef): Unit = {
+    if (nodeMetadata.nodeKeys.contains(key)) {
+      nodeMap.get(KEYS).put(nodeMetadata.nodeKeys.getOrElse(key, key), value)
+    }
+    if (nodeMetadata.nodeProps.contains(key)) {
+      nodeMap.get(PROPERTIES).put(nodeMetadata.nodeProps.getOrElse(key, key), value)
+    }
+  }
+
   private def keysStrategyConsumer(): MappingBiConsumer = new MappingBiConsumer {
     override def accept(key: String, value: AnyRef): Unit = {
       val source = options.relationshipMetadata.source
       val target = options.relationshipMetadata.target
 
-      if (source.nodeKeys.contains(key)) {
-        sourceNodeMap.get(KEYS).put(source.nodeKeys.getOrElse(key, key), value)
-      }
-      if (source.nodeProps.contains(key)) {
-        sourceNodeMap.get(PROPERTIES).put(source.nodeProps.getOrElse(key, key), value)
-      }
-      if (target.nodeKeys.contains(key)) {
-        targetNodeMap.get(KEYS).put(target.nodeKeys.getOrElse(key, key), value)
-      }
-      if (target.nodeProps.contains(key)) {
-        targetNodeMap.get(PROPERTIES).put(target.nodeProps.getOrElse(key, key), value)
-      }
+      addToNodeMap(sourceNodeMap, source, key, value)
+      addToNodeMap(targetNodeMap, target, key, value)
+
       if (options.relationshipMetadata.properties.contains(key)) {
         relMap.get(PROPERTIES).put(options.relationshipMetadata.properties.getOrElse(key, key), value)
       }

--- a/src/main/scala/org/neo4j/spark/service/Neo4jQueryService.scala
+++ b/src/main/scala/org/neo4j/spark/service/Neo4jQueryService.scala
@@ -36,7 +36,7 @@ class Neo4jQueryWriteStrategy(private val saveMode: SaveMode) extends Neo4jQuery
 
   private def createQueryPart(keyword: String, labels: String, keys: String, alias: String): String = {
     val setStatement = if (!keyword.equals("MATCH")) s"SET $alias += $BATCH_VARIABLE.$alias.${Neo4jWriteMappingStrategy.PROPERTIES}" else ""
-    s"""$keyword ($alias${if (labels.isEmpty) "" else s":$labels"} ${if (keys.isEmpty) "" else s"{$keys}"}) $setStatement""".stripMargin
+    s"""$keyword ($alias${if (labels.isEmpty) "" else s":$labels"} ${if (keys.isEmpty) "" else s"{$keys}"})$setStatement""".stripMargin
   }
 
   override def createStatementForRelationships(options: Neo4jOptions): String = {
@@ -229,15 +229,6 @@ abstract class Neo4jQueryStrategy {
   def createStatementForRelationships(options: Neo4jOptions): String
 
   def createStatementForNodes(options: Neo4jOptions): String
-
-  protected def createQueryPart(keyword: String, labels: String, keys: String, alias: String, additionalAliases: Seq[String] = Seq[String]()): String = {
-    val withAliases = additionalAliases ++ Seq(BATCH_VARIABLE, alias)
-
-    val setStatement = if (!keyword.equals("MATCH")) s" SET $alias += $BATCH_VARIABLE.$alias.${Neo4jWriteMappingStrategy.PROPERTIES}" else ""
-
-    s"""$keyword ($alias${if (labels.isEmpty) "" else s":$labels"} ${if (keys.isEmpty) "" else s"{$keys}"})$setStatement
-    |WITH ${withAliases.mkString(", ")}""".stripMargin
-  }
 }
 
 class Neo4jQueryService(private val options: Neo4jOptions,

--- a/src/main/scala/org/neo4j/spark/service/Neo4jQueryService.scala
+++ b/src/main/scala/org/neo4j/spark/service/Neo4jQueryService.scala
@@ -17,6 +17,12 @@ class Neo4jQueryWriteStrategy(private val saveMode: SaveMode) extends Neo4jQuery
        |${options.query.value}
        |""".stripMargin
 
+  private def createPropsList(props: Map[String, String], prefix: String): String = {
+    props.map(key => {
+      s"${key._2.quote()}: $BATCH_VARIABLE.$prefix.${key._1.removeAlias().quote()}"
+    }).mkString(", ")
+  }
+
   private def keywordFromSaveMode(saveMode: Any): String = {
     saveMode match {
       case NodeSaveMode.Overwrite | SaveMode.Overwrite => "MERGE"
@@ -46,13 +52,14 @@ class Neo4jQueryWriteStrategy(private val saveMode: SaveMode) extends Neo4jQuery
       .map(_.quote())
       .mkString(":")
 
-    val sourceKeys = options.relationshipMetadata.source.nodeKeys.map(key => {
-      s"${key._2.quote()}: $BATCH_VARIABLE.source.${Neo4jWriteMappingStrategy.KEYS}.${key._1.removeAlias().quote()}"
-    }).mkString(", ")
-    val targetKeys = options.relationshipMetadata.target.nodeKeys.map(key => {
-      s"${key._2.quote()}: $BATCH_VARIABLE.target.${Neo4jWriteMappingStrategy.KEYS}.${key._1.removeAlias().quote()}"
-    }).mkString(", ")
-
+    val sourceKeys = createPropsList(
+      options.relationshipMetadata.source.nodeKeys,
+      s"source.${Neo4jWriteMappingStrategy.KEYS}"
+    )
+    val targetKeys = createPropsList(
+      options.relationshipMetadata.target.nodeKeys,
+      s"target.${Neo4jWriteMappingStrategy.KEYS}"
+    )
     val sourceQueryPart = createQueryPart(sourceKeyword, sourceLabels, sourceKeys, Neo4jUtil.RELATIONSHIP_SOURCE_ALIAS)
     val targetQueryPart = createQueryPart(targetKeyword, targetLabels, targetKeys, Neo4jUtil.RELATIONSHIP_TARGET_ALIAS)
 
@@ -68,12 +75,13 @@ class Neo4jQueryWriteStrategy(private val saveMode: SaveMode) extends Neo4jQuery
     val keyword = keywordFromSaveMode(saveMode)
 
     val labels = options.nodeMetadata.labels
-      .map(_.quote)
+      .map(_.quote())
       .mkString(":")
-    val keys = options.nodeMetadata.nodeKeys
-      .map(key => {
-        s"${key._2.quote()}: $BATCH_VARIABLE.${Neo4jWriteMappingStrategy.KEYS}.${key._1.removeAlias().quote()}"
-      }).mkString(", ")
+
+    val keys =  createPropsList(
+      options.nodeMetadata.nodeKeys,
+      Neo4jWriteMappingStrategy.KEYS
+    )
 
     s"""UNWIND ${"$"}events AS $BATCH_VARIABLE
        |$keyword (node${if (labels.isEmpty) "" else s":$labels"} ${if (keys.isEmpty) "" else s"{$keys}"})

--- a/src/main/scala/org/neo4j/spark/service/Neo4jQueryService.scala
+++ b/src/main/scala/org/neo4j/spark/service/Neo4jQueryService.scala
@@ -47,10 +47,10 @@ class Neo4jQueryWriteStrategy(private val saveMode: SaveMode) extends Neo4jQuery
       .mkString(":")
 
     val sourceKeys = options.relationshipMetadata.source.nodeKeys.map(key => {
-      s"${key._2.quote()}:$BATCH_VARIABLE.source.${Neo4jWriteMappingStrategy.KEYS}.${key._1.removeAlias().quote()}"
+      s"${key._2.quote()}: $BATCH_VARIABLE.source.${Neo4jWriteMappingStrategy.KEYS}.${key._1.removeAlias().quote()}"
     }).mkString(", ")
     val targetKeys = options.relationshipMetadata.target.nodeKeys.map(key => {
-      s"${key._2.quote()}:$BATCH_VARIABLE.target.${Neo4jWriteMappingStrategy.KEYS}.${key._1.removeAlias().quote()}"
+      s"${key._2.quote()}: $BATCH_VARIABLE.target.${Neo4jWriteMappingStrategy.KEYS}.${key._1.removeAlias().quote()}"
     }).mkString(", ")
 
     val sourceQueryPart = createQueryPart(sourceKeyword, sourceLabels, sourceKeys, Neo4jUtil.RELATIONSHIP_SOURCE_ALIAS)
@@ -70,10 +70,10 @@ class Neo4jQueryWriteStrategy(private val saveMode: SaveMode) extends Neo4jQuery
     val labels = options.nodeMetadata.labels
       .map(_.quote)
       .mkString(":")
-    val keys = options.nodeMetadata.nodeKeys.keys
-      .map(_.quote)
-      .map(k => s"$k: $BATCH_VARIABLE.${Neo4jWriteMappingStrategy.KEYS}.$k")
-      .mkString(", ")
+    val keys = options.nodeMetadata.nodeKeys
+      .map(key => {
+        s"${key._2.quote()}: $BATCH_VARIABLE.${Neo4jWriteMappingStrategy.KEYS}.${key._1.removeAlias().quote()}"
+      }).mkString(", ")
 
     s"""UNWIND ${"$"}events AS $BATCH_VARIABLE
        |$keyword (node${if (labels.isEmpty) "" else s":$labels"} ${if (keys.isEmpty) "" else s"{$keys}"})

--- a/src/main/scala/org/neo4j/spark/service/Neo4jQueryService.scala
+++ b/src/main/scala/org/neo4j/spark/service/Neo4jQueryService.scala
@@ -19,9 +19,8 @@ class Neo4jQueryWriteStrategy(private val saveMode: SaveMode) extends Neo4jQuery
 
   private def createPropsList(props: Map[String, String], prefix: String): String = {
     props
-      .map(key => Neo4jSparkFieldMapping(key._2.quote(), key._1.removeAlias().quote()))
-      .map(fieldMapping => {
-        s"${fieldMapping.neo4jFieldName}: $BATCH_VARIABLE.$prefix.${fieldMapping.sparkFieldName}"
+      .map(key => {
+        s"${key._2.quote()}: $BATCH_VARIABLE.$prefix.${key._2.quote()}"
       }).mkString(", ")
   }
 
@@ -35,7 +34,7 @@ class Neo4jQueryWriteStrategy(private val saveMode: SaveMode) extends Neo4jQuery
   }
 
   private def createQueryPart(keyword: String, labels: String, keys: String, alias: String): String = {
-    val setStatement = if (!keyword.equals("MATCH")) s"SET $alias += $BATCH_VARIABLE.$alias.${Neo4jWriteMappingStrategy.PROPERTIES}" else ""
+    val setStatement = if (!keyword.equals("MATCH")) s" SET $alias += $BATCH_VARIABLE.$alias.${Neo4jWriteMappingStrategy.PROPERTIES}" else ""
     s"""$keyword ($alias${if (labels.isEmpty) "" else s":$labels"} ${if (keys.isEmpty) "" else s"{$keys}"})$setStatement""".stripMargin
   }
 

--- a/src/main/scala/org/neo4j/spark/writer/Neo4jDataWriter.scala
+++ b/src/main/scala/org/neo4j/spark/writer/Neo4jDataWriter.scala
@@ -54,6 +54,7 @@ class Neo4jDataWriter(jobId: String,
         s"""Writing a batch of ${batch.size()} elements to Neo4j,
            |for jobId=$jobId and partitionId=$partitionId
            |with query: $query
+           |and params: $batch
            |""".stripMargin)
       val result = transaction.run(query,
         Values.value(Collections.singletonMap[String, Object]("events", batch)))

--- a/src/test/scala/org/neo4j/spark/DataSourceReaderTSE.scala
+++ b/src/test/scala/org/neo4j/spark/DataSourceReaderTSE.scala
@@ -769,7 +769,6 @@ class DataSourceReaderTSE extends SparkConnectorScalaBaseTSE {
       .load()
 
     assertEquals(5, partitionedDf.rdd.getNumPartitions)
-    partitionedDf.show()
     assertEquals(100, partitionedDf.collect().map(_.getAs[Long]("<rel.id>")).toSet.size)
     assertEquals(100, partitionedDf.collect().map(_.getAs[Long]("<rel.id>")).size)
   }

--- a/src/test/scala/org/neo4j/spark/DataSourceReaderWithApocTSE.scala
+++ b/src/test/scala/org/neo4j/spark/DataSourceReaderWithApocTSE.scala
@@ -818,7 +818,6 @@ class DataSourceReaderWithApocTSE extends SparkConnectorScalaBaseWithApocTSE {
       .load()
 
     assertEquals(5, partitionedDf.rdd.getNumPartitions)
-    partitionedDf.show()
     assertEquals(100, partitionedDf.collect().map(_.getAs[Long]("<rel.id>")).toSet.size)
   }
 

--- a/src/test/scala/org/neo4j/spark/Neo4jQueryServiceTest.scala
+++ b/src/test/scala/org/neo4j/spark/Neo4jQueryServiceTest.scala
@@ -241,9 +241,9 @@ class Neo4jQueryServiceTest {
     options.put(Neo4jOptions.URL, "bolt://localhost")
     options.put("relationship", "BOUGHT")
     options.put("relationship.source.labels", "Person")
-    options.put("relationship.source.node.keys", "FirstName:name")
+    options.put("relationship.source.node.keys", "FirstName:name,LastName:lastName")
     options.put("relationship.target.labels", "Product")
-    options.put("relationship.target.node.keys", "ProductPrice:price")
+    options.put("relationship.target.node.keys", "ProductPrice:price,ProductId:id")
 
     val neo4jOptions: Neo4jOptions = new Neo4jOptions(options)
 
@@ -251,9 +251,9 @@ class Neo4jQueryServiceTest {
 
     assertEquals(
       """UNWIND $events AS event
-        |MATCH (source:Person {name: event.source.keys.FirstName})
+        |MATCH (source:Person {name: event.source.keys.FirstName, lastName: event.source.keys.LastName})
         |WITH event, source
-        |MATCH (target:Product {price: event.target.keys.ProductPrice})
+        |MATCH (target:Product {price: event.target.keys.ProductPrice, id: event.target.keys.ProductId})
         |WITH source, event, target
         |MERGE (source)-[rel:BOUGHT]->(target)
         |SET rel += event.rel.properties

--- a/src/test/scala/org/neo4j/spark/Neo4jQueryServiceTest.scala
+++ b/src/test/scala/org/neo4j/spark/Neo4jQueryServiceTest.scala
@@ -252,9 +252,7 @@ class Neo4jQueryServiceTest {
     assertEquals(
       """UNWIND $events AS event
         |MATCH (source:Person {name: event.source.keys.FirstName, lastName: event.source.keys.LastName})
-        |WITH event, source
         |MATCH (target:Product {price: event.target.keys.ProductPrice, id: event.target.keys.ProductId})
-        |WITH source, event, target
         |MERGE (source)-[rel:BOUGHT]->(target)
         |SET rel += event.rel.properties
         |""".stripMargin, query.stripMargin)

--- a/src/test/scala/org/neo4j/spark/Neo4jQueryServiceTest.scala
+++ b/src/test/scala/org/neo4j/spark/Neo4jQueryServiceTest.scala
@@ -230,7 +230,7 @@ class Neo4jQueryServiceTest {
 
     assertEquals(
       """UNWIND $events AS event
-        |MERGE (node:Location {name: event.keys.LocationName, type: event.keys.LocationType, featureId: event.keys.FeatureID})
+        |MERGE (node:Location {name: event.keys.name, type: event.keys.type, featureId: event.keys.featureId})
         |SET node += event.properties
         |""".stripMargin, query)
   }
@@ -251,8 +251,8 @@ class Neo4jQueryServiceTest {
 
     assertEquals(
       """UNWIND $events AS event
-        |MATCH (source:Person {name: event.source.keys.FirstName, lastName: event.source.keys.LastName})
-        |MATCH (target:Product {price: event.target.keys.ProductPrice, id: event.target.keys.ProductId})
+        |MATCH (source:Person {name: event.source.keys.name, lastName: event.source.keys.lastName})
+        |MATCH (target:Product {price: event.target.keys.price, id: event.target.keys.id})
         |MERGE (source)-[rel:BOUGHT]->(target)
         |SET rel += event.rel.properties
         |""".stripMargin, query.stripMargin)


### PR DESCRIPTION
Fixes #179 

Details in the issue.

Setup available in the issue will now generate this query:

```
UNWIND $events AS event
MERGE (node:Location {name: event.keys.LocationName, type: event.keys.LocationType, featureId: event.keys.FeatureID})
SET node += event.properties
```

Additional edits:
- removed `.show` calls in tests