### PR TITLE
fixes #182: different types for the same field causes error

### DIFF
--- a/src/test/scala/org/neo4j/spark/DataSourceReaderTSE.scala
+++ b/src/test/scala/org/neo4j/spark/DataSourceReaderTSE.scala
@@ -46,6 +46,16 @@ class DataSourceReaderTSE extends SparkConnectorScalaBaseTSE {
   }
 
   @Test
+  def testReadNodeWithFieldWithDifferentTypes(): Unit = {
+    val df: DataFrame = initTest("CREATE (p1:Person {field: [12,34]}), (p2:Person {field: 123})")
+
+    val res = df.collectAsList()
+
+    assertEquals("[12,34]", res.get(0).get(2))
+    assertEquals("123", res.get(1).get(2))
+  }
+
+  @Test
   def testReadNodeWithString(): Unit = {
     val name: String = "John"
     val df: DataFrame = initTest(s"CREATE (p:Person {name: '$name'})")
@@ -711,6 +721,40 @@ class DataSourceReaderTSE extends SparkConnectorScalaBaseTSE {
     assertEquals(10, repartitionedDf.rdd.getNumPartitions)
     val numNode = repartitionedDf.collect().length
     assertEquals(100, numNode)
+  }
+
+  @Test
+  def testRelationshipsDifferentFieldValues(): Unit = {
+    val fixtureQuery: String =
+      s"""CREATE (pr1:Product {id: '1'})
+         |CREATE (pr2:Product {id: 2})
+         |CREATE (pe1:Person {id: '3'})
+         |CREATE (pe2:Person {id: 4})
+         |CREATE (pe1)-[:BOUGHT]->(pr1)
+         |CREATE (pe2)-[:BOUGHT]->(pr2)
+         |RETURN *
+    """.stripMargin
+
+    SparkConnectorScalaSuiteIT.session()
+      .writeTransaction(
+        new TransactionWork[ResultSummary] {
+          override def execute(tx: Transaction): ResultSummary = tx.run(fixtureQuery).consume()
+        })
+
+    val df: DataFrame = ss.read.format(classOf[DataSource].getName)
+      .option("url", SparkConnectorScalaSuiteIT.server.getBoltUrl)
+      .option("relationship.nodes.map", "false")
+      .option("relationship", "BOUGHT")
+      .option("relationship.source.labels", ":Person")
+      .option("relationship.target.labels", ":Product")
+      .load()
+
+    val res = df.sort("`source.id`").collectAsList()
+
+    assertEquals("3", res.get(0).get(4))
+    assertEquals("1", res.get(0).get(7))
+    assertEquals("4", res.get(1).get(4))
+    assertEquals("2", res.get(1).get(7))
   }
 
   @Test

--- a/src/test/scala/org/neo4j/spark/DataSourceReaderWithApocTSE.scala
+++ b/src/test/scala/org/neo4j/spark/DataSourceReaderWithApocTSE.scala
@@ -757,7 +757,7 @@ class DataSourceReaderWithApocTSE extends SparkConnectorScalaBaseWithApocTSE {
       .option("relationship.target.labels", ":Product")
       .load()
 
-    val res = df.collectAsList()
+    val res = df.sort("`source.id`").collectAsList()
 
     assertEquals("3", res.get(0).get(4))
     assertEquals("1", res.get(0).get(7))

--- a/src/test/scala/org/neo4j/spark/DataSourceReaderWithApocTSE.scala
+++ b/src/test/scala/org/neo4j/spark/DataSourceReaderWithApocTSE.scala
@@ -46,6 +46,16 @@ class DataSourceReaderWithApocTSE extends SparkConnectorScalaBaseWithApocTSE {
   }
 
   @Test
+  def testReadNodeWithFieldWithDifferentTypes(): Unit = {
+    val df: DataFrame = initTest("CREATE (p1:Person {field: [12,34]}), (p2:Person {field: 123})")
+
+    val res = df.collectAsList()
+
+    assertEquals("[12,34]", res.get(0).get(2))
+    assertEquals("123", res.get(1).get(2))
+  }
+
+  @Test
   def testReadNodeWithString(): Unit = {
     val name: String = "John"
     val df: DataFrame = initTest(s"CREATE (p:Person {name: '$name'})")
@@ -719,6 +729,40 @@ class DataSourceReaderWithApocTSE extends SparkConnectorScalaBaseWithApocTSE {
       .filter(row => row.keys == Set("id", "name", "<id>", "<labels>"))
       .size
     assertEquals(total, countTargetMap)
+  }
+
+  @Test
+  def testRelationshipsDifferentFieldValues(): Unit = {
+    val fixtureQuery: String =
+      s"""CREATE (pr1:Product {id: '1'})
+         |CREATE (pr2:Product {id: 2})
+         |CREATE (pe1:Person {id: '3'})
+         |CREATE (pe2:Person {id: 4})
+         |CREATE (pe1)-[:BOUGHT]->(pr1)
+         |CREATE (pe2)-[:BOUGHT]->(pr2)
+         |RETURN *
+    """.stripMargin
+
+    SparkConnectorScalaSuiteWithApocIT.session()
+      .writeTransaction(
+        new TransactionWork[ResultSummary] {
+          override def execute(tx: Transaction): ResultSummary = tx.run(fixtureQuery).consume()
+        })
+
+    val df: DataFrame = ss.read.format(classOf[DataSource].getName)
+      .option("url", SparkConnectorScalaSuiteWithApocIT.server.getBoltUrl)
+      .option("relationship.nodes.map", "false")
+      .option("relationship", "BOUGHT")
+      .option("relationship.source.labels", ":Person")
+      .option("relationship.target.labels", ":Product")
+      .load()
+
+    val res = df.collectAsList()
+
+    assertEquals("3", res.get(0).get(4))
+    assertEquals("1", res.get(0).get(7))
+    assertEquals("4", res.get(1).get(4))
+    assertEquals("2", res.get(1).get(7))
   }
 
   @Test


### PR DESCRIPTION
fixes #182

Say we have 

```
CREATE (p1:Person {age: "32"}), (p2:Person {age: 23})
```

Field has 2 different types and this is a problem.

When APOC is used to find the schema, and more than 1 type is present for the same field, all the values will be casted to String and a Warning message will be displayed saying:

```
The field "age" has different types: [String, Long]
Every value will be casted to string.
```