### PR TITLE
Issue #172: Implement SupportsPushDownRequiredColumns

### DIFF
--- a/doc/docs/modules/ROOT/pages/reading.adoc
+++ b/doc/docs/modules/ROOT/pages/reading.adoc
@@ -67,6 +67,11 @@ When `string` it coerces all the properties to String otherwise it will try to s
 |`true`
 |No
 
+|`pushdown.columns.enabled`
+|Enable or disable the Push Down Column support
+|`true`
+|No
+
 |`partitions`
 |This defines the parallelization level while pulling data from Neo4j.
 

--- a/src/main/scala/org/neo4j/spark/Neo4jOptions.scala
+++ b/src/main/scala/org/neo4j/spark/Neo4jOptions.scala
@@ -32,6 +32,7 @@ class Neo4jOptions(private val parameters: java.util.Map[String, String]) extend
   }
 
   val pushdownFiltersEnabled: Boolean = getParameter(PUSHDOWN_FILTERS_ENABLED, DEFAULT_PUSHDOWN_FILTERS_ENABLED.toString).toBoolean
+  val pushdownColumnsEnabled: Boolean = getParameter(PUSHDOWN_COLUMNS_ENABLED, DEFAULT_PUSHDOWN_COLUMNS_ENABLED.toString).toBoolean
 
   val schemaMetadata = Neo4jSchemaMetadata(getParameter(SCHEMA_FLATTEN_LIMIT, DEFAULT_SCHEMA_FLATTEN_LIMIT.toString).toInt,
     SchemaStrategy.withCaseInsensitiveName(getParameter(SCHEMA_STRATEGY, DEFAULT_SCHEMA_STRATEGY.toString).toUpperCase),
@@ -284,6 +285,7 @@ object Neo4jOptions {
   val SAVE_MODE = "save.mode"
 
   val PUSHDOWN_FILTERS_ENABLED = "pushdown.filters.enabled"
+  val PUSHDOWN_COLUMNS_ENABLED = "pushdown.columns.enabled"
 
   // schema options
   val SCHEMA_STRATEGY = "schema.strategy"
@@ -338,6 +340,7 @@ object Neo4jOptions {
   val DEFAULT_RELATIONSHIP_SOURCE_SAVE_MODE: NodeSaveMode.Value = NodeSaveMode.Match
   val DEFAULT_RELATIONSHIP_TARGET_SAVE_MODE: NodeSaveMode.Value = NodeSaveMode.Match
   val DEFAULT_PUSHDOWN_FILTERS_ENABLED = true
+  val DEFAULT_PUSHDOWN_COLUMNS_ENABLED = true
   val DEFAULT_PARTITIONS = 1
   val DEFAULT_OPTIMIZATION_TYPE = OptimizationType.NONE
 }

--- a/src/main/scala/org/neo4j/spark/reader/Neo4jDataSourceReader.scala
+++ b/src/main/scala/org/neo4j/spark/reader/Neo4jDataSourceReader.scala
@@ -75,5 +75,7 @@ class Neo4jDataSourceReader(private val options: DataSourceOptions, private val 
 
   override def pushedFilters(): Array[Filter] = filters
 
-  override def pruneColumns(requiredSchema: StructType): Unit = requiredColumns = requiredSchema
+  override def pruneColumns(requiredSchema: StructType): Unit = {
+    requiredColumns = requiredSchema
+  }
 }

--- a/src/main/scala/org/neo4j/spark/reader/Neo4jDataSourceReader.scala
+++ b/src/main/scala/org/neo4j/spark/reader/Neo4jDataSourceReader.scala
@@ -76,6 +76,10 @@ class Neo4jDataSourceReader(private val options: DataSourceOptions, private val 
   override def pushedFilters(): Array[Filter] = filters
 
   override def pruneColumns(requiredSchema: StructType): Unit = {
-    requiredColumns = requiredSchema
+    requiredColumns = if (neo4jOptions.pushdownColumnsEnabled) {
+      requiredSchema
+    } else {
+      new StructType()
+    }
   }
 }

--- a/src/main/scala/org/neo4j/spark/reader/Neo4jDataSourceReader.scala
+++ b/src/main/scala/org/neo4j/spark/reader/Neo4jDataSourceReader.scala
@@ -14,9 +14,12 @@ import org.neo4j.spark.util.Validations
 import scala.collection.JavaConverters._
 
 class Neo4jDataSourceReader(private val options: DataSourceOptions, private val jobId: String) extends DataSourceReader
-  with SupportsPushDownFilters {
+  with SupportsPushDownFilters
+  with SupportsPushDownRequiredColumns {
 
   private var filters: Array[Filter] = Array[Filter]()
+
+  private var requiredColumns: StructType = new StructType()
 
   private val neo4jOptions: Neo4jOptions = new Neo4jOptions(options.asMap())
     .validate(options => Validations.read(options, jobId))
@@ -71,4 +74,6 @@ class Neo4jDataSourceReader(private val options: DataSourceOptions, private val 
   }
 
   override def pushedFilters(): Array[Filter] = filters
+
+  override def pruneColumns(requiredSchema: StructType): Unit = requiredColumns = requiredSchema
 }

--- a/src/main/scala/org/neo4j/spark/service/Neo4jQueryService.scala
+++ b/src/main/scala/org/neo4j/spark/service/Neo4jQueryService.scala
@@ -212,11 +212,7 @@ class Neo4jQueryReadStrategy(filters: Array[Filter] = Array.empty[Filter],
       matchQuery.returning(entity)
     }
     else {
-      matchQuery.returning(requiredColumns.map {
-        case Neo4jUtil.INTERNAL_ID_FIELD => Functions.id(entity.asInstanceOf[Node]).as(Neo4jUtil.INTERNAL_ID_FIELD.quote())
-        case Neo4jUtil.INTERNAL_LABELS_FIELD => Functions.labels(entity.asInstanceOf[Node]).as(Neo4jUtil.INTERNAL_LABELS_FIELD.quote())
-        case name => entity.property(name).as(name.quote())
-      }: _*)
+      matchQuery.returning(requiredColumns.map(column => getCorrectProperty(column, entity)): _*)
     }
   }
 

--- a/src/main/scala/org/neo4j/spark/service/Neo4jQueryService.scala
+++ b/src/main/scala/org/neo4j/spark/service/Neo4jQueryService.scala
@@ -54,7 +54,6 @@ class Neo4jQueryWriteStrategy(private val saveMode: SaveMode) extends Neo4jQuery
       .map(_.quote())
       .mkString(":")
 
-
     val sourceKeys = createPropsList(
       options.relationshipMetadata.source.nodeKeys,
       s"source.${Neo4jWriteMappingStrategy.KEYS}"
@@ -100,7 +99,8 @@ class Neo4jQueryWriteStrategy(private val saveMode: SaveMode) extends Neo4jQuery
 }
 
 class Neo4jQueryReadStrategy(filters: Array[Filter] = Array.empty[Filter],
-                             partitionSkipLimit: PartitionSkipLimit = PartitionSkipLimit.EMPTY) extends Neo4jQueryStrategy {
+                             partitionSkipLimit: PartitionSkipLimit = PartitionSkipLimit.EMPTY,
+                             requiredColumns: Seq[String] = Seq.empty) extends Neo4jQueryStrategy {
   private val renderer: Renderer = Renderer.getDefaultRenderer
 
   override def createStatementForQuery(options: Neo4jOptions): String = {
@@ -124,8 +124,44 @@ class Neo4jQueryReadStrategy(filters: Array[Filter] = Array.empty[Filter],
 
     val matchQuery: StatementBuilder.OngoingReadingWithoutWhere = filterRelationship(sourceNode, targetNode, relationship)
 
-    val returning = matchQuery.returning(sourceNode, relationship, targetNode)
-    renderer.render(buildStatement(returning))
+    val aliasedSourceNode = sourceNode.as(Neo4jUtil.RELATIONSHIP_SOURCE_ALIAS)
+    val aliasedTargetNode = targetNode.as(Neo4jUtil.RELATIONSHIP_TARGET_ALIAS)
+    val aliasedRelationship = relationship.getRequiredSymbolicName
+
+    val returnExpressions: Seq[Expression] = if (requiredColumns.isEmpty) {
+      Seq(aliasedRelationship, aliasedSourceNode, aliasedTargetNode)
+    }
+    else {
+      requiredColumns.map(column => {
+        val splatColumn = column.split('.')
+        val entityName = splatColumn.head
+
+        val entity = if (entityName.contains(Neo4jUtil.RELATIONSHIP_ALIAS)) {
+          relationship
+        }
+        else if (entityName.contains(Neo4jUtil.RELATIONSHIP_SOURCE_ALIAS)) {
+          sourceNode
+        }
+        else if (entityName.contains(Neo4jUtil.RELATIONSHIP_TARGET_ALIAS)) {
+          targetNode
+        }
+        else {
+          throw new IllegalArgumentException(s"`${column}` is not a valid column.`")
+        }
+
+        if (splatColumn.length.equals(1)) {
+          entity match {
+            case n: Node => n.as(entityName.quote())
+            case r: Relationship => r.getRequiredSymbolicName
+          }
+        }
+        else {
+          getCorrectProperty(column, entity)
+        }
+      })
+    }
+
+    renderer.render(buildStatement(matchQuery.returning(returnExpressions : _*)))
   }
 
   private def buildStatement(returning: StatementBuilder.OngoingReadingAndReturn) =
@@ -171,11 +207,33 @@ class Neo4jQueryReadStrategy(filters: Array[Filter] = Array.empty[Filter],
     matchQuery
   }
 
+  private def returnRequiredColumns(entity: PropertyContainer, matchQuery: StatementBuilder.OngoingReading): StatementBuilder.OngoingReadingAndReturn = {
+    if (requiredColumns.isEmpty) {
+      matchQuery.returning(entity)
+    }
+    else {
+      matchQuery.returning(requiredColumns.map {
+        case Neo4jUtil.INTERNAL_ID_FIELD => Functions.id(entity.asInstanceOf[Node]).as(Neo4jUtil.INTERNAL_ID_FIELD.quote())
+        case Neo4jUtil.INTERNAL_LABELS_FIELD => Functions.labels(entity.asInstanceOf[Node]).as(Neo4jUtil.INTERNAL_LABELS_FIELD.quote())
+        case name => entity.property(name).as(name.quote())
+      }: _*)
+    }
+  }
+
+  private def getCorrectProperty(column: String, entity: PropertyContainer): Expression = {
+    column match {
+      case Neo4jUtil.INTERNAL_ID_FIELD => Functions.id(entity.asInstanceOf[Node]).as(Neo4jUtil.INTERNAL_ID_FIELD.quote())
+      case Neo4jUtil.INTERNAL_LABELS_FIELD => Functions.labels(entity.asInstanceOf[Node]).as(Neo4jUtil.INTERNAL_LABELS_FIELD.quote())
+      case name => entity.property(name.removeAlias()).as(name.quote())
+    }
+  }
+
   override def createStatementForNodes(options: Neo4jOptions): String = {
     val node = createNode(Neo4jUtil.NODE_ALIAS, options.nodeMetadata.labels)
     val matchQuery = filterNode(node)
-    val returning = matchQuery.returning(node)
-    renderer.render(buildStatement(returning))
+//    val returning = matchQuery.returning(node)
+//    renderer.render(buildStatement(returning))
+    renderer.render(buildStatement(returnRequiredColumns(node, matchQuery)))
   }
 
   private def filterNode(node: Node) = {

--- a/src/main/scala/org/neo4j/spark/service/Neo4jQueryService.scala
+++ b/src/main/scala/org/neo4j/spark/service/Neo4jQueryService.scala
@@ -223,6 +223,9 @@ class Neo4jQueryReadStrategy(filters: Array[Filter] = Array.empty[Filter],
   private def getCorrectProperty(column: String, entity: PropertyContainer): Expression = {
     column match {
       case Neo4jUtil.INTERNAL_ID_FIELD => Functions.id(entity.asInstanceOf[Node]).as(Neo4jUtil.INTERNAL_ID_FIELD.quote())
+      case Neo4jUtil.INTERNAL_REL_ID_FIELD => Functions.id(entity.asInstanceOf[Relationship]).as(Neo4jUtil.INTERNAL_REL_ID_FIELD.quote())
+      case Neo4jUtil.INTERNAL_REL_SOURCE_ID_FIELD => Functions.id(entity.asInstanceOf[Node]).as(Neo4jUtil.INTERNAL_REL_SOURCE_ID_FIELD.quote())
+      case Neo4jUtil.INTERNAL_REL_TARGET_ID_FIELD => Functions.id(entity.asInstanceOf[Node]).as(Neo4jUtil.INTERNAL_REL_TARGET_ID_FIELD.quote())
       case Neo4jUtil.INTERNAL_LABELS_FIELD => Functions.labels(entity.asInstanceOf[Node]).as(Neo4jUtil.INTERNAL_LABELS_FIELD.quote())
       case name => entity.property(name.removeAlias()).as(name.quote())
     }

--- a/src/main/scala/org/neo4j/spark/service/Neo4jQueryService.scala
+++ b/src/main/scala/org/neo4j/spark/service/Neo4jQueryService.scala
@@ -283,7 +283,7 @@ class Neo4jQueryReadStrategy(filters: Array[Filter] = Array.empty[Filter],
     if (labels.isEmpty) {
       Cypher.anyNode(name)
     } else {
-      Cypher.node(primaryLabel, otherLabels.asJava).named(name)
+      Cypher.node(primaryLabel, otherLabels.asJava).named(name.quote())
     }
   }
 }

--- a/src/test/scala/org/neo4j/spark/DataSourceReaderTSE.scala
+++ b/src/test/scala/org/neo4j/spark/DataSourceReaderTSE.scala
@@ -1123,9 +1123,11 @@ class DataSourceReaderTSE extends SparkConnectorScalaBaseTSE {
       .option("url", SparkConnectorScalaSuiteIT.server.getBoltUrl)
       .option("query", "MATCH (i:Instrument) RETURN id(i) as internal_id, i.id as id, i.name as name, i.name")
       .load
+      .sort("id")
 
-    assertEquals(1L, df.collectAsList().get(0).get(1))
-    assertEquals("Drums", df.collectAsList().get(0).get(2))
+    val row = df.collectAsList().get(0)
+    assertEquals(1L, row.get(1))
+    assertEquals("Drums", row.get(2))
     assertEquals(Set("internal_id", "id", "name", "i.name"), df.columns.toSet)
   }
 
@@ -1297,6 +1299,95 @@ class DataSourceReaderTSE extends SparkConnectorScalaBaseTSE {
       .load
 
     assertEquals(10, df.count())
+  }
+
+  @Test
+  def testShouldReturnJustTheSelectedFieldWithNode(): Unit = {
+    val total = 100
+    val fixtureQuery: String =
+      s"""UNWIND range(1, $total) as id
+         |CREATE (pr:Product {id: id, name: 'Product ' + id})
+         |RETURN *
+    """.stripMargin
+
+    SparkConnectorScalaSuiteIT.session()
+      .writeTransaction(
+        new TransactionWork[ResultSummary] {
+          override def execute(tx: Transaction): ResultSummary = tx.run(fixtureQuery).consume()
+        })
+
+    val df = ss.read
+      .format(classOf[DataSource].getName)
+      .option("url", SparkConnectorScalaSuiteIT.server.getBoltUrl)
+      .option("labels", "Product")
+      .load
+      .select("name")
+
+    df.count()
+
+    assertEquals(Set("name"), df.columns.toSet)
+  }
+
+  @Test
+  def testShouldReturnJustTheSelectedFieldWithRelationship(): Unit = {
+    val total = 100
+    val fixtureQuery: String =
+      s"""UNWIND range(1, $total) as id
+         |CREATE (pr:Product {id: id * rand(), name: 'Product ' + id})
+         |CREATE (pe:Person {id: id, fullName: 'Person ' + id})
+         |CREATE (pe)-[:BOUGHT{when: rand(), quantity: rand() * 1000}]->(pr)
+         |RETURN *
+    """.stripMargin
+
+    SparkConnectorScalaSuiteIT.session()
+      .writeTransaction(
+        new TransactionWork[ResultSummary] {
+          override def execute(tx: Transaction): ResultSummary = tx.run(fixtureQuery).consume()
+        })
+
+    val df = ss.read
+      .format(classOf[DataSource].getName)
+      .option("url", SparkConnectorScalaSuiteIT.server.getBoltUrl)
+      .option("relationship", "BOUGHT")
+      .option("relationship.source.labels", "Product")
+      .option("relationship.target.labels", "Person")
+      .load
+      .select("`source.name`")
+
+    df.count()
+
+    assertEquals(Set("source.name"), df.columns.toSet)
+  }
+
+  @Test
+  def testShouldReturnJustTheSelectedFieldWithQuery(): Unit = {
+    val total = 100
+    val fixtureQuery: String =
+      s"""UNWIND range(1, $total) as id
+         |CREATE (pr:Product {id: id * rand(), name: 'Product ' + id})
+         |CREATE (pe:Person {id: id, fullName: 'Person ' + id})
+         |CREATE (pe)-[:BOUGHT{when: rand(), quantity: rand() * 1000}]->(pr)
+         |RETURN *
+    """.stripMargin
+
+    SparkConnectorScalaSuiteIT.session()
+      .writeTransaction(
+        new TransactionWork[ResultSummary] {
+          override def execute(tx: Transaction): ResultSummary = tx.run(fixtureQuery).consume()
+        })
+
+    val df = ss.read
+      .format(classOf[DataSource].getName)
+      .option("url", SparkConnectorScalaSuiteIT.server.getBoltUrl)
+      .option("query", "MATCH (p:Product) RETURN p.name as name")
+      .option("partitions", 2)
+      .option("query.count", 20)
+      .load
+      .select("name")
+
+    df.count()
+
+    assertEquals(Set("name"), df.columns.toSet)
   }
 
   private def initTest(query: String): DataFrame = {

--- a/src/test/scala/org/neo4j/spark/DataSourceReaderTSE.scala
+++ b/src/test/scala/org/neo4j/spark/DataSourceReaderTSE.scala
@@ -1412,7 +1412,7 @@ class DataSourceReaderTSE extends SparkConnectorScalaBaseTSE {
       .load
       .select("`target.(╯°□°)╯︵ ┻━┻`", "`<source.id>`")
 
-    df.show()
+    df.count()
 
     assertEquals(Set("target.(╯°□°)╯︵ ┻━┻", "<source.id>"), df.columns.toSet)
   }
@@ -1497,15 +1497,15 @@ class DataSourceReaderTSE extends SparkConnectorScalaBaseTSE {
       .format(classOf[DataSource].getName)
       .option("url", SparkConnectorScalaSuiteIT.server.getBoltUrl)
       .option("relationship", "BOUGHT")
-      .option("relationship.source.labels", "Produce")
-      .option("relationship.target.labels", "Person")
+      .option("relationship.source.labels", "Person")
+      .option("relationship.target.labels", "Product")
       .load
-      .filter("`source.name` = 'Product 1' AND `<target>`.`id` = '16'")
-      .select("`source.name`", "`<source.id>`")
+      .filter("`target.name` = 'Product 1' AND `target.id` = '16'")
+      .select("`target.name`", "`target.id`")
 
-    df.count()
+    df.show()
 
-    assertEquals(Set("source.name", "<source.id>"), df.columns.toSet)
+    assertEquals(Set("target.name", "target.id"), df.columns.toSet)
   }
 
   private def initTest(query: String): DataFrame = {

--- a/src/test/scala/org/neo4j/spark/DataSourceReaderTSE.scala
+++ b/src/test/scala/org/neo4j/spark/DataSourceReaderTSE.scala
@@ -1417,7 +1417,6 @@ class DataSourceReaderTSE extends SparkConnectorScalaBaseTSE {
     assertEquals(Set("target.(╯°□°)╯︵ ┻━┻", "<source.id>"), df.columns.toSet)
   }
 
-
   @Test
   def testShouldReturnJustTheSelectedFieldWithQuery(): Unit = {
     val total = 100
@@ -1503,7 +1502,7 @@ class DataSourceReaderTSE extends SparkConnectorScalaBaseTSE {
       .filter("`target.name` = 'Product 1' AND `target.id` = '16'")
       .select("`target.name`", "`target.id`")
 
-    df.show()
+    df.count()
 
     assertEquals(Set("target.name", "target.id"), df.columns.toSet)
   }

--- a/src/test/scala/org/neo4j/spark/Neo4jOptionsTest.scala
+++ b/src/test/scala/org/neo4j/spark/Neo4jOptionsTest.scala
@@ -134,6 +134,17 @@ class Neo4jOptionsTest {
   }
 
   @Test
+  def testPushDownColumnIsDisabled(): Unit = {
+    val options: java.util.Map[String, String] = new java.util.HashMap[String, String]()
+    options.put(Neo4jOptions.URL, "bolt://localhost")
+    options.put("pushdown.columns.enabled", "false")
+
+    val neo4jOptions: Neo4jOptions = new Neo4jOptions(options)
+
+    assertFalse(neo4jOptions.pushdownColumnsEnabled)
+  }
+
+  @Test
   def testDriverDefaults(): Unit = {
     val options: java.util.Map[String, String] = new java.util.HashMap[String, String]()
     options.put(Neo4jOptions.URL, "bolt://localhost")

--- a/src/test/scala/org/neo4j/spark/service/Neo4jQueryServiceTest.scala
+++ b/src/test/scala/org/neo4j/spark/service/Neo4jQueryServiceTest.scala
@@ -166,7 +166,28 @@ class Neo4jQueryServiceTest {
   }
 
   @Test
-  def testRelationshipWithOneMoreColumnsSelected(): Unit = {
+  def testRelationshipWithMoreColumnSelected(): Unit = {
+    val options: java.util.Map[String, String] = new java.util.HashMap[String, String]()
+    options.put(Neo4jOptions.URL, "bolt://localhost")
+    options.put("relationship", "KNOWS")
+    options.put("relationship.nodes.map", "false")
+    options.put("relationship.source.labels", "Person")
+    options.put("relationship.target.labels", "Person")
+    val neo4jOptions: Neo4jOptions = new Neo4jOptions(options)
+
+    val query: String = new Neo4jQueryService(neo4jOptions, new Neo4jQueryReadStrategy(
+      Array[Filter](),
+      PartitionSkipLimit(0, -1, -1),
+      List("source.name", "<source.id>")
+    )).createQuery()
+
+    assertEquals("MATCH (source:`Person`) " +
+      "MATCH (target:`Person`) " +
+      "MATCH (source)-[rel:`KNOWS`]->(target) RETURN source.name AS `source.name`, id(source) AS `<source.id>`", query)
+  }
+
+  @Test
+  def testRelationshipWithMoreColumnsSelected(): Unit = {
     val options: java.util.Map[String, String] = new java.util.HashMap[String, String]()
     options.put(Neo4jOptions.URL, "bolt://localhost")
     options.put("relationship", "KNOWS")

--- a/src/test/scala/org/neo4j/spark/service/Neo4jQueryServiceTest.scala
+++ b/src/test/scala/org/neo4j/spark/service/Neo4jQueryServiceTest.scala
@@ -41,7 +41,7 @@ class Neo4jQueryServiceTest {
 
     val query: String = new Neo4jQueryService(
       neo4jOptions,
-      new Neo4jQueryReadStrategy(Array.empty[Filter], PartitionSkipLimit(0, -1, -1), Seq())
+      new Neo4jQueryReadStrategy(Array.empty[Filter], PartitionSkipLimit.EMPTY, Seq())
     ).createQuery()
 
     assertEquals("MATCH (n:`Person`) RETURN n", query)
@@ -56,7 +56,7 @@ class Neo4jQueryServiceTest {
 
     val query: String = new Neo4jQueryService(
       neo4jOptions,
-      new Neo4jQueryReadStrategy(Array.empty[Filter], PartitionSkipLimit(0, -1, -1), Seq("name"))
+      new Neo4jQueryReadStrategy(Array.empty[Filter], PartitionSkipLimit.EMPTY, Seq("name"))
     ).createQuery()
 
     assertEquals("MATCH (n:`Person`) RETURN n.name AS name", query)
@@ -71,7 +71,7 @@ class Neo4jQueryServiceTest {
 
     val query: String = new Neo4jQueryService(
       neo4jOptions,
-      new Neo4jQueryReadStrategy(Array.empty[Filter], PartitionSkipLimit(0, -1, -1), List("name", "bornDate"))
+      new Neo4jQueryReadStrategy(Array.empty[Filter], PartitionSkipLimit.EMPTY, List("name", "bornDate"))
     ).createQuery()
 
     assertEquals("MATCH (n:`Person`) RETURN n.name AS name, n.bornDate AS bornDate", query)
@@ -86,7 +86,7 @@ class Neo4jQueryServiceTest {
 
     val query: String = new Neo4jQueryService(
       neo4jOptions,
-      new Neo4jQueryReadStrategy(Array.empty[Filter], PartitionSkipLimit(0, -1, -1), List("<id>"))
+      new Neo4jQueryReadStrategy(Array.empty[Filter], PartitionSkipLimit.EMPTY, List("<id>"))
     ).createQuery()
 
     assertEquals("MATCH (n:`Person`) RETURN id(n) AS `<id>`", query)
@@ -171,7 +171,7 @@ class Neo4jQueryServiceTest {
 
     val query: String = new Neo4jQueryService(neo4jOptions, new Neo4jQueryReadStrategy(
       Array[Filter](),
-      PartitionSkipLimit(0, -1, -1),
+      PartitionSkipLimit.EMPTY,
       List("source.name")
     )).createQuery()
 
@@ -192,7 +192,7 @@ class Neo4jQueryServiceTest {
 
     val query: String = new Neo4jQueryService(neo4jOptions, new Neo4jQueryReadStrategy(
       Array[Filter](),
-      PartitionSkipLimit(0, -1, -1),
+      PartitionSkipLimit.EMPTY,
       List("source.name", "<source.id>")
     )).createQuery()
 
@@ -213,7 +213,7 @@ class Neo4jQueryServiceTest {
 
     val query: String = new Neo4jQueryService(neo4jOptions, new Neo4jQueryReadStrategy(
       Array[Filter](),
-      PartitionSkipLimit(0, -1, -1),
+      PartitionSkipLimit.EMPTY,
       List("source.name", "source.id", "rel.someprops", "target.date")
     )).createQuery()
 

--- a/src/test/scala/org/neo4j/spark/service/Neo4jQueryServiceTest.scala
+++ b/src/test/scala/org/neo4j/spark/service/Neo4jQueryServiceTest.scala
@@ -1,10 +1,10 @@
-package org.neo4j.spark
+package org.neo4j.spark.service
 
 import org.apache.spark.sql.SaveMode
-import org.apache.spark.sql.sources.{And, EqualNullSafe, EqualTo, Filter, GreaterThanOrEqual, LessThan, Not, Or, StringEndsWith, StringStartsWith}
+import org.apache.spark.sql.sources._
 import org.junit.Assert._
 import org.junit.Test
-import org.neo4j.spark.service.{Neo4jQueryReadStrategy, Neo4jQueryService, Neo4jQueryWriteStrategy}
+import org.neo4j.spark.{Neo4jOptions, QueryType}
 
 class Neo4jQueryServiceTest {
 
@@ -30,6 +30,51 @@ class Neo4jQueryServiceTest {
     val query: String = new Neo4jQueryService(neo4jOptions, new Neo4jQueryReadStrategy).createQuery()
 
     assertEquals("MATCH (n:`Person`:`Player`:`Midfield`) RETURN n", query)
+  }
+
+  @Test
+  def testNodeOneLabelWithOneSelectedColumn(): Unit = {
+    val options: java.util.Map[String, String] = new java.util.HashMap[String, String]()
+    options.put(Neo4jOptions.URL, "bolt://localhost")
+    options.put(QueryType.LABELS.toString.toLowerCase, "Person")
+    val neo4jOptions: Neo4jOptions = new Neo4jOptions(options)
+
+    val query: String = new Neo4jQueryService(
+      neo4jOptions,
+      new Neo4jQueryReadStrategy(Array.empty[Filter], PartitionSkipLimit(0, -1, -1), Seq("name"))
+    ).createQuery()
+
+    assertEquals("MATCH (n:`Person`) RETURN n.name AS name", query)
+  }
+
+  @Test
+  def testNodeOneLabelWithMultipleColumnSelected(): Unit = {
+    val options: java.util.Map[String, String] = new java.util.HashMap[String, String]()
+    options.put(Neo4jOptions.URL, "bolt://localhost")
+    options.put(QueryType.LABELS.toString.toLowerCase, "Person")
+    val neo4jOptions: Neo4jOptions = new Neo4jOptions(options)
+
+    val query: String = new Neo4jQueryService(
+      neo4jOptions,
+      new Neo4jQueryReadStrategy(Array.empty[Filter], PartitionSkipLimit(0, -1, -1), List("name", "bornDate"))
+    ).createQuery()
+
+    assertEquals("MATCH (n:`Person`) RETURN n.name AS name, n.bornDate AS bornDate", query)
+  }
+
+  @Test
+  def testNodeOneLabelWithInternalIdSelected(): Unit = {
+    val options: java.util.Map[String, String] = new java.util.HashMap[String, String]()
+    options.put(Neo4jOptions.URL, "bolt://localhost")
+    options.put(QueryType.LABELS.toString.toLowerCase, "Person")
+    val neo4jOptions: Neo4jOptions = new Neo4jOptions(options)
+
+    val query: String = new Neo4jQueryService(
+      neo4jOptions,
+      new Neo4jQueryReadStrategy(Array.empty[Filter], PartitionSkipLimit(0, -1, -1), List("<id>"))
+    ).createQuery()
+
+    assertEquals("MATCH (n:`Person`) RETURN id(n) AS `<id>`", query)
   }
 
   @Test
@@ -100,6 +145,48 @@ class Neo4jQueryServiceTest {
   }
 
   @Test
+  def testRelationshipWithOneColumnSelected(): Unit = {
+    val options: java.util.Map[String, String] = new java.util.HashMap[String, String]()
+    options.put(Neo4jOptions.URL, "bolt://localhost")
+    options.put("relationship", "KNOWS")
+    options.put("relationship.nodes.map", "false")
+    options.put("relationship.source.labels", "Person")
+    options.put("relationship.target.labels", "Person")
+    val neo4jOptions: Neo4jOptions = new Neo4jOptions(options)
+
+    val query: String = new Neo4jQueryService(neo4jOptions, new Neo4jQueryReadStrategy(
+      Array[Filter](),
+      PartitionSkipLimit(0, -1, -1),
+      List("source.name")
+    )).createQuery()
+
+    assertEquals("MATCH (source:`Person`) " +
+      "MATCH (target:`Person`) " +
+      "MATCH (source)-[rel:`KNOWS`]->(target) RETURN source.name AS `source.name`", query)
+  }
+
+  @Test
+  def testRelationshipWithOneMoreColumnsSelected(): Unit = {
+    val options: java.util.Map[String, String] = new java.util.HashMap[String, String]()
+    options.put(Neo4jOptions.URL, "bolt://localhost")
+    options.put("relationship", "KNOWS")
+    options.put("relationship.nodes.map", "false")
+    options.put("relationship.source.labels", "Person")
+    options.put("relationship.target.labels", "Person")
+    val neo4jOptions: Neo4jOptions = new Neo4jOptions(options)
+
+    val query: String = new Neo4jQueryService(neo4jOptions, new Neo4jQueryReadStrategy(
+      Array[Filter](),
+      PartitionSkipLimit(0, -1, -1),
+      List("source.name", "source.id", "rel.someprops", "target.date")
+    )).createQuery()
+
+    assertEquals("MATCH (source:`Person`) " +
+      "MATCH (target:`Person`) " +
+      "MATCH (source)-[rel:`KNOWS`]->(target) RETURN source.name AS `source.name`, source.id AS `source.id`, rel.someprops AS `rel.someprops`, target.date AS `target.date`", query)
+  }
+
+  @Test
   def testRelationshipFilterEqualTo(): Unit = {
     val options: java.util.Map[String, String] = new java.util.HashMap[String, String]()
     options.put(Neo4jOptions.URL, "bolt://localhost")
@@ -117,7 +204,7 @@ class Neo4jQueryServiceTest {
 
     assertEquals("MATCH (source:`Person`) " +
       "MATCH (target:`Person`) " +
-      "MATCH (source)-[rel:`KNOWS`]->(target) WHERE source.name = 'John Doe' RETURN source, rel, target", query)
+      "MATCH (source)-[rel:`KNOWS`]->(target) WHERE source.name = 'John Doe' RETURN rel, source AS source, target AS target", query)
   }
 
   @Test
@@ -138,7 +225,30 @@ class Neo4jQueryServiceTest {
 
     assertEquals("MATCH (source:`Person`) " +
       "MATCH (target:`Person`) " +
-      "MATCH (source)-[rel:`KNOWS`]->(target) WHERE (source.name = 'John Doe' OR target.name = 'John Doe') RETURN source, rel, target", query)
+      "MATCH (source)-[rel:`KNOWS`]->(target) WHERE (source.name = 'John Doe' OR target.name = 'John Doe') RETURN rel, source AS source, target AS target", query)
+  }
+
+  @Test
+  def testRelationshipAndFilterEqualTo(): Unit = {
+    val options: java.util.Map[String, String] = new java.util.HashMap[String, String]()
+    options.put(Neo4jOptions.URL, "bolt://localhost")
+    options.put("relationship", "KNOWS")
+    options.put("relationship.nodes.map", "true")
+    options.put("relationship.source.labels", "Person")
+    options.put("relationship.target.labels", "Person")
+    val neo4jOptions: Neo4jOptions = new Neo4jOptions(options)
+
+    val filters: Array[Filter] = Array[Filter](
+      EqualTo("source.id", "14"),
+      EqualTo("target.id", "16")
+    )
+
+    val query: String = new Neo4jQueryService(neo4jOptions, new Neo4jQueryReadStrategy(filters)).createQuery()
+
+    assertEquals(
+      "MATCH (source:`Person`) MATCH (target:`Person`) MATCH (source)-[rel:`KNOWS`]->(target) " +
+        "WHERE (source.id = '14' AND target.id = '16') " +
+        "RETURN rel, source AS source, target AS target", query)
   }
 
   @Test
@@ -188,7 +298,7 @@ class Neo4jQueryServiceTest {
       "WHERE ((source.name = 'John Doe' OR target.name = 'John Doraemon' OR source.name = 'Jane Doe') " +
       "AND (target.age = 34 OR target.age = 18) " +
       "AND rel.score = 12) " +
-      "RETURN source, rel, target", query)
+      "RETURN rel, source AS source, target AS target", query)
   }
 
   @Test
@@ -215,7 +325,7 @@ class Neo4jQueryServiceTest {
       "WHERE ((source.name = 'John Doe' OR target.name = 'John Doraemon' OR source.name = 'Jane Doe') " +
       "AND (target.age = 34 OR target.age = 18) " +
       "AND rel.score = 12) " +
-      "RETURN source, rel, target", query)
+      "RETURN rel, source AS source, target AS target", query)
   }
 
   @Test

--- a/src/test/scala/org/neo4j/spark/service/Neo4jQueryServiceTest.scala
+++ b/src/test/scala/org/neo4j/spark/service/Neo4jQueryServiceTest.scala
@@ -33,6 +33,21 @@ class Neo4jQueryServiceTest {
   }
 
   @Test
+  def testNodeLabelWithNoSelectedColumns(): Unit = {
+    val options: java.util.Map[String, String] = new java.util.HashMap[String, String]()
+    options.put(Neo4jOptions.URL, "bolt://localhost")
+    options.put(QueryType.LABELS.toString.toLowerCase, "Person")
+    val neo4jOptions: Neo4jOptions = new Neo4jOptions(options)
+
+    val query: String = new Neo4jQueryService(
+      neo4jOptions,
+      new Neo4jQueryReadStrategy(Array.empty[Filter], PartitionSkipLimit(0, -1, -1), Seq())
+    ).createQuery()
+
+    assertEquals("MATCH (n:`Person`) RETURN n", query)
+  }
+
+  @Test
   def testNodeOneLabelWithOneSelectedColumn(): Unit = {
     val options: java.util.Map[String, String] = new java.util.HashMap[String, String]()
     options.put(Neo4jOptions.URL, "bolt://localhost")


### PR DESCRIPTION
Fixes #172

This can reduce the amount of data moved from Neo4j to Spark by reducing the number of columns selected by Neo4j.