### PR TITLE
fixes #254: Returning a function from a query breaks in 3.5

### DIFF
--- a/src/main/scala/org/neo4j/spark/service/SchemaService.scala
+++ b/src/main/scala/org/neo4j/spark/service/SchemaService.scala
@@ -212,7 +212,11 @@ class SchemaService(private val options: Neo4jOptions, private val driverCache: 
       // specified by the RETURN statement
       columns.map(StructField(_, DataTypes.StringType))
     } else {
-      columns.map(c => structFields.find(_.name.quote().equals(c.quote())).get)
+      try {
+        columns.map(c => structFields.find(_.name.quote().equals(c.quote())).get)
+      } catch {
+        case _: Throwable => structFields.toArray
+      }
     }
 
     StructType(sortedStructFields)

--- a/src/test/scala/org/neo4j/spark/DataSourceReaderNeo4j41xWithApocTSE.scala
+++ b/src/test/scala/org/neo4j/spark/DataSourceReaderNeo4j41xWithApocTSE.scala
@@ -1,0 +1,32 @@
+package org.neo4j.spark
+
+import org.junit.Assert.assertEquals
+import org.junit.{Assume, BeforeClass, Test}
+
+object DataSourceReaderNeo4j41xWithApocTSE {
+  @BeforeClass
+  def checkNeo4jVersion() {
+    val neo4jVersion = TestUtil.neo4jVersion()
+    Assume.assumeTrue(!neo4jVersion.startsWith("3.5") && !neo4jVersion.startsWith("4.0"))
+  }
+}
+
+class DataSourceReaderNeo4j41xWithApocTSE extends SparkConnectorScalaBaseWithApocTSE {
+
+  @Test
+  def testReturnProcedure(): Unit = {
+    val query =
+      """RETURN apoc.convert.toSet([1,1,3]) AS foo, 'bar' AS bar
+        |""".stripMargin
+
+    val df = ss.read.format(classOf[DataSource].getName)
+      .option("url", SparkConnectorScalaSuiteWithApocIT.server.getBoltUrl)
+      .option("partitions", 1)
+      .option("query", query)
+      .load
+
+    assertEquals(Seq("foo", "bar"), df.columns.toSeq) // ordering should be preserved
+    assertEquals(1, df.count())
+  }
+
+}

--- a/src/test/scala/org/neo4j/spark/DataSourceReaderWithApocTSE.scala
+++ b/src/test/scala/org/neo4j/spark/DataSourceReaderWithApocTSE.scala
@@ -910,6 +910,22 @@ class DataSourceReaderWithApocTSE extends SparkConnectorScalaBaseWithApocTSE {
     assertEquals(100, partitionedDf.collect().map(_.getAs[Long]("<rel.id>")).toSet.size)
   }
 
+  @Test
+  def testReturnProcedure(): Unit = {
+    val query =
+      """RETURN apoc.convert.toSet([1,1,3]) AS foo, 'bar' AS bar
+        |""".stripMargin
+
+    val df = ss.read.format(classOf[DataSource].getName)
+      .option("url", SparkConnectorScalaSuiteWithApocIT.server.getBoltUrl)
+      .option("partitions", 1)
+      .option("query", query)
+      .load
+
+    assertEquals(Set("foo", "bar"), df.columns.toSet)
+    assertEquals(1, df.count())
+  }
+
   private def initTest(query: String): DataFrame = {
     SparkConnectorScalaSuiteWithApocIT.session()
       .writeTransaction(


### PR DESCRIPTION
Fixes #254 

Added a fallback mechanism in case the argument parse fails.