### PR TITLE
fixes #183: Better error messages

### DIFF
--- a/src/main/scala/org/neo4j/spark/service/SchemaService.scala
+++ b/src/main/scala/org/neo4j/spark/service/SchemaService.scala
@@ -47,7 +47,7 @@ class SchemaService(private val options: Neo4jOptions, private val driverCache: 
       retrieveSchemaFromApoc(query, params)
     } catch {
       case e: ClientException =>
-        log.warn("Switching to query schema resolution because of the following exception:", e)
+        logSchemaResolutionChange(e)
         // TODO get back to Cypher DSL when rand function will be available
         val query =
           s"""MATCH (${Neo4jUtil.NODE_ALIAS}:${labels.map(_.quote()).mkString(":")})
@@ -168,7 +168,7 @@ class SchemaService(private val options: Neo4jOptions, private val driverCache: 
       retrieveSchemaFromApoc(query, params)
     } catch {
       case e: ClientException =>
-        log.warn("Switching to query schema resolution because of the following exception:", e)
+        logSchemaResolutionChange(e)
         // TODO get back to Cypher DSL when rand function will be available
         val query =
           s"""MATCH (${Neo4jUtil.RELATIONSHIP_SOURCE_ALIAS}:${options.relationshipMetadata.source.labels.map(_.quote()).mkString(":")})
@@ -526,6 +526,13 @@ class SchemaService(private val options: Neo4jOptions, private val driverCache: 
           }
         }
       })
+  }
+
+  private def logSchemaResolutionChange(e: ClientException): Unit = {
+    log.warn(s"Switching to query schema resolution")
+    if(!e.code().equals("Neo.ClientError.Procedure.ProcedureNotFound")) {
+      log.warn(s"For the following exception", e)
+    }
   }
 
   override def close(): Unit = {

--- a/src/main/scala/org/neo4j/spark/writer/Neo4jDataWriter.scala
+++ b/src/main/scala/org/neo4j/spark/writer/Neo4jDataWriter.scala
@@ -44,7 +44,7 @@ class Neo4jDataWriter(jobId: String,
         writeBatch()
       }
       catch {
-        case e: Exception => log.error(s"Unhandled exception: ${e.getMessage}")
+        case e: Exception => log.error(e.getMessage)
       }
     }
   }

--- a/src/test/scala/org/neo4j/spark/DataSourceWriterTSE.scala
+++ b/src/test/scala/org/neo4j/spark/DataSourceWriterTSE.scala
@@ -4,7 +4,8 @@ import org.apache.commons.lang3.exception.ExceptionUtils
 import org.apache.spark.SparkException
 import org.apache.spark.sql.{DataFrame, SaveMode, SparkSession}
 import org.junit.Assert._
-import org.junit.Test
+import org.junit.{Ignore, Test}
+import org.neo4j.driver.exceptions.ClientException
 import org.neo4j.driver.internal.types.InternalTypeSystem
 import org.neo4j.driver.internal.{InternalPoint2D, InternalPoint3D}
 import org.neo4j.driver.summary.ResultSummary
@@ -706,39 +707,39 @@ class DataSourceWriterTSE extends SparkConnectorScalaBaseTSE {
     assertEquals("Guitar", res.get(3).getString(7))
   }
 
