### PR TITLE
fixes #323: Node keys are ignored when the field is a map

### DIFF
--- a/common/src/main/scala/org/neo4j/spark/reader/BasePartitionReader.scala
+++ b/common/src/main/scala/org/neo4j/spark/reader/BasePartitionReader.scala
@@ -24,7 +24,7 @@ abstract class BasePartitionReader(private val options: Neo4jOptions,
   private val driverCache: DriverCache = new DriverCache(options.connection,
     if (partitionSkipLimit.partitionNumber > 0) s"$jobId-${partitionSkipLimit.partitionNumber}" else jobId)
 
-  private val query: String = new Neo4jQueryService(options, new Neo4jQueryReadStrategy(filters, partitionSkipLimit, requiredColumns.getFieldsName))
+  private val query: String = new Neo4jQueryService(options, new Neo4jQueryReadStrategy(filters, partitionSkipLimit, requiredColumns.fieldNames))
     .createQuery()
 
   private val mappingService = new MappingService(new Neo4jReadMappingStrategy(options, requiredColumns), options)

--- a/common/src/main/scala/org/neo4j/spark/service/MappingService.scala
+++ b/common/src/main/scala/org/neo4j/spark/service/MappingService.scala
@@ -30,9 +30,9 @@ class Neo4jWriteMappingStrategy(private val options: Neo4jOptions)
     query(row, schema)
       .forEach(new BiConsumer[String, AnyRef] {
         override def accept(key: String, value: AnyRef): Unit = if (options.nodeMetadata.nodeKeys.contains(key)) {
-          keys.put(key, value)
+          keys.put(options.nodeMetadata.nodeKeys.getOrElse(key, key), value)
         } else {
-          properties.put(key, value)
+          properties.put(options.nodeMetadata.nodeProps.getOrElse(key, key), value)
         }
       })
 

--- a/common/src/main/scala/org/neo4j/spark/util/Neo4jUtil.scala
+++ b/common/src/main/scala/org/neo4j/spark/util/Neo4jUtil.scala
@@ -20,6 +20,7 @@ import org.neo4j.spark.service.SchemaService
 import org.neo4j.spark.util.Neo4jImplicits.EntityImplicits
 import org.slf4j.Logger
 
+import org.neo4j.spark.util.Neo4jImplicits._
 import scala.collection.JavaConverters._
 
 object Neo4jUtil {
@@ -213,7 +214,7 @@ object Neo4jUtil {
 
   def flattenMap(map: java.util.Map[String, AnyRef],
                  prefix: String = ""): java.util.Map[String, AnyRef] = map.asScala.flatMap(t => {
-    val key = if (prefix != "") s"$prefix.${t._1}" else t._1
+    val key: String = if (prefix != "") s"${prefix.quote()}.${t._1.quote()}" else t._1.quote()
     t._2 match {
       case nestedMap: Map[String, AnyRef] => flattenMap(nestedMap.asJava, key).asScala.toSeq
       case _ => Seq((key, t._2))

--- a/common/src/test/scala/org/neo4j/spark/util/Neo4jImplicitsTest.scala
+++ b/common/src/test/scala/org/neo4j/spark/util/Neo4jImplicitsTest.scala
@@ -94,9 +94,11 @@ class Neo4jImplicitsTest {
 
   @Test
   def `struct should return true if contains fields`: Unit = {
-    val struct = StructType(Seq(StructField("is_hero", DataTypes.BooleanType), StructField("name", DataTypes.StringType)))
+    val struct = StructType(Seq(StructField("is_hero", DataTypes.BooleanType),
+      StructField("name", DataTypes.StringType),
+      StructField("fi``(╯°□°)╯︵ ┻━┻eld", DataTypes.StringType)))
 
-    assertEquals(0, struct.getMissingFields(Set("is_hero", "name")).size)
+    assertEquals(0, struct.getMissingFields(Set("is_hero", "name", "fi``(╯°□°)╯︵ ┻━┻eld")).size)
   }
 
   @Test
@@ -104,5 +106,20 @@ class Neo4jImplicitsTest {
     val struct = StructType(Seq(StructField("is_hero", DataTypes.BooleanType), StructField("name", DataTypes.StringType)))
 
     assertEquals(Set[String]("hero_name"), struct.getMissingFields(Set("is_hero", "hero_name")))
+  }
+
+  @Test
+  def `getMissingFields should handle maps`: Unit = {
+    val struct = StructType(Seq(
+      StructField("im", DataTypes.StringType),
+      StructField("im.a", DataTypes.createMapType(DataTypes.StringType, DataTypes.StringType)),
+      StructField("im.also.a", DataTypes.createMapType(DataTypes.StringType, DataTypes.StringType)),
+      StructField("im.not.a.map", DataTypes.StringType),
+      StructField("fi``(╯°□°)╯︵ ┻━┻eld", DataTypes.StringType)
+    ))
+
+    val result = struct.getMissingFields(Set("im.aMap", "`im.also.a`.field", "`im.a`.map", "`im.not.a.map`", "fi``(╯°□°)╯︵ ┻━┻eld"))
+
+    assertEquals(Set("im.aMap"), result)
   }
 }


### PR DESCRIPTION
Fixes #323 for map data types you can now use the inner field as in `node.keys` or `node.properties`