### PR TITLE
Fixes #284: leverage Spark Config as default configuration values

### DIFF
--- a/common/src/main/scala/org/neo4j/spark/util/Neo4jOptions.scala
+++ b/common/src/main/scala/org/neo4j/spark/util/Neo4jOptions.scala
@@ -1,19 +1,37 @@
 package org.neo4j.spark.util
 
-import org.apache.spark.sql.SaveMode
+import org.apache.spark.sql.{SaveMode, SparkSession}
 import org.neo4j.driver.Config.TrustStrategy
 import org.neo4j.driver._
 
 import java.io.File
 import java.net.URI
+import java.util
 import java.util.UUID
 import java.util.concurrent.TimeUnit
 import scala.collection.JavaConverters._
 
 
-class Neo4jOptions(private val parameters: java.util.Map[String, String]) extends Serializable {
+class Neo4jOptions(private val options: java.util.Map[String, String]) extends Serializable {
   import Neo4jOptions._
   import QueryType._
+
+  private def parameters: util.Map[String, String] = {
+    val params = new util.HashMap[String, String]()
+
+      params.putAll(SparkSession.getActiveSession
+      .map { _.conf
+        .getAll
+        .filterKeys(k => k.startsWith("neo4j."))
+        .map { elem => (elem._1.substring("neo4.".length + 1), elem._2) }
+        .toMap
+      }
+      .getOrElse(Map.empty)
+      .asJava)
+
+    params.putAll(options)
+    params
+  }
 
   private def getRequiredParameter(parameter: String): String = {
     if (!parameters.containsKey(parameter) || parameters.get(parameter).isEmpty) {

--- a/common/src/main/scala/org/neo4j/spark/util/Neo4jOptions.scala
+++ b/common/src/main/scala/org/neo4j/spark/util/Neo4jOptions.scala
@@ -17,9 +17,7 @@ class Neo4jOptions(private val options: java.util.Map[String, String]) extends S
   import QueryType._
 
   private def parameters: util.Map[String, String] = {
-    val params = new util.HashMap[String, String]()
-
-      params.putAll(SparkSession.getActiveSession
+    val sparkOptions = SparkSession.getActiveSession
       .map { _.conf
         .getAll
         .filterKeys(k => k.startsWith("neo4j."))
@@ -27,10 +25,9 @@ class Neo4jOptions(private val options: java.util.Map[String, String]) extends S
         .toMap
       }
       .getOrElse(Map.empty)
-      .asJava)
 
-    params.putAll(options)
-    params
+
+    (sparkOptions ++ options.asScala).asJava
   }
 
   private def getRequiredParameter(parameter: String): String = {

--- a/doc/docs/modules/ROOT/pages/configuration.adoc
+++ b/doc/docs/modules/ROOT/pages/configuration.adoc
@@ -19,6 +19,32 @@ val df = spark.read.format("org.neo4j.spark.DataSource")
         .load()
 ----
 
+Alternatively, you can specify a global configuration in the Spark Session, to avoid retyping connection options every time.
+You can set any Neo4j Connector option, just preped it with `neo4j.`.
+
+For example if you want to set the option `authentication.type` in the session, you have to type `neo4j.authentication.type`.
+Here's a full example:
+
+[source,scala]
+----
+import org.apache.spark.sql.{SaveMode, SparkSession}
+
+val spark = SparkSession.builder()
+    .config("neo4j.url", "bolt://localhost:7687")
+    .config("neo4j.authentication.type", "basic")
+    .config("neo4j.authentication.basic.username", "myuser")
+    .config("neo4j.authentication.basic.password", "neo4jpassword")
+    .getOrCreate()
+
+val dfPerson = spark.read.format("org.neo4j.spark.DataSource")
+        .option("labels", "Person")
+        .load()
+
+val dfProduct = spark.read.format("org.neo4j.spark.DataSource")
+        .option("labels", "Product")
+        .load()
+----
+
 == Neo4j Driver Options
 
 Under the covers, the spark connector uses the link:https://neo4j.com/docs/driver-manual/current/get-started/#driver-get-started-about[official Neo4j Java Driver].  As such, in many situations you'll want the control to set driver options to account for your production deployment of Neo4j, and how to communicate with it.   This is done using the `options` example above.

--- a/doc/docs/modules/ROOT/pages/configuration.adoc
+++ b/doc/docs/modules/ROOT/pages/configuration.adoc
@@ -45,6 +45,22 @@ val dfProduct = spark.read.format("org.neo4j.spark.DataSource")
         .load()
 ----
 
+== Configuration on Databricks
+
+On Databricks you can't set Session configuration at runtime, but you can set Spark configuration on the Cluster you're running your notebooks on.
+To do this go on the cluster configuration page, click the _Advanced Options_ toggle and then the _Spark_ tab.
+
+Add the Neo4j Connector configuration in the text area like this:
+
+----
+neo4j.url bolt://1.2.3.4
+neo4j.authentication.type basic
+neo4j.authentication.basic.password mysecret
+neo4j.authentication.basic.username neo4j
+----
+
+
+
 == Neo4j Driver Options
 
 Under the covers, the spark connector uses the link:https://neo4j.com/docs/driver-manual/current/get-started/#driver-get-started-about[official Neo4j Java Driver].  As such, in many situations you'll want the control to set driver options to account for your production deployment of Neo4j, and how to communicate with it.   This is done using the `options` example above.

--- a/spark-2.4/src/test/scala/org/neo4j/spark/DefaultConfigTSE.scala
+++ b/spark-2.4/src/test/scala/org/neo4j/spark/DefaultConfigTSE.scala
@@ -1,0 +1,28 @@
+package org.neo4j.spark
+
+import org.junit.Assert.assertEquals
+import org.junit.Test
+import org.neo4j.driver.{Transaction, TransactionWork}
+import org.neo4j.driver.summary.ResultSummary
+
+class DefaultConfigTSE extends SparkConnectorScalaBaseTSE {
+
+  @Test
+  def `when session has default parameters it should use those instead of requiring options`(): Unit = {
+
+    SparkConnectorScalaSuiteIT.session()
+      .writeTransaction(
+        new TransactionWork[ResultSummary] {
+          override def execute(tx: Transaction): ResultSummary = tx.run("CREATE (p:Person {name: 'Foobar'})").consume()
+        })
+
+    ss.conf.set("neo4j.url", SparkConnectorScalaSuiteIT.server.getBoltUrl)
+
+    val df = ss.read.format(classOf[DataSource].getName)
+      .option("labels", "Person")
+      .load()
+
+    assertEquals(df.count(), 1)
+  }
+
+}

--- a/spark-2.4/src/test/scala/org/neo4j/spark/SparkConnector24ScalaSuiteIT.scala
+++ b/spark-2.4/src/test/scala/org/neo4j/spark/SparkConnector24ScalaSuiteIT.scala
@@ -10,6 +10,7 @@ import org.junit.runners.Suite
   classOf[DataSourceReaderNeo4j4xTSE],
   classOf[DataSourceWriterTSE],
   classOf[DataSourceWriterNeo4j4xTSE],
-  classOf[DataSourceReaderNeo4j35xTSE]
+  classOf[DataSourceReaderNeo4j35xTSE],
+  classOf[DefaultConfigTSE]
 ))
 class SparkConnector24ScalaSuiteIT extends SparkConnectorScalaSuiteIT {}

--- a/spark-3/src/test/scala/org/neo4j/spark/DefaultConfigTSE.scala
+++ b/spark-3/src/test/scala/org/neo4j/spark/DefaultConfigTSE.scala
@@ -1,0 +1,28 @@
+package org.neo4j.spark
+
+import org.junit.Assert.assertEquals
+import org.junit.Test
+import org.neo4j.driver.{Transaction, TransactionWork}
+import org.neo4j.driver.summary.ResultSummary
+
+class DefaultConfigTSE extends SparkConnectorScalaBaseTSE {
+
+  @Test
+  def `when session has default parameters it should use those instead of requiring options`(): Unit = {
+
+    SparkConnectorScalaSuiteIT.session()
+      .writeTransaction(
+        new TransactionWork[ResultSummary] {
+          override def execute(tx: Transaction): ResultSummary = tx.run("CREATE (p:Person {name: 'Foobar'})").consume()
+        })
+
+    ss.conf.set("neo4j.url", SparkConnectorScalaSuiteIT.server.getBoltUrl)
+
+    val df = ss.read.format(classOf[DataSource].getName)
+      .option("labels", "Person")
+      .load()
+
+    assertEquals(df.count(), 1)
+  }
+
+}

--- a/spark-3/src/test/scala/org/neo4j/spark/SparkConnector30ScalaSuiteIT.scala
+++ b/spark-3/src/test/scala/org/neo4j/spark/SparkConnector30ScalaSuiteIT.scala
@@ -10,6 +10,7 @@ import org.junit.runners.Suite
   classOf[DataSourceReaderNeo4j4xTSE],
   classOf[DataSourceWriterNeo4j4xTSE],
   classOf[DataSourceReaderNeo4j35xTSE],
-  classOf[DataSourceWriterTSE]
+  classOf[DataSourceWriterTSE],
+  classOf[DefaultConfigTSE]
 ))
 class SparkConnector30ScalaSuiteIT extends SparkConnectorScalaSuiteIT {}


### PR DESCRIPTION
Fixes #284


Had to change the code a bit since the configurations set via `ss.conf.set()` are not available in the sparkContext.