### PR TITLE
fix antora lint errors preventing docs deploy

### DIFF
--- a/doc/docs/modules/ROOT/pages/quickstart.adoc
+++ b/doc/docs/modules/ROOT/pages/quickstart.adoc
@@ -66,7 +66,7 @@ For complete details on type handling, consult the xref::types.adoc[Neo4j-Spark 
 |Type |Struct
 
 |Duration
-a|[small]
+a|
 ----
 Struct(Array(
     ("type", DataTypes.StringType, false),
@@ -79,7 +79,7 @@ Struct(Array(
 ----
 
 |Point
-a|[small]
+a|
 ----
 Struct(Array(
     ("type", DataTypes.StringType, false),
@@ -91,7 +91,7 @@ Struct(Array(
 ----
 
 |Time
-a|[small]
+a|
 ----
 Struct(Array(
     ("type", DataTypes.StringType, false),


### PR DESCRIPTION
docs cannot be deployed to the Neo4j docs site due to lint errors in the build pipeline; this small PR resolves them so that @adam-cowley can help us bring docs live.