### PR TITLE
fixes #217: Multiple duplicate property names when reading multi-labeled nodes

### DIFF
--- a/src/main/scala/org/neo4j/spark/service/SchemaService.scala
+++ b/src/main/scala/org/neo4j/spark/service/SchemaService.scala
@@ -33,7 +33,11 @@ class SchemaService(private val options: Neo4jOptions, private val driverCache: 
 
   private def structForNode(labels: Seq[String] = options.nodeMetadata.labels): StructType = {
     var structFields: mutable.Buffer[StructField] = (try {
-        val query = "CALL apoc.meta.nodeTypeProperties({ includeLabels: $labels })"
+        val query =
+          """CALL apoc.meta.nodeTypeProperties({ includeLabels: $labels })
+            |YIELD propertyName, propertyTypes
+            |RETURN DISTINCT propertyName, propertyTypes
+            |""".stripMargin
         val params = Map[String, AnyRef]("labels" -> labels.asJava)
           .asJava
         retrieveSchemaFromApoc(query, params)


### PR DESCRIPTION
fixes #217 

Multiple duplicate property names when reading multi-labelled nodes are now managed properly