### PR TITLE
fixes #172: Add support for PushDownRequiredColumn

### DIFF
--- a/src/main/scala/org/neo4j/spark/reader/Neo4jDataSourceReader.scala
+++ b/src/main/scala/org/neo4j/spark/reader/Neo4jDataSourceReader.scala
@@ -2,18 +2,20 @@ package org.neo4j.spark.reader
 
 import java.util
 
+import org.apache.spark.internal.Logging
 import org.apache.spark.sql.catalyst.InternalRow
 import org.apache.spark.sql.sources.Filter
 import org.apache.spark.sql.sources.v2.DataSourceOptions
 import org.apache.spark.sql.sources.v2.reader.{DataSourceReader, InputPartition, SupportsPushDownFilters, SupportsPushDownRequiredColumns}
 import org.apache.spark.sql.types.StructType
 import org.neo4j.spark.{DriverCache, Neo4jOptions}
-import org.neo4j.spark.service.{PartitionSkipLimit, SchemaService}
+import org.neo4j.spark.service.SchemaService
 import org.neo4j.spark.util.Validations
 
 import scala.collection.JavaConverters._
 
 class Neo4jDataSourceReader(private val options: DataSourceOptions, private val jobId: String) extends DataSourceReader
+  with Logging
   with SupportsPushDownFilters
   with SupportsPushDownRequiredColumns {
 
@@ -85,6 +87,13 @@ class Neo4jDataSourceReader(private val options: DataSourceOptions, private val 
   override def pushedFilters(): Array[Filter] = filters
 
   override def pruneColumns(requiredSchema: StructType): Unit = {
+    if (requiredSchema.nonEmpty) {
+      log.info(s"Using requiredSchema: ${requiredSchema.toString()}")
+    }
+    else {
+      log.info(s"No pruned columns")
+    }
+
     requiredColumns = requiredSchema
   }
 }

--- a/src/main/scala/org/neo4j/spark/reader/Neo4jInputPartitionReader.scala
+++ b/src/main/scala/org/neo4j/spark/reader/Neo4jInputPartitionReader.scala
@@ -57,7 +57,7 @@ class Neo4jInputPartitionReader(private val options: Neo4jOptions,
     result.hasNext
   }
 
-  def get: InternalRow = mappingService.convert(result.next(), schema, requiredColumns != null && requiredColumns.nonEmpty)
+  def get: InternalRow = mappingService.convert(result.next(), schema, requiredColumns)
 
   def close(): Unit = {
     Neo4jUtil.closeSafety(transaction, log)

--- a/src/main/scala/org/neo4j/spark/reader/Neo4jInputPartitionReader.scala
+++ b/src/main/scala/org/neo4j/spark/reader/Neo4jInputPartitionReader.scala
@@ -57,7 +57,7 @@ class Neo4jInputPartitionReader(private val options: Neo4jOptions,
     result.hasNext
   }
 
-  def get: InternalRow = mappingService.convert(result.next(), schema)
+  def get: InternalRow = mappingService.convert(result.next(), schema, requiredColumns != null && requiredColumns.nonEmpty)
 
   def close(): Unit = {
     Neo4jUtil.closeSafety(transaction, log)

--- a/src/main/scala/org/neo4j/spark/service/MappingService.scala
+++ b/src/main/scala/org/neo4j/spark/service/MappingService.scala
@@ -218,9 +218,9 @@ abstract class Neo4jMappingStrategy[IN, OUT] extends Serializable {
 
 class MappingService[IN, OUT](private val strategy: Neo4jMappingStrategy[IN, OUT], private val options: Neo4jOptions) extends Serializable {
 
-  def convert(record: IN, schema: StructType, hasRequiredColumns: Boolean = false): OUT = {
-    if (hasRequiredColumns) {
-      strategy.query(record, schema)
+  def convert(record: IN, schema: StructType, requiredColumns: StructType = null): OUT = {
+    if (requiredColumns != null && requiredColumns.nonEmpty) {
+      strategy.query(record, requiredColumns)
     }
     else {
       options.query.queryType match {

--- a/src/main/scala/org/neo4j/spark/service/MappingService.scala
+++ b/src/main/scala/org/neo4j/spark/service/MappingService.scala
@@ -139,10 +139,16 @@ class Neo4jWriteMappingStrategy(private val options: Neo4jOptions)
 class Neo4jReadMappingStrategy(private val options: Neo4jOptions) extends Neo4jMappingStrategy[Record, InternalRow] {
 
   override def node(record: Record, schema: StructType): InternalRow = {
-    val node = record.get(Neo4jUtil.NODE_ALIAS).asNode()
-    val nodeMap = new util.HashMap[String, Any](node.asMap())
-    nodeMap.put(Neo4jUtil.INTERNAL_ID_FIELD, node.id())
-    nodeMap.put(Neo4jUtil.INTERNAL_LABELS_FIELD, node.labels())
+    val nodeMap = if(record.get(Neo4jUtil.NODE_ALIAS) == null) {
+      val node = record.get(Neo4jUtil.NODE_ALIAS).asNode()
+      val tempMap = new util.HashMap[String, Any](node.asMap())
+      tempMap.put(Neo4jUtil.INTERNAL_ID_FIELD, node.id())
+      tempMap.put(Neo4jUtil.INTERNAL_LABELS_FIELD, node.labels())
+      tempMap
+    }
+    else {
+      new util.HashMap[String, Any](record.asMap())
+    }
 
     mapToInternalRow(nodeMap, schema)
   }

--- a/src/main/scala/org/neo4j/spark/util/Neo4jImplicits.scala
+++ b/src/main/scala/org/neo4j/spark/util/Neo4jImplicits.scala
@@ -14,7 +14,7 @@ object Neo4jImplicits {
   implicit class CypherImplicits(str: String) {
     def quote(): String = if (!SourceVersion.isIdentifier(str) && !str.trim.startsWith("`") && !str.trim.endsWith("`")) s"`$str`" else str
 
-    def removeAlias(): String = {
+    def removeEntityName(): String = {
       val splatString = str.split('.')
 
       if (splatString.size > 1) {

--- a/src/test/scala/org/neo4j/spark/DataSourceReaderTSE.scala
+++ b/src/test/scala/org/neo4j/spark/DataSourceReaderTSE.scala
@@ -1046,6 +1046,8 @@ class DataSourceReaderTSE extends SparkConnectorScalaBaseTSE {
       .option("partitions", "2")
       .load
 
+    df.show()
+
     assertEquals(2, df.count())
   }
 

--- a/src/test/scala/org/neo4j/spark/service/Neo4jQueryServiceTest.scala
+++ b/src/test/scala/org/neo4j/spark/service/Neo4jQueryServiceTest.scala
@@ -1,10 +1,10 @@
-package org.neo4j.spark
+package org.neo4j.spark.service
 
 import org.apache.spark.sql.SaveMode
-import org.apache.spark.sql.sources.{And, EqualNullSafe, EqualTo, Filter, GreaterThanOrEqual, LessThan, Not, Or, StringEndsWith, StringStartsWith}
+import org.apache.spark.sql.sources.{EqualNullSafe, EqualTo, Filter, GreaterThanOrEqual, LessThan, Not, Or, StringEndsWith, StringStartsWith}
 import org.junit.Assert._
 import org.junit.Test
-import org.neo4j.spark.service.{Neo4jQueryReadStrategy, Neo4jQueryService, Neo4jQueryWriteStrategy}
+import org.neo4j.spark.{Neo4jOptions, QueryType}
 
 class Neo4jQueryServiceTest {
 
@@ -30,6 +30,51 @@ class Neo4jQueryServiceTest {
     val query: String = new Neo4jQueryService(neo4jOptions, new Neo4jQueryReadStrategy).createQuery()
 
     assertEquals("MATCH (n:`Person`:`Player`:`Midfield`) RETURN n", query)
+  }
+
+  @Test
+  def testNodeOneLabelWithOneSelectedColumn(): Unit = {
+    val options: java.util.Map[String, String] = new java.util.HashMap[String, String]()
+    options.put(Neo4jOptions.URL, "bolt://localhost")
+    options.put(QueryType.LABELS.toString.toLowerCase, "Person")
+    val neo4jOptions: Neo4jOptions = new Neo4jOptions(options)
+
+    val query: String = new Neo4jQueryService(
+      neo4jOptions,
+      new Neo4jQueryReadStrategy(Array.empty[Filter], PartitionSkipLimit(0, -1, -1), Seq("name"))
+    ).createQuery()
+
+    assertEquals("MATCH (n:`Person`) RETURN n.name AS name", query)
+  }
+
+  @Test
+  def testNodeOneLabelWithMultipleColumnSelected(): Unit = {
+    val options: java.util.Map[String, String] = new java.util.HashMap[String, String]()
+    options.put(Neo4jOptions.URL, "bolt://localhost")
+    options.put(QueryType.LABELS.toString.toLowerCase, "Person")
+    val neo4jOptions: Neo4jOptions = new Neo4jOptions(options)
+
+    val query: String = new Neo4jQueryService(
+      neo4jOptions,
+      new Neo4jQueryReadStrategy(Array.empty[Filter], PartitionSkipLimit(0, -1, -1), List("name", "bornDate"))
+    ).createQuery()
+
+    assertEquals("MATCH (n:`Person`) RETURN n.name AS name, n.bornDate AS bornDate", query)
+  }
+
+  @Test
+  def testNodeOneLabelWithInternalIdSelected(): Unit = {
+    val options: java.util.Map[String, String] = new java.util.HashMap[String, String]()
+    options.put(Neo4jOptions.URL, "bolt://localhost")
+    options.put(QueryType.LABELS.toString.toLowerCase, "Person")
+    val neo4jOptions: Neo4jOptions = new Neo4jOptions(options)
+
+    val query: String = new Neo4jQueryService(
+      neo4jOptions,
+      new Neo4jQueryReadStrategy(Array.empty[Filter], PartitionSkipLimit(0, -1, -1), List("<id>"))
+    ).createQuery()
+
+    assertEquals("MATCH (n:`Person`) RETURN id(n) AS `<id>`", query)
   }
 
   @Test

--- a/src/test/scala/org/neo4j/spark/service/Neo4jQueryServiceTest.scala
+++ b/src/test/scala/org/neo4j/spark/service/Neo4jQueryServiceTest.scala
@@ -229,6 +229,29 @@ class Neo4jQueryServiceTest {
   }
 
   @Test
+  def testRelationshipAndFilterEqualTo(): Unit = {
+    val options: java.util.Map[String, String] = new java.util.HashMap[String, String]()
+    options.put(Neo4jOptions.URL, "bolt://localhost")
+    options.put("relationship", "KNOWS")
+    options.put("relationship.nodes.map", "true")
+    options.put("relationship.source.labels", "Person")
+    options.put("relationship.target.labels", "Person")
+    val neo4jOptions: Neo4jOptions = new Neo4jOptions(options)
+
+    val filters: Array[Filter] = Array[Filter](
+      EqualTo("source.id", "14"),
+      EqualTo("target.id", "16")
+    )
+
+    val query: String = new Neo4jQueryService(neo4jOptions, new Neo4jQueryReadStrategy(filters)).createQuery()
+
+    assertEquals(
+      "MATCH (source:`Person`) MATCH (target:`Person`) MATCH (source)-[rel:`KNOWS`]->(target) " +
+        "WHERE (source.id = '14' AND target.id = '16') " +
+        "RETURN source, rel, target", query)
+  }
+
+  @Test
   def testComplexNodeConditions(): Unit = {
     val options: java.util.Map[String, String] = new java.util.HashMap[String, String]()
     options.put(Neo4jOptions.URL, "bolt://localhost")

--- a/src/test/scala/org/neo4j/spark/service/Neo4jQueryServiceTest.scala
+++ b/src/test/scala/org/neo4j/spark/service/Neo4jQueryServiceTest.scala
@@ -145,6 +145,48 @@ class Neo4jQueryServiceTest {
   }
 
   @Test
+  def testRelationshipWithOneColumnSelected(): Unit = {
+    val options: java.util.Map[String, String] = new java.util.HashMap[String, String]()
+    options.put(Neo4jOptions.URL, "bolt://localhost")
+    options.put("relationship", "KNOWS")
+    options.put("relationship.nodes.map", "false")
+    options.put("relationship.source.labels", "Person")
+    options.put("relationship.target.labels", "Person")
+    val neo4jOptions: Neo4jOptions = new Neo4jOptions(options)
+
+    val query: String = new Neo4jQueryService(neo4jOptions, new Neo4jQueryReadStrategy(
+      Array[Filter](),
+      PartitionSkipLimit(0, -1, -1),
+      List("source.name")
+    )).createQuery()
+
+    assertEquals("MATCH (source:`Person`) " +
+      "MATCH (target:`Person`) " +
+      "MATCH (source)-[rel:`KNOWS`]->(target) RETURN source.name AS `source.name`", query)
+  }
+
+  @Test
+  def testRelationshipWithOneMoreColumnsSelected(): Unit = {
+    val options: java.util.Map[String, String] = new java.util.HashMap[String, String]()
+    options.put(Neo4jOptions.URL, "bolt://localhost")
+    options.put("relationship", "KNOWS")
+    options.put("relationship.nodes.map", "false")
+    options.put("relationship.source.labels", "Person")
+    options.put("relationship.target.labels", "Person")
+    val neo4jOptions: Neo4jOptions = new Neo4jOptions(options)
+
+    val query: String = new Neo4jQueryService(neo4jOptions, new Neo4jQueryReadStrategy(
+      Array[Filter](),
+      PartitionSkipLimit(0, -1, -1),
+      List("source.name", "source.id", "rel.someprops", "target.date")
+    )).createQuery()
+
+    assertEquals("MATCH (source:`Person`) " +
+      "MATCH (target:`Person`) " +
+      "MATCH (source)-[rel:`KNOWS`]->(target) RETURN source.name AS `source.name`, source.id AS `source.id`, rel.someprops AS `rel.someprops`, target.date AS `target.date`", query)
+  }
+
+  @Test
   def testRelationshipFilterEqualTo(): Unit = {
     val options: java.util.Map[String, String] = new java.util.HashMap[String, String]()
     options.put(Neo4jOptions.URL, "bolt://localhost")


### PR DESCRIPTION
Fixes #172 

This can reduce the amount of data moved from Neo4j to Spark by reducing the number of columns selected by Neo4j.