### PR TITLE
Fixes #285: Add version check for Spark

### DIFF
--- a/.github/workflows/python-ci.yml
+++ b/.github/workflows/python-ci.yml
@@ -1,4 +1,4 @@
-name: Python Tests for Spark
+name: Python CI
 
 on:
   push:
@@ -12,6 +12,7 @@ jobs:
   test:
     runs-on: ubuntu-latest
     strategy:
+      fail-fast: false
       matrix:
         python-version: [ 3.6, 3.7, 3.8 ]
         neo4j-version: [ 3.5, 4.0, 4.1, 4.2 ]
@@ -27,12 +28,20 @@ jobs:
         uses: actions/setup-java@v1
         with:
           java-version: 1.8
+      - name: Cache Maven packages
+        uses: actions/cache@v1
+        with:
+          path: ~/.m2
+          key: ${{ runner.os }}-m2-${{ hashFiles('**/pom.xml') }}
+          restore-keys: ${{ runner.os }}-m2
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
           pip install pypandoc
           pip install pyspark==${{ matrix.spark-version.ext }} "testcontainers[neo4j]"
       - name: Build artifact
+        env:
+          CI: true
         run: |
           ./mvnw clean package -DskipTests -P spark-${{ matrix.spark-version.short }} -P scala-2.12 --no-transfer-progress
       - name: Run tests for Spark ${{ matrix.spark-version.ext }} and Neo4j ${{ matrix.neo4j-version }}

--- a/.github/workflows/python-tests.yml
+++ b/.github/workflows/python-tests.yml
@@ -34,7 +34,7 @@ jobs:
           pip install pyspark==${{ matrix.spark-version.ext }} "testcontainers[neo4j]"
       - name: Build artifact
         run: |
-          ./mvnw clean package -DskipTests -P spark-${{ matrix.spark-version }} -P scala-2.12 --no-transfer-progress
+          ./mvnw clean package -DskipTests -P spark-${{ matrix.spark-version.short }} -P scala-2.12 --no-transfer-progress
       - name: Run tests for Spark ${{ matrix.spark-version.ext }} and Neo4j ${{ matrix.neo4j-version }}
         if: ${{ ! (matrix.spark-version.short == 2.4 && matrix.python-version == 3.8) }}
         run: |

