### PR TITLE
Fixes #180: Inner CALL { block } breaks certain cypher patterns when reading via custom query

### DIFF
--- a/src/main/scala/org/neo4j/spark/service/SchemaService.scala
+++ b/src/main/scala/org/neo4j/spark/service/SchemaService.scala
@@ -39,7 +39,7 @@ class SchemaService(private val options: Neo4jOptions, private val driverCache: 
         retrieveSchemaFromApoc(query, params)
       } catch {
         case e: ClientException =>
-          log.warn("Switching to query schema resolution because of the following exception:", e)
+          log.warn("Switching to query schema resolution because of the following exception:", e.getMessage)
           // TODO get back to Cypher DSL when rand function will be available
           val query = s"""MATCH (${Neo4jUtil.NODE_ALIAS}:${labels.map(_.quote()).mkString(":")})
             |RETURN ${Neo4jUtil.NODE_ALIAS}
@@ -127,7 +127,7 @@ class SchemaService(private val options: Neo4jOptions, private val driverCache: 
         retrieveSchemaFromApoc(query, params)
       } catch {
         case e: ClientException =>
-          log.warn("Switching to query schema resolution because of the following exception:", e)
+          log.warn("Switching to query schema resolution because of the following exception:", e.getMessage)
           // TODO get back to Cypher DSL when rand function will be available
           val query = s"""MATCH (${Neo4jUtil.RELATIONSHIP_SOURCE_ALIAS}:${options.relationshipMetadata.source.labels.map(_.quote()).mkString(":")})
             |MATCH (${Neo4jUtil.RELATIONSHIP_TARGET_ALIAS}:${options.relationshipMetadata.target.labels.map(_.quote()).mkString(":")})
@@ -264,14 +264,14 @@ class SchemaService(private val options: Neo4jOptions, private val driverCache: 
     }
   } catch {
     case e: ClientException => {
-      log.warn("Switching to query count resolution because of the following exception:", e)
+      log.warn("Switching to query count resolution because of the following exception:", e.getMessage)
       countForRelationshipWithQuery(filters)
     }
     case e: Throwable => logExceptionForCount(e)
   }
 
   private def logExceptionForCount(e: Throwable): Long = {
-    log.error("Cannot compute the count because the following exception:", e)
+    log.error("Cannot compute the count because the following exception:", e.getMessage)
     -1
   }
 

--- a/src/main/scala/org/neo4j/spark/service/SchemaService.scala
+++ b/src/main/scala/org/neo4j/spark/service/SchemaService.scala
@@ -22,6 +22,7 @@ import scala.collection.mutable.ArrayBuffer
 object PartitionSkipLimit {
   val EMPTY = PartitionSkipLimit(0, -1, -1)
 }
+
 case class PartitionSkipLimit(partitionNumber: Int, skip: Long, limit: Long)
 
 class SchemaService(private val options: Neo4jOptions, private val driverCache: DriverCache, private val filters: Array[Filter] = Array.empty)