-// df: leaving this for the reviewers, wasn't able to recreate the deadlock issue
-//
-//  @Test
-//  def `should give better errors if transaction fails`(): Unit = {
-//    val df = List.fill(200)(("John Bonham", "Drums")).toDF("name", "instrument")
-//
-//    df.write
-//      .format(classOf[DataSource].getName)
-//      .option("url", SparkConnectorScalaSuiteIT.server.getBoltUrl)
-//      .option("relationship", "PLAYS")
-//      .option("relationship.source.save.mode", "ErrorIfExists")
-//      .option("relationship.target.save.mode", "ErrorIfExists")
-//      .option("relationship.save.strategy", "keys")
-//      .option("relationship.source.labels", ":Musician")
-//      .option("relationship.source.node.keys", "name:name")
-//      .option("relationship.target.labels", ":Instrument")
-//      .option("relationship.target.node.keys", "instrument:name")
-//      .save()
-//
-//    df.write
-//      .format(classOf[DataSource].getName)
-//      .option("url", SparkConnectorScalaSuiteIT.server.getBoltUrl)
-//      .option("partitions", "2")
-//      .option("relationship", "PLAYS_2")
-//      .option("relationship.source.save.mode", "Overwrite")
-//      .option("relationship.target.save.mode", "Overwrite")
-//      .option("relationship.save.strategy", "keys")
-//      .option("relationship.source.labels", ":Musician")
-//      .option("relationship.source.node.keys", "name:name")
-//      .option("relationship.target.labels", ":Instrument")
-//      .option("relationship.target.node.keys", "instrument_2:name")
-//      .save()
-//  }
+  @Test
+  @Ignore("trying to recreate the deadlock issue")
+  def `should give better errors if transaction fails`(): Unit = {
+    val df = List.fill(200)(("John Bonham", "Drums")).toDF("name", "instrument")
+
+    df.write
+      .format(classOf[DataSource].getName)
+      .option("url", SparkConnectorScalaSuiteIT.server.getBoltUrl)
+      .option("relationship", "PLAYS")
+      .option("relationship.source.save.mode", "ErrorIfExists")
+      .option("relationship.target.save.mode", "ErrorIfExists")
+      .option("relationship.save.strategy", "keys")
+      .option("relationship.source.labels", ":Musician")
+      .option("relationship.source.node.keys", "name:name")
+      .option("relationship.target.labels", ":Instrument")
+      .option("relationship.target.node.keys", "instrument:name")
+      .save()
+
+    df.write
+      .format(classOf[DataSource].getName)
+      .option("url", SparkConnectorScalaSuiteIT.server.getBoltUrl)
+      .option("transaction.retries", 0)
+      .option("partitions", "10")
+      .option("relationship", "PLAYS")
+      .option("relationship.source.save.mode", "Overwrite")
+      .option("relationship.target.save.mode", "Overwrite")
+      .option("relationship.save.strategy", "keys")
+      .option("relationship.source.labels", ":Musician")
+      .option("relationship.source.node.keys", "name:name")
+      .option("relationship.target.labels", ":Instrument")
+      .option("relationship.target.node.keys", "instrument:name")
+      .save()
+  }
 
   @Test
   def `should write relations with KEYS mode with props`(): Unit = {

--- a/src/test/scala/org/neo4j/spark/DataSourceWriterTSE.scala
+++ b/src/test/scala/org/neo4j/spark/DataSourceWriterTSE.scala
@@ -706,6 +706,40 @@ class DataSourceWriterTSE extends SparkConnectorScalaBaseTSE {
     assertEquals("Guitar", res.get(3).getString(7))
   }
 
+// df: leaving this for the reviewers, wasn't able to recreate the deadlock issue
+//
+//  @Test
+//  def `should give better errors if transaction fails`(): Unit = {
+//    val df = List.fill(200)(("John Bonham", "Drums")).toDF("name", "instrument")
+//
+//    df.write
+//      .format(classOf[DataSource].getName)
+//      .option("url", SparkConnectorScalaSuiteIT.server.getBoltUrl)
+//      .option("relationship", "PLAYS")
+//      .option("relationship.source.save.mode", "ErrorIfExists")
+//      .option("relationship.target.save.mode", "ErrorIfExists")
+//      .option("relationship.save.strategy", "keys")
+//      .option("relationship.source.labels", ":Musician")
+//      .option("relationship.source.node.keys", "name:name")
+//      .option("relationship.target.labels", ":Instrument")
+//      .option("relationship.target.node.keys", "instrument:name")
+//      .save()
+//
+//    df.write
+//      .format(classOf[DataSource].getName)
+//      .option("url", SparkConnectorScalaSuiteIT.server.getBoltUrl)
+//      .option("partitions", "2")
+//      .option("relationship", "PLAYS_2")
+//      .option("relationship.source.save.mode", "Overwrite")
+//      .option("relationship.target.save.mode", "Overwrite")
+//      .option("relationship.save.strategy", "keys")
+//      .option("relationship.source.labels", ":Musician")
+//      .option("relationship.source.node.keys", "name:name")
+//      .option("relationship.target.labels", ":Instrument")
+//      .option("relationship.target.node.keys", "instrument_2:name")
+//      .save()
+//  }
+
   @Test
   def `should write relations with KEYS mode with props`(): Unit = {
     val musicDf = Seq(


### PR DESCRIPTION
fixes #183 

Compared to the example in the issue, now the same error will be logged as

```
Py4JJavaError: An error occurred while calling o116.save.
: org.neo4j.driver.exceptions.TransientException: Database 'neo4j' is unavailable.
	at org.neo4j.driver.internal.util.Futures.blockingGet(Futures.java:143)
	at org.neo4j.driver.internal.InternalTransaction.commit(InternalTransaction.java:39)
	at org.neo4j.driver.internal.InternalSession.lambda$transaction$4(InternalSession.java:154)
	at org.neo4j.driver.internal.retry.ExponentialBackoffRetryLogic.retry(ExponentialBackoffRetryLogic.java:102)
	at org.neo4j.driver.internal.InternalSession.transaction(InternalSession.java:146)
	at org.neo4j.driver.internal.InternalSession.writeTransaction(InternalSession.java:124)
	at org.neo4j.driver.internal.InternalSession.writeTransaction(InternalSession.java:118)
	at org.neo4j.spark.service.SchemaService.execute(SchemaService.scala:494)
	at org.neo4j.spark.writer.Neo4jDataSourceWriter.createWriterFactory(Neo4jDataSourceWriter.scala:29)
	at org.apache.spark.sql.execution.datasources.v2.WriteToDataSourceV2Exec.doExecute(WriteToDataSourceV2Exec.scala:55)
	at org.apache.spark.sql.execution.SparkPlan$$anonfun$execute$1.apply(SparkPlan.scala:131)
	at org.apache.spark.sql.execution.SparkPlan$$anonfun$execute$1.apply(SparkPlan.scala:127)
	at org.apache.spark.sql.execution.SparkPlan$$anonfun$executeQuery$1.apply(SparkPlan.scala:155)
	at org.apache.spark.rdd.RDDOperationScope$.withScope(RDDOperationScope.scala:151)
	at org.apache.spark.sql.execution.SparkPlan.executeQuery(SparkPlan.scala:152)
	at org.apache.spark.sql.execution.SparkPlan.execute(SparkPlan.scala:127)
	at org.apache.spark.sql.execution.QueryExecution.toRdd$lzycompute(QueryExecution.scala:80)
	at org.apache.spark.sql.execution.QueryExecution.toRdd(QueryExecution.scala:80)
	at org.apache.spark.sql.DataFrameWriter$$anonfun$runCommand$1.apply(DataFrameWriter.scala:676)
	at org.apache.spark.sql.DataFrameWriter$$anonfun$runCommand$1.apply(DataFrameWriter.scala:676)
	at org.apache.spark.sql.execution.SQLExecution$$anonfun$withNewExecutionId$1.apply(SQLExecution.scala:78)
	at org.apache.spark.sql.execution.SQLExecution$.withSQLConfPropagated(SQLExecution.scala:125)
	at org.apache.spark.sql.execution.SQLExecution$.withNewExecutionId(SQLExecution.scala:73)
	at org.apache.spark.sql.DataFrameWriter.runCommand(DataFrameWriter.scala:676)
	at org.apache.spark.sql.DataFrameWriter.save(DataFrameWriter.scala:260)
	at sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
	at sun.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62)
	at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
	at java.lang.reflect.Method.invoke(Method.java:498)
	at py4j.reflection.MethodInvoker.invoke(MethodInvoker.java:244)
	at py4j.reflection.ReflectionEngine.invoke(ReflectionEngine.java:357)
	at py4j.Gateway.invoke(Gateway.java:282)
	at py4j.commands.AbstractCommand.invokeMethod(AbstractCommand.java:132)
	at py4j.commands.CallCommand.execute(CallCommand.java:79)
	at py4j.GatewayConnection.run(GatewayConnection.java:238)
	at java.lang.Thread.run(Thread.java:748)
```

Unfortunately I wasn't able to reproduce the issue in the integration tests. If you have any suggestions please write down a comment.