### PR TITLE
Fixes #200: Reading empty query sets fails due to schema inference

### DIFF
--- a/doc/docs/modules/ROOT/pages/faq.adoc
+++ b/doc/docs/modules/ROOT/pages/faq.adoc
@@ -57,7 +57,7 @@ and need each column to always have the same type.
 
 You can read more <<quickstart.adoc#bookmark-read-known-problem, here>>.
 
-== The returned columns are not in the same ordere as I specified in the query
+== The returned columns are not in the same order as I specified in the query
 
 Unfortunately this is a known issue and is there for Neo4j 3.* and Neo4j 4.0.
 With Neo4j 4.1+ you will get the same order as specified in the return statement.

--- a/doc/docs/modules/ROOT/pages/faq.adoc
+++ b/doc/docs/modules/ROOT/pages/faq.adoc
@@ -56,3 +56,8 @@ all the values for that field will be casted to String. This because Spark is no
 and need each column to always have the same type.
 
 You can read more <<quickstart.adoc#bookmark-read-known-problem, here>>.
+
+== The returned columns are not in the same ordere as I specified in the query
+
+Unfortunately this is a known issue and is there for Neo4j 3.* and Neo4j 4.0.
+With Neo4j 4.1+ you will get the same order as specified in the return statement.

--- a/doc/docs/modules/ROOT/pages/reading.adoc
+++ b/doc/docs/modules/ROOT/pages/reading.adoc
@@ -196,6 +196,30 @@ and the result of the last query will be injected into the `query`.
 ==== Schema
 The first 10 (or any number specified by the `schema.flatten.limit` option) results will be flattened and the schema will be created from those properties.
 
+If the query returns no data the sampling won't be possible.
+In these case the connector will create a schema from the return statement and every column will be of type String.
+This won't cause any problems since you won't have any data in your dataset.
+
+For example, say you have this query:
+[source]
+----
+MATCH (n:NON_EXISTENT_LABEL) RETURN id(n) as id, n.name, n.age
+----
+
+The created schema will be
+
+|===
+|Column|Type
+
+|id|String
+|n.name|String
+|n.age|String
+|===
+
+[NOTE]
+The returned column order is not guarantee to match the RETURN statement for Neo4j 3.* and Neo4j 4.0.
+Starting from Neo4j 4.1 it the order will be the same.
+
 [[bookmark-read-node]]
 === Node
 