@@ -33,25 +34,26 @@ class SchemaService(private val options: Neo4jOptions, private val driverCache: 
 
   private def structForNode(labels: Seq[String] = options.nodeMetadata.labels): StructType = {
     var structFields: mutable.Buffer[StructField] = (try {
-        val query = "CALL apoc.meta.nodeTypeProperties({ includeLabels: $labels })"
-        val params = Map[String, AnyRef]("labels" -> labels.asJava)
-          .asJava
-        retrieveSchemaFromApoc(query, params)
-      } catch {
-        case e: ClientException =>
-          e.code match {
-            case "Neo.ClientError.Procedure.ProcedureNotFound" => {
-              // TODO get back to Cypher DSL when rand function will be available
-              val query = s"""MATCH (${Neo4jUtil.NODE_ALIAS}:${labels.map(_.quote()).mkString(":")})
-                |RETURN ${Neo4jUtil.NODE_ALIAS}
-                |ORDER BY rand()
-                |LIMIT ${options.schemaMetadata.flattenLimit}
-                |""".stripMargin
-              val params = Collections.emptyMap[String, AnyRef]()
-              retrieveSchema(query, params, { record => record.get(Neo4jUtil.NODE_ALIAS).asNode.asMap.asScala.toMap })
-            }
+      val query = "CALL apoc.meta.nodeTypeProperties({ includeLabels: $labels })"
+      val params = Map[String, AnyRef]("labels" -> labels.asJava)
+        .asJava
+      retrieveSchemaFromApoc(query, params)
+    } catch {
+      case e: ClientException =>
+        e.code match {
+          case "Neo.ClientError.Procedure.ProcedureNotFound" => {
+            // TODO get back to Cypher DSL when rand function will be available
+            val query =
+              s"""MATCH (${Neo4jUtil.NODE_ALIAS}:${labels.map(_.quote()).mkString(":")})
+                 |RETURN ${Neo4jUtil.NODE_ALIAS}
+                 |ORDER BY rand()
+                 |LIMIT ${options.schemaMetadata.flattenLimit}
+                 |""".stripMargin
+            val params = Collections.emptyMap[String, AnyRef]()
+            retrieveSchema(query, params, { record => record.get(Neo4jUtil.NODE_ALIAS).asNode.asMap.asScala.toMap })
           }
-      })
+        }
+    })
       .sortBy(t => t.name)
 
     structFields += StructField(Neo4jUtil.INTERNAL_LABELS_FIELD, DataTypes.createArrayType(DataTypes.StringType), nullable = true)
@@ -116,46 +118,51 @@ class SchemaService(private val options: Neo4jOptions, private val driverCache: 
     }
 
     structFields ++= (try {
+      val query =
+        """CALL apoc.meta.relTypeProperties({ includeRels: $rels }) YIELD sourceNodeLabels, targetNodeLabels,
+          | propertyName, propertyTypes
+          |WITH *
+          |WHERE sourceNodeLabels = $sourceLabels AND targetNodeLabels = $targetLabels
+          |RETURN *
+          |""".stripMargin
+      val params = Map[String, AnyRef]("rels" -> Seq(options.relationshipMetadata.relationshipType).asJava,
+        "sourceLabels" -> options.relationshipMetadata.source.labels.asJava,
+        "targetLabels" -> options.relationshipMetadata.target.labels.asJava)
+        .asJava
+      retrieveSchemaFromApoc(query, params)
+    } catch {
+      case e: ClientException =>
+        // TODO get back to Cypher DSL when rand function will be available
         val query =
-          """CALL apoc.meta.relTypeProperties({ includeRels: $rels }) YIELD sourceNodeLabels, targetNodeLabels,
-            | propertyName, propertyTypes
-            |WITH *
-            |WHERE sourceNodeLabels = $sourceLabels AND targetNodeLabels = $targetLabels
-            |RETURN *
-            |""".stripMargin
-        val params = Map[String, AnyRef]("rels" -> Seq(options.relationshipMetadata.relationshipType).asJava,
-            "sourceLabels" -> options.relationshipMetadata.source.labels.asJava,
-            "targetLabels" -> options.relationshipMetadata.target.labels.asJava)
-          .asJava
-        retrieveSchemaFromApoc(query, params)
-      } catch {
-        case e: ClientException =>
-          e.code match {
-            case "Neo.ClientError.Procedure.ProcedureNotFound" => {
-              // TODO get back to Cypher DSL when rand function will be available
-              val query = s"""MATCH (${Neo4jUtil.RELATIONSHIP_SOURCE_ALIAS}:${options.relationshipMetadata.source.labels.map(_.quote()).mkString(":")})
-                |MATCH (${Neo4jUtil.RELATIONSHIP_TARGET_ALIAS}:${options.relationshipMetadata.target.labels.map(_.quote()).mkString(":")})
-                |MATCH (${Neo4jUtil.RELATIONSHIP_SOURCE_ALIAS})-[${Neo4jUtil.RELATIONSHIP_ALIAS}:${options.relationshipMetadata.relationshipType}]->(${Neo4jUtil.RELATIONSHIP_TARGET_ALIAS})
-                |RETURN ${Neo4jUtil.RELATIONSHIP_ALIAS}
-                |ORDER BY rand()
-                |LIMIT ${options.schemaMetadata.flattenLimit}
-                |""".stripMargin
-              val params = Collections.emptyMap[String, AnyRef]()
-              retrieveSchema(query, params, { record => record.get(Neo4jUtil.RELATIONSHIP_ALIAS).asRelationship.asMap.asScala.toMap })
-            }
-          }
-      })
+          s"""MATCH (${Neo4jUtil.RELATIONSHIP_SOURCE_ALIAS}:${options.relationshipMetadata.source.labels.map(_.quote()).mkString(":")})
+             |MATCH (${Neo4jUtil.RELATIONSHIP_TARGET_ALIAS}:${options.relationshipMetadata.target.labels.map(_.quote()).mkString(":")})
+             |MATCH (${Neo4jUtil.RELATIONSHIP_SOURCE_ALIAS})-[${Neo4jUtil.RELATIONSHIP_ALIAS}:${options.relationshipMetadata.relationshipType}]->(${Neo4jUtil.RELATIONSHIP_TARGET_ALIAS})
+             |RETURN ${Neo4jUtil.RELATIONSHIP_ALIAS}
+             |ORDER BY rand()
+             |LIMIT ${options.schemaMetadata.flattenLimit}
+             |""".stripMargin
+        val params = Collections.emptyMap[String, AnyRef]()
+        retrieveSchema(query, params, { record => record.get(Neo4jUtil.RELATIONSHIP_ALIAS).asRelationship.asMap.asScala.toMap })
+    })
       .map(field => StructField(s"rel.${field.name}", field.dataType, field.nullable, field.metadata))
       .sortBy(t => t.name)
     StructType(structFields)
   }
 
   def structForQuery(): StructType = {
-    val query = s"""CALL { ${options.query.value} }
-                   |RETURN *
-                   |ORDER BY rand()
-                   |LIMIT ${options.schemaMetadata.flattenLimit}
-                   |""".stripMargin
+    val queryValue = if (options.query.value.startsWith("CALL")) {
+      options.query.value.substring("CALL".length)
+    }
+    else {
+      s"{ ${options.query.value} }"
+    }
+
+    val query =
+      s"""CALL $queryValue
+         |RETURN *
+         |ORDER BY rand()
+         |LIMIT ${options.schemaMetadata.flattenLimit}
+         |""".stripMargin
     val params = Collections.emptyMap[String, AnyRef]()
     val structFields = retrieveSchema(query, params, { record => record.asMap.asScala.toMap })
     StructType(structFields)
@@ -177,7 +184,8 @@ class SchemaService(private val options: Neo4jOptions, private val driverCache: 
     val query = if (filters.isEmpty) {
       options.nodeMetadata.labels
         .map(_.quote())
-        .map(label => s"""
+        .map(label =>
+          s"""
              |MATCH (:$label)
              |RETURN count(*) AS count""".stripMargin)
         .mkString(" UNION ALL ")
@@ -197,14 +205,16 @@ class SchemaService(private val options: Neo4jOptions, private val driverCache: 
     val query = if (filters.isEmpty) {
       val sourceQueries = options.relationshipMetadata.source.labels
         .map(_.quote())
-        .map(label => s"""MATCH (:$label)-[${Neo4jUtil.RELATIONSHIP_ALIAS}:${options.relationshipMetadata.relationshipType.quote()}]->()
-                         |RETURN count(${Neo4jUtil.RELATIONSHIP_ALIAS}) AS count
-                         |""".stripMargin)
+        .map(label =>
+          s"""MATCH (:$label)-[${Neo4jUtil.RELATIONSHIP_ALIAS}:${options.relationshipMetadata.relationshipType.quote()}]->()
+             |RETURN count(${Neo4jUtil.RELATIONSHIP_ALIAS}) AS count
+             |""".stripMargin)
       val targetQueries = options.relationshipMetadata.target.labels
         .map(_.quote())
-        .map(label => s"""MATCH ()-[${Neo4jUtil.RELATIONSHIP_ALIAS}:${options.relationshipMetadata.relationshipType.quote()}]->(:$label)
-                         |RETURN count(${Neo4jUtil.RELATIONSHIP_ALIAS}) AS count
-                         |""".stripMargin)
+        .map(label =>
+          s"""MATCH ()-[${Neo4jUtil.RELATIONSHIP_ALIAS}:${options.relationshipMetadata.relationshipType.quote()}]->(:$label)
+             |RETURN count(${Neo4jUtil.RELATIONSHIP_ALIAS}) AS count
+             |""".stripMargin)
       (sourceQueries ++ targetQueries)
         .mkString(" UNION ALL ")
     } else {

--- a/src/main/scala/org/neo4j/spark/service/SchemaService.scala
+++ b/src/main/scala/org/neo4j/spark/service/SchemaService.scala
@@ -39,7 +39,7 @@ class SchemaService(private val options: Neo4jOptions, private val driverCache: 
         retrieveSchemaFromApoc(query, params)
       } catch {
         case e: ClientException =>
-          log.warn("Switching to query schema resolution because of the following exception:", e.getMessage)
+          log.warn("Switching to query schema resolution because of the following exception:", e)
           // TODO get back to Cypher DSL when rand function will be available
           val query = s"""MATCH (${Neo4jUtil.NODE_ALIAS}:${labels.map(_.quote()).mkString(":")})
             |RETURN ${Neo4jUtil.NODE_ALIAS}
@@ -127,7 +127,7 @@ class SchemaService(private val options: Neo4jOptions, private val driverCache: 
         retrieveSchemaFromApoc(query, params)
       } catch {
         case e: ClientException =>
-          log.warn("Switching to query schema resolution because of the following exception:", e.getMessage)
+          log.warn("Switching to query schema resolution because of the following exception:", e)
           // TODO get back to Cypher DSL when rand function will be available
           val query = s"""MATCH (${Neo4jUtil.RELATIONSHIP_SOURCE_ALIAS}:${options.relationshipMetadata.source.labels.map(_.quote()).mkString(":")})
             |MATCH (${Neo4jUtil.RELATIONSHIP_TARGET_ALIAS}:${options.relationshipMetadata.target.labels.map(_.quote()).mkString(":")})
@@ -264,14 +264,14 @@ class SchemaService(private val options: Neo4jOptions, private val driverCache: 
     }
   } catch {
     case e: ClientException => {
-      log.warn("Switching to query count resolution because of the following exception:", e.getMessage)
+      log.warn("Switching to query count resolution because of the following exception:", e)
       countForRelationshipWithQuery(filters)
     }
     case e: Throwable => logExceptionForCount(e)
   }
 
   private def logExceptionForCount(e: Throwable): Long = {
-    log.error("Cannot compute the count because the following exception:", e.getMessage)
+    log.error("Cannot compute the count because the following exception:", e)
     -1
   }
 

--- a/src/main/scala/org/neo4j/spark/service/SchemaService.scala
+++ b/src/main/scala/org/neo4j/spark/service/SchemaService.scala
@@ -150,16 +150,8 @@ class SchemaService(private val options: Neo4jOptions, private val driverCache: 
   }
 
   def structForQuery(): StructType = {
-    val queryValue = if (options.query.value.startsWith("CALL")) {
-      options.query.value.substring("CALL".length)
-    }
-    else {
-      s"{ ${options.query.value} }"
-    }
-
     val query =
-      s"""CALL $queryValue
-         |RETURN *
+      s"""${options.query.value}
          |ORDER BY rand()
          |LIMIT ${options.schemaMetadata.flattenLimit}
          |""".stripMargin

--- a/src/main/scala/org/neo4j/spark/service/SchemaService.scala
+++ b/src/main/scala/org/neo4j/spark/service/SchemaService.scala
@@ -41,6 +41,7 @@ class SchemaService(private val options: Neo4jOptions, private val driverCache: 
         case e: ClientException =>
           e.code match {
             case "Neo.ClientError.Procedure.ProcedureNotFound" => {
+              log.warn("Switching to query schema resolution")
               // TODO get back to Cypher DSL when rand function will be available
               val query = s"""MATCH (${Neo4jUtil.NODE_ALIAS}:${labels.map(_.quote()).mkString(":")})
                 |RETURN ${Neo4jUtil.NODE_ALIAS}
@@ -130,6 +131,7 @@ class SchemaService(private val options: Neo4jOptions, private val driverCache: 
         retrieveSchemaFromApoc(query, params)
       } catch {
         case e: ClientException =>
+          log.warn("Switching to query schema resolution")
           // TODO get back to Cypher DSL when rand function will be available
           val query = s"""MATCH (${Neo4jUtil.RELATIONSHIP_SOURCE_ALIAS}:${options.relationshipMetadata.source.labels.map(_.quote()).mkString(":")})
             |MATCH (${Neo4jUtil.RELATIONSHIP_TARGET_ALIAS}:${options.relationshipMetadata.target.labels.map(_.quote()).mkString(":")})

--- a/src/test/scala/org/neo4j/spark/DataSourceReaderTSE.scala
+++ b/src/test/scala/org/neo4j/spark/DataSourceReaderTSE.scala
@@ -823,7 +823,8 @@ class DataSourceReaderTSE extends SparkConnectorScalaBaseTSE {
           |MATCH (p:Person)-[r:BOUGHT]->(pr:Product{name: 'Product 2'})
           |RETURN p.name AS person, pr.name AS product, r.quantity AS quantity""".stripMargin)
       .option("partitions", "5")
-      .option("query.count", """
+      .option("query.count",
+        """
           |MATCH (p:Person)-[r:BOUGHT]->(pr:Product{name: 'Product 2'})
           |RETURN count(p) AS count""".stripMargin)
       .load()
@@ -1086,6 +1087,16 @@ class DataSourceReaderTSE extends SparkConnectorScalaBaseTSE {
       }
       case _ => fail(s"should be thrown a ${classOf[IllegalArgumentException].getName}")
     }
+  }
+
+  @Test()
+  def testCallShouldReturnCorrectSchema(): Unit = {
+    val callDf: DataFrame = ss.read.format(classOf[DataSource].getName)
+      .option("url", SparkConnectorScalaSuiteIT.server.getBoltUrl)
+      .option("query", "CALL db.info() YIELD id, name, creationDate")
+      .load()
+
+    callDf.show()
   }
 
   @Test

--- a/src/test/scala/org/neo4j/spark/DataSourceReaderTSE.scala
+++ b/src/test/scala/org/neo4j/spark/DataSourceReaderTSE.scala
@@ -1093,10 +1093,14 @@ class DataSourceReaderTSE extends SparkConnectorScalaBaseTSE {
   def testCallShouldReturnCorrectSchema(): Unit = {
     val callDf: DataFrame = ss.read.format(classOf[DataSource].getName)
       .option("url", SparkConnectorScalaSuiteIT.server.getBoltUrl)
-      .option("query", "CALL db.info() YIELD id, name, creationDate")
+      .option("query", "CALL db.info() YIELD id, name RETURN *")
       .load()
 
-    callDf.show()
+    val res = callDf.select("name")
+      .collectAsList()
+      .get(0)
+
+    assertEquals(res.getString(0), "neo4j")
   }
 
   @Test

--- a/src/test/scala/org/neo4j/spark/DataSourceReaderWithApocTSE.scala
+++ b/src/test/scala/org/neo4j/spark/DataSourceReaderWithApocTSE.scala
@@ -821,6 +821,20 @@ class DataSourceReaderWithApocTSE extends SparkConnectorScalaBaseWithApocTSE {
     assertEquals(100, partitionedDf.collect().map(_.getAs[Long]("<rel.id>")).toSet.size)
   }
 
+  @Test()
+  def testCallShouldReturnCorrectSchema(): Unit = {
+    val callDf: DataFrame = ss.read.format(classOf[DataSource].getName)
+      .option("url", SparkConnectorScalaSuiteWithApocIT.server.getBoltUrl)
+      .option("query", "CALL db.info() YIELD id, name")
+      .load()
+
+    val res = callDf.select("name")
+      .collectAsList()
+      .get(0)
+
+    assertEquals(res.getString(0), "neo4j")
+  }
+
   private def initTest(query: String): DataFrame = {
     SparkConnectorScalaSuiteWithApocIT.session()
       .writeTransaction(

--- a/src/test/scala/org/neo4j/spark/DataSourceReaderWithApocTSE.scala
+++ b/src/test/scala/org/neo4j/spark/DataSourceReaderWithApocTSE.scala
@@ -825,7 +825,7 @@ class DataSourceReaderWithApocTSE extends SparkConnectorScalaBaseWithApocTSE {
   def testCallShouldReturnCorrectSchema(): Unit = {
     val callDf: DataFrame = ss.read.format(classOf[DataSource].getName)
       .option("url", SparkConnectorScalaSuiteWithApocIT.server.getBoltUrl)
-      .option("query", "CALL db.info() YIELD id, name")
+      .option("query", "CALL db.info() YIELD id, name RETURN *")
       .load()
 
     val res = callDf.select("name")

--- a/src/test/scala/org/neo4j/spark/SparkConnectorScalaSuiteIT.scala
+++ b/src/test/scala/org/neo4j/spark/SparkConnectorScalaSuiteIT.scala
@@ -39,6 +39,7 @@ object SparkConnectorScalaSuiteIT {
       conf = new SparkConf().setAppName("neoTest")
         .setMaster("local[*]")
       ss = SparkSession.builder.config(conf).getOrCreate()
+      ss.sparkContext.setLogLevel("ERROR")
       driver = GraphDatabase.driver(server.getBoltUrl, AuthTokens.none())
       session()
         .readTransaction(new TransactionWork[ResultSummary] {

--- a/src/test/scala/org/neo4j/spark/SparkConnectorScalaSuiteWithApocIT.scala
+++ b/src/test/scala/org/neo4j/spark/SparkConnectorScalaSuiteWithApocIT.scala
@@ -8,6 +8,7 @@ import org.junit.{AfterClass, Assume, BeforeClass}
 import org.neo4j.Neo4jContainerExtension
 import org.neo4j.driver.summary.ResultSummary
 import org.neo4j.driver._
+import org.neo4j.spark.SparkConnectorScalaSuiteIT.ss
 import org.neo4j.spark.service.SchemaServiceWithApocTSE
 import org.neo4j.spark.util.Neo4jUtil
 
@@ -39,6 +40,7 @@ object SparkConnectorScalaSuiteWithApocIT {
       conf = new SparkConf().setAppName("neoTest")
         .setMaster("local[*]")
       ss = SparkSession.builder.config(conf).getOrCreate()
+      ss.sparkContext.setLogLevel("ERROR")
       driver = GraphDatabase.driver(server.getBoltUrl, AuthTokens.none())
       session()
         .readTransaction(new TransactionWork[ResultSummary] {

--- a/src/test/scala/org/neo4j/spark/SparkConnectorScalaSuiteWithApocIT.scala
+++ b/src/test/scala/org/neo4j/spark/SparkConnectorScalaSuiteWithApocIT.scala
@@ -13,7 +13,7 @@ import org.neo4j.spark.util.Neo4jUtil
 
 
 object SparkConnectorScalaSuiteWithApocIT {
-  val server: Neo4jContainerExtension = new Neo4jContainerExtension("neo4j:4.0.1-enterprise")
+  val server: Neo4jContainerExtension = new Neo4jContainerExtension("neo4j:4.0.8-enterprise")
     .withNeo4jConfig("dbms.security.auth_enabled", "false")
     .withEnv("NEO4J_ACCEPT_LICENSE_AGREEMENT", "yes")
     .withEnv("NEO4JLABS_PLUGINS", "[\"apoc\"]")


### PR DESCRIPTION
Fixes #180 

Additional details in the issue.

Please take a look at the newly added test for a use case.