--- a/common/src/main/scala/org/neo4j/spark/util/Validations.scala
+++ b/common/src/main/scala/org/neo4j/spark/util/Validations.scala
@@ -9,14 +9,14 @@ import org.neo4j.spark.util.Neo4jImplicits.StructTypeImplicit
 
 object Validations extends Logging {
 
-  def version(supportedVersions: Seq[String]): Unit = {
+  def version(supportedVersions: String*): Unit = {
     val sparkVersion = SparkSession.getActiveSession
       .map { _.version }
       .getOrElse("UNKNOWN")
 
     ValidationUtil.isTrue(
-      sparkVersion == "UNKNOWN" || supportedVersions.contains(sparkVersion.split('.').slice(0, 2).mkString(".")),
-      s"""You current Spark version ${sparkVersion} is not supported by the current connector.
+      sparkVersion == "UNKNOWN" || supportedVersions.exists(sparkVersion.matches),
+      s"""Your currentSpark version ${sparkVersion} is not supported by the current connector.
        |Please visit https://neo4j.com/developer/spark/overview/#_spark_compatibility to know which connector version you need.
        |""".stripMargin
     )

--- a/common/src/main/scala/org/neo4j/spark/util/Validations.scala
+++ b/common/src/main/scala/org/neo4j/spark/util/Validations.scala
@@ -15,7 +15,7 @@ object Validations extends Logging {
       .getOrElse("UNKNOWN")
 
     ValidationUtil.isTrue(
-      sparkVersion != "UNKNOWN" && supportedVersions.contains(sparkVersion.split('.').slice(0, 2).mkString(".")),
+      sparkVersion == "UNKNOWN" || supportedVersions.contains(sparkVersion.split('.').slice(0, 2).mkString(".")),
       s"""You current Spark version ${sparkVersion} is not supported by the current connector.
        |Please visit https://neo4j.com/developer/spark/overview/#_spark_compatibility to know which connector version you need.
        |""".stripMargin

--- a/common/src/main/scala/org/neo4j/spark/util/Validations.scala
+++ b/common/src/main/scala/org/neo4j/spark/util/Validations.scala
@@ -1,16 +1,26 @@
 package org.neo4j.spark.util
 
 import org.apache.spark.internal.Logging
-import org.apache.spark.sql.SaveMode
+import org.apache.spark.sql.{SaveMode, SparkSession}
 import org.apache.spark.sql.types.StructType
 import org.neo4j.driver.{AccessMode, Session}
 import org.neo4j.spark.service.{Neo4jQueryStrategy, SchemaService}
 import org.neo4j.spark.util.Neo4jImplicits.StructTypeImplicit
-import org.neo4j.spark._
-
-import java.util.concurrent.Callable
 
 object Validations extends Logging {
+
+  def version(supportedVersions: Seq[String]): Unit = {
+    val sparkVersion = SparkSession.getActiveSession
+      .map { _.version }
+      .getOrElse("UNKNOWN")
+
+    ValidationUtil.isTrue(
+      sparkVersion != "UNKNOWN" && supportedVersions.contains(sparkVersion.split('.').slice(0, 2).mkString(".")),
+      s"""You current Spark version ${sparkVersion} is not supported by the current connector.
+       |Please visit https://neo4j.com/developer/spark/overview/#_spark_compatibility to know which connector version you need.
+       |""".stripMargin
+    )
+  }
 
   val writer: (Neo4jOptions, String, SaveMode, Neo4jOptions => Unit) => Unit = { (neo4jOptions, jobId, saveMode, customValidation) =>
     ValidationUtil.isFalse(neo4jOptions.session.accessMode == AccessMode.READ,

--- a/doc/docs/modules/ROOT/pages/faq.adoc
+++ b/doc/docs/modules/ROOT/pages/faq.adoc
@@ -83,3 +83,15 @@ and that is the default save mode.
 So please, change the save mode to one of `SaveMode.Append` or `SaveMode.Overwrite`.
 
 We are working to fully support all the Save Mode on Spark 3.
+
+== I'm getting a NoClassDefFoundError or ClassNotFoundException.
+
+If you see this type of error:
+
+----
+NoClassDefFoundError: org/apache/spark/sql/sources/v2/ReadSupport
+Caused by: ClassNotFoundException: org.apache.spark.sql.sources.v2.ReadSupport
+----
+
+This means that your Spark version doesn't match the Spark version on the connector.
+Please refer to xref:overview.adoc#_spark_compatibility[this page] to know which version you need.

--- a/spark-2.4/src/main/scala/org/neo4j/spark/DataSource.scala
+++ b/spark-2.4/src/main/scala/org/neo4j/spark/DataSource.scala
@@ -7,10 +7,12 @@ import org.apache.spark.sql.sources.v2.writer.DataSourceWriter
 import org.apache.spark.sql.sources.v2.{DataSourceOptions, DataSourceV2, ReadSupport, WriteSupport}
 import org.apache.spark.sql.types.StructType
 import org.neo4j.spark.reader.Neo4jDataSourceReader
-import org.neo4j.spark.util.Neo4jOptions
+import org.neo4j.spark.util.{Neo4jOptions, Validations}
 import org.neo4j.spark.writer.Neo4jDataSourceWriter
 
 class DataSource extends DataSourceV2 with ReadSupport with DataSourceRegister with WriteSupport {
+
+  Validations.version(Seq("2.4"))
 
   private val jobId: String = UUID.randomUUID().toString
 

--- a/spark-2.4/src/main/scala/org/neo4j/spark/DataSource.scala
+++ b/spark-2.4/src/main/scala/org/neo4j/spark/DataSource.scala
@@ -12,7 +12,7 @@ import org.neo4j.spark.writer.Neo4jDataSourceWriter
 
 class DataSource extends DataSourceV2 with ReadSupport with DataSourceRegister with WriteSupport {
 
-  Validations.version("2.4")
+  Validations.version("2.4.*")
 
   private val jobId: String = UUID.randomUUID().toString
 

--- a/spark-2.4/src/main/scala/org/neo4j/spark/DataSource.scala
+++ b/spark-2.4/src/main/scala/org/neo4j/spark/DataSource.scala
@@ -12,7 +12,7 @@ import org.neo4j.spark.writer.Neo4jDataSourceWriter
 
 class DataSource extends DataSourceV2 with ReadSupport with DataSourceRegister with WriteSupport {
 
-  Validations.version(Seq("2.4"))
+  Validations.version("2.4")
 
   private val jobId: String = UUID.randomUUID().toString
 

--- a/spark-2.4/src/test/scala/org/neo4j/spark/VersionValidationTSE.scala
+++ b/spark-2.4/src/test/scala/org/neo4j/spark/VersionValidationTSE.scala
@@ -1,0 +1,23 @@
+package org.neo4j.spark
+
+import org.junit.Assert.{assertEquals, fail}
+import org.junit.Test
+import org.neo4j.spark.util.Validations
+
+class VersionValidationTSE extends SparkConnectorScalaBaseTSE {
+
+  @Test
+  def testThrowsExceptionSparkVersionIsNotSupported(): Unit = {
+    try {
+      Validations.version(Seq("3.0", "3.1"))
+    } catch {
+      case e: IllegalArgumentException =>
+        assertEquals(
+          """You current Spark version 2.4.5 is not supported by the current connector.
+            |Please visit https://neo4j.com/developer/spark/overview/#_spark_compatibility to know which connector version you need.
+            |""".stripMargin, e.getMessage)
+      case _: Throwable => fail(s"should be thrown a ${classOf[IllegalArgumentException].getName}")
+    }
+  }
+
+}

--- a/spark-2.4/src/test/scala/org/neo4j/spark/VersionValidationTSE.scala
+++ b/spark-2.4/src/test/scala/org/neo4j/spark/VersionValidationTSE.scala
@@ -13,7 +13,7 @@ class VersionValidationTSE extends SparkConnectorScalaBaseTSE {
     } catch {
       case e: IllegalArgumentException =>
         assertEquals(
-          """You current Spark version 2.4.5 is not supported by the current connector.
+          """Your currentSpark version 2.4.5 is not supported by the current connector.
             |Please visit https://neo4j.com/developer/spark/overview/#_spark_compatibility to know which connector version you need.
             |""".stripMargin, e.getMessage)
       case _: Throwable => fail(s"should be thrown a ${classOf[IllegalArgumentException].getName}")

--- a/spark-2.4/src/test/scala/org/neo4j/spark/VersionValidationTSE.scala
+++ b/spark-2.4/src/test/scala/org/neo4j/spark/VersionValidationTSE.scala
@@ -9,7 +9,7 @@ class VersionValidationTSE extends SparkConnectorScalaBaseTSE {
   @Test
   def testThrowsExceptionSparkVersionIsNotSupported(): Unit = {
     try {
-      Validations.version(Seq("3.0", "3.1"))
+      Validations.version("3.*")
     } catch {
       case e: IllegalArgumentException =>
         assertEquals(

--- a/spark-3/src/main/scala/org/neo4j/spark/DataSource.scala
+++ b/spark-3/src/main/scala/org/neo4j/spark/DataSource.scala
@@ -13,7 +13,7 @@ import org.neo4j.spark.util.{DriverCache, Neo4jOptions, Validations}
 class DataSource extends TableProvider
   with DataSourceRegister {
 
-  Validations.version(Seq("3.0", "3.1"))
+  Validations.version("3.*")
 
   private val jobId: String = UUID.randomUUID().toString
 

--- a/spark-3/src/main/scala/org/neo4j/spark/DataSource.scala
+++ b/spark-3/src/main/scala/org/neo4j/spark/DataSource.scala
@@ -8,10 +8,12 @@ import org.apache.spark.sql.types.StructType
 import org.apache.spark.sql.util.CaseInsensitiveStringMap
 import org.neo4j.spark.service.SchemaService
 import org.neo4j.spark.util.Validations.validateConnection
-import org.neo4j.spark.util.{DriverCache, Neo4jOptions}
+import org.neo4j.spark.util.{DriverCache, Neo4jOptions, Validations}
 
 class DataSource extends TableProvider
   with DataSourceRegister {
+
+  Validations.version(Seq("3.0", "3.1"))
 
   private val jobId: String = UUID.randomUUID().toString
 

--- a/spark-3/src/test/scala/org/neo4j/spark/VersionValidationTSE.scala
+++ b/spark-3/src/test/scala/org/neo4j/spark/VersionValidationTSE.scala
@@ -9,7 +9,7 @@ class VersionValidationTSE extends SparkConnectorScalaBaseTSE {
   @Test
   def testThrowsExceptionSparkVersionIsNotSupported(): Unit = {
     try {
-      Validations.version(Seq("2.4"))
+      Validations.version("2.4")
     } catch {
       case e: IllegalArgumentException =>
         assertEquals(

--- a/spark-3/src/test/scala/org/neo4j/spark/VersionValidationTSE.scala
+++ b/spark-3/src/test/scala/org/neo4j/spark/VersionValidationTSE.scala
@@ -13,7 +13,7 @@ class VersionValidationTSE extends SparkConnectorScalaBaseTSE {
     } catch {
       case e: IllegalArgumentException =>
         assertEquals(
-          """You current Spark version 3.1.1 is not supported by the current connector.
+          """Your currentSpark version 3.1.1 is not supported by the current connector.
             |Please visit https://neo4j.com/developer/spark/overview/#_spark_compatibility to know which connector version you need.
             |""".stripMargin, e.getMessage)
       case e: Throwable => fail(s"should be thrown a ${classOf[IllegalArgumentException].getName}, got ${e.getClass} instead")

--- a/spark-3/src/test/scala/org/neo4j/spark/VersionValidationTSE.scala
+++ b/spark-3/src/test/scala/org/neo4j/spark/VersionValidationTSE.scala
@@ -1,0 +1,23 @@
+package org.neo4j.spark
+
+import org.junit.Assert.{assertEquals, fail}
+import org.junit.Test
+import org.neo4j.spark.util.Validations
+
+class VersionValidationTSE extends SparkConnectorScalaBaseTSE {
+
+  @Test
+  def testThrowsExceptionSparkVersionIsNotSupported(): Unit = {
+    try {
+      Validations.version(Seq("2.4"))
+    } catch {
+      case e: IllegalArgumentException =>
+        assertEquals(
+          """You current Spark version 3.1.1 is not supported by the current connector.
+            |Please visit https://neo4j.com/developer/spark/overview/#_spark_compatibility to know which connector version you need.
+            |""".stripMargin, e.getMessage)
+      case e: Throwable => fail(s"should be thrown a ${classOf[IllegalArgumentException].getName}, got ${e.getClass} instead")
+    }
+  }
+
+}


### PR DESCRIPTION
Fixes #285 

The check between Spark 3 and Spark 2 (and viceversa) doesn't work properly. 
The version check is the entry point of the connector and is executed when the class DataSource is instantiated. Problem is the Spark 3 doesn't have some classes required by DataSource on Spark 2, and viceversa. In this was the DataSource is never instantiated and the process fails with an error like:

```
Caused by: ClassNotFoundException: org.apache.spark.sql.sources.v2.ReadSupport
```

The check is working between Spark 2.4 and Spark 2.3.

I left the check on connector for Spark 3 as well, throwing an exception if the Spark version is different from 3.0 or 3.1.


I added a FAQ in the docs explaining that type of error means there's a version conflict between Spark and the connector.