### PR TITLE
Fixes #205: add example section in quickstart page, link to notebooks repository

### DIFF
--- a/doc/docs/modules/ROOT/pages/quickstart.adoc
+++ b/doc/docs/modules/ROOT/pages/quickstart.adoc
@@ -308,3 +308,10 @@ MATCH (p:Person)-[r:BOUGHT]->(pr:Product)
 WHERE pr.name = 'An Awesome Product'
 RETURN count(p) AS count
 ----
+
+=== Examples
+
+You can find examples on how to use the Neo4j Connector for Apache Spark at link:https://github.com/utnaf/spark-connector-notebooks[this repository].
+It's a collection of Zeppelin Notebooks with different usage scenarios, along with a getting started guide.
+
+The repository is in constant development, and feel free to submit your examples.


### PR DESCRIPTION
Fixes #205 

- Added “Examples“ section in the Quickstart doc page
- Added a link to https://github.com/utnaf/spark-connector-notebooks

Leaving it as draft since I'm working on the notebooks repo