--- a/src/main/scala/org/neo4j/spark/service/SchemaService.scala
+++ b/src/main/scala/org/neo4j/spark/service/SchemaService.scala
@@ -222,7 +222,7 @@ class SchemaService(private val options: Neo4jOptions, private val driverCache: 
     val sortedStructFields = if (structFields.isEmpty) {
       columns.map(StructField(_, DataTypes.StringType))
     } else {
-      columns.map(c => structFields.find(_.name.equals(c)).get)
+      columns.map(c => structFields.find(_.name.quote().equals(c.quote())).get)
     }
 
     StructType(sortedStructFields)

--- a/src/main/scala/org/neo4j/spark/service/SchemaService.scala
+++ b/src/main/scala/org/neo4j/spark/service/SchemaService.scala
@@ -193,7 +193,7 @@ class SchemaService(private val options: Neo4jOptions, private val driverCache: 
     val params = Collections.singletonMap[String, AnyRef](Neo4jQueryStrategy.VARIABLE_SCRIPT_RESULT, Collections.emptyList())
     val structFields = retrieveSchema(query, params, { record => record.asMap.asScala.toMap })
 
-    val result = session.run(s"EXPLAIN ${options.query.value}").consume()
+    val result = session.run(s"EXPLAIN $query").consume()
     val plan = result.plan()
 
     val columns = if (plan.arguments().containsKey("Details")) {

--- a/src/main/scala/org/neo4j/spark/service/SchemaService.scala
+++ b/src/main/scala/org/neo4j/spark/service/SchemaService.scala
@@ -209,6 +209,7 @@ class SchemaService(private val options: Neo4jOptions, private val driverCache: 
 
       lastChild.operatorType() match {
         case "EagerAggregation" => lastChild.identifiers().asScala.toArray
+        case "ProcedureCall" => plan.identifiers().asScala.toArray
         case _ =>
           val expressions = lastChild.arguments().get("Expressions").asString()
 

--- a/src/test/scala/org/neo4j/spark/DataSourceReaderNeo4j41xTSE.scala
+++ b/src/test/scala/org/neo4j/spark/DataSourceReaderNeo4j41xTSE.scala
@@ -1,0 +1,92 @@
+package org.neo4j.spark
+
+import org.apache.spark.sql.DataFrame
+import org.junit.Assert.assertEquals
+import org.junit.{Assume, BeforeClass, Test}
+import org.neo4j.driver.summary.ResultSummary
+import org.neo4j.driver.{SessionConfig, Transaction, TransactionWork}
+
+object DataSourceReaderNeo4j41xTSE {
+  @BeforeClass
+  def checkNeo4jVersion() {
+    Assume.assumeTrue(TestUtil.neo4jVersion().startsWith("4.1"))
+  }
+}
+
+class DataSourceReaderNeo4j41xTSE extends SparkConnectorScalaBaseTSE {
+
+  @Test
+  def testEmptyDataset(): Unit = {
+    val df = ss.read
+      .format(classOf[DataSource].getName)
+      .option("url", SparkConnectorScalaSuiteIT.server.getBoltUrl)
+      .option("query", "MATCH (e:ID_DO_NOT_EXIST) RETURN id(e) as f, 1 as g")
+      .load
+
+    assertEquals(0, df.count())
+    assertEquals(Seq("f", "g"), df.columns.toSeq)
+  }
+
+  @Test
+  def testColumnSorted(): Unit = {
+    SparkConnectorScalaSuiteIT.session()
+      .writeTransaction(
+        new TransactionWork[ResultSummary] {
+          override def execute(tx: Transaction): ResultSummary = tx.run("CREATE (i1:Instrument{name: 'Drums', id: 1}), (i2:Instrument{name: 'Guitar', id: 2})").consume()
+        })
+
+    val df = ss.read
+      .format(classOf[DataSource].getName)
+      .option("url", SparkConnectorScalaSuiteIT.server.getBoltUrl)
+      .option("query", "MATCH (i:Instrument) RETURN id(i) as internal_id, i.id as id, i.name as name, i.name")
+      .load
+
+    assertEquals(1L, df.collectAsList().get(0).get(1))
+    assertEquals("Drums", df.collectAsList().get(0).get(2))
+    assertEquals(Seq("internal_id", "id", "name", "i.name"), df.columns.toSeq)
+  }
+
+  @Test
+  def testComplexReturnStatement(): Unit = {
+    val total = 100
+    val fixtureQuery: String =
+      s"""UNWIND range(1, $total) as id
+         |CREATE (pr:Product {id: id * rand(), name: 'Product ' + id})
+         |CREATE (pe:Person {id: id, fullName: 'Person ' + id})
+         |CREATE (pe)-[:BOUGHT{when: rand(), quantity: rand() * 1000}]->(pr)
+         |RETURN *
+    """.stripMargin
+
+    SparkConnectorScalaSuiteIT.session()
+      .writeTransaction(
+        new TransactionWork[ResultSummary] {
+          override def execute(tx: Transaction): ResultSummary = tx.run(fixtureQuery).consume()
+        })
+
+    val df = ss.read.format(classOf[DataSource].getName)
+      .option("url", SparkConnectorScalaSuiteIT.server.getBoltUrl)
+      .option("query",
+        """MATCH (p:Person)-[b:BOUGHT]->(pr:Product)
+          |RETURN id(p) AS personId, id(pr) AS productId, {quantity: b.quantity, when: b.when} AS map, "some string" as someString, {anotherField: "201"} as map2""".stripMargin)
+      .option("schema.strategy", "string")
+      .load()
+
+    assertEquals(Seq("personId", "productId", "map", "someString", "map2"), df.columns.toSeq)
+    assertEquals(100, df.count())
+  }
+
+  @Test
+  def testComplexReturnStatementNoValues(): Unit = {
+    val df = ss.read.format(classOf[DataSource].getName)
+      .option("url", SparkConnectorScalaSuiteIT.server.getBoltUrl)
+      .option("query",
+        """MATCH (p:Person)-[b:BOUGHT]->(pr:Product)
+          |RETURN id(p) AS personId, id(pr) AS productId, {quantity: b.quantity, when: b.when} AS map, "some string" as someString, {anotherField: "201", and: 1} as map2""".stripMargin)
+      .option("schema.strategy", "string")
+      .load()
+
+    assertEquals(Seq("personId", "productId", "map", "someString", "map2"), df.columns.toSeq)
+    assertEquals(0, df.count())
+  }
+
+}

--- a/src/test/scala/org/neo4j/spark/DataSourceReaderNeo4j41xTSE.scala
+++ b/src/test/scala/org/neo4j/spark/DataSourceReaderNeo4j41xTSE.scala
@@ -9,7 +9,8 @@ import org.neo4j.driver.{SessionConfig, Transaction, TransactionWork}
 object DataSourceReaderNeo4j41xTSE {
   @BeforeClass
   def checkNeo4jVersion() {
-    Assume.assumeTrue(TestUtil.neo4jVersion().startsWith("4.1"))
+    val neo4jVersion = TestUtil.neo4jVersion()
+    Assume.assumeTrue(!neo4jVersion.startsWith("3.5") && !neo4jVersion.startsWith("4.0"))
   }
 }
 

--- a/src/test/scala/org/neo4j/spark/DataSourceReaderTSE.scala
+++ b/src/test/scala/org/neo4j/spark/DataSourceReaderTSE.scala
@@ -1122,9 +1122,47 @@ class DataSourceReaderTSE extends SparkConnectorScalaBaseTSE {
       .option("query", "MATCH (i:Instrument) RETURN id(i) as internal_id, i.id as id, i.name as name, i.name")
       .load
 
-    assertEquals(0L, df.collectAsList().get(0).get(0))
     assertEquals(1L, df.collectAsList().get(0).get(1))
     assertEquals("Drums", df.collectAsList().get(0).get(2))
+  }
+
+  @Test
+  def testComplexReturnStatement(): Unit = {
+    val total = 100
+    val fixtureQuery: String =
+      s"""UNWIND range(1, $total) as id
+         |CREATE (pr:Product {id: id * rand(), name: 'Product ' + id})
+         |CREATE (pe:Person {id: id, fullName: 'Person ' + id})
+         |CREATE (pe)-[:BOUGHT{when: rand(), quantity: rand() * 1000}]->(pr)
+         |RETURN *
+    """.stripMargin
+
+    SparkConnectorScalaSuiteIT.session()
+      .writeTransaction(
+        new TransactionWork[ResultSummary] {
+          override def execute(tx: Transaction): ResultSummary = tx.run(fixtureQuery).consume()
+        })
+
+    ss.read.format(classOf[DataSource].getName)
+      .option("url", SparkConnectorScalaSuiteIT.server.getBoltUrl)
+      .option("query",
+        """MATCH (p:Person)-[b:BOUGHT]->(pr:Product)
+          |RETURN id(p) AS personId, id(pr) AS productId, {quantity: b.quantity, when: b.when} AS map, "some string" as someString, {anotherField: "201"} as map2""".stripMargin)
+      .option("schema.strategy", "string")
+      .load()
+      .show()
+  }
+
+  @Test
+  def testComplexReturnStatementNoValues(): Unit = {
+    ss.read.format(classOf[DataSource].getName)
+      .option("url", SparkConnectorScalaSuiteIT.server.getBoltUrl)
+      .option("query",
+        """MATCH (p:Person)-[b:BOUGHT]->(pr:Product)
+          |RETURN id(p) AS personId, id(pr) AS productId, {quantity: b.quantity, when: b.when} AS map, "some string" as someString, {anotherField: "201", and: 1} as map2""".stripMargin)
+      .option("schema.strategy", "string")
+      .load()
+      .show()
   }
 
   @Test


### PR DESCRIPTION
Fixes #200 

We had to deal with some missing data from the API across different versions of Neo4j. 
It has been solved but it's rather unstable for Neo4j 4.0 and 3.5, and requires additional testing. Test cases has been added but I think we might miss something.

This also solves the returned column order issue.