### PR TITLE
Taskless: Implemented BasePartitionReader in Spark 2.4

### DIFF
--- a/spark-2.4/src/main/scala/org/neo4j/spark/reader/Neo4jDataSourceReader.scala
+++ b/spark-2.4/src/main/scala/org/neo4j/spark/reader/Neo4jDataSourceReader.scala
@@ -50,7 +50,7 @@ class Neo4jDataSourceReader(private val options: DataSourceOptions, private val 
   override def planInputPartitions: util.ArrayList[InputPartition[InternalRow]] = {
     // we retrieve the schema in order to parse the data correctly
     val schema = readSchema()
-    val neo4jPartitions: Seq[Neo4jInputPartitionReader] = createPartitions(schema)
+    val neo4jPartitions: Seq[Neo4jInputPartition] = createPartitions(schema)
     new util.ArrayList[InputPartition[InternalRow]](neo4jPartitions.asJava)
   }
 
@@ -60,7 +60,7 @@ class Neo4jDataSourceReader(private val options: DataSourceOptions, private val 
       (schemaService.skipLimitFromPartition(), schemaService.execute(neo4jOptions.script)) }
     // we generate a partition for each element
     partitionSkipLimitList
-      .map(partitionSkipLimit => new Neo4jInputPartitionReader(neo4jOptions, filters, schema, jobId,
+      .map(partitionSkipLimit => new Neo4jInputPartition(neo4jOptions, filters, schema, jobId,
         partitionSkipLimit, scriptResult, requiredColumns))
   }
 

--- a/spark-2.4/src/main/scala/org/neo4j/spark/reader/Neo4jInputPartition.scala
+++ b/spark-2.4/src/main/scala/org/neo4j/spark/reader/Neo4jInputPartition.scala
@@ -1,0 +1,21 @@
+package org.neo4j.spark.reader
+
+import org.apache.spark.sql.catalyst.InternalRow
+import org.apache.spark.sql.sources.Filter
+import org.apache.spark.sql.sources.v2.reader.{InputPartition, InputPartitionReader}
+import org.apache.spark.sql.types.StructType
+import org.neo4j.spark.service._
+import org.neo4j.spark.util.Neo4jOptions
+
+class Neo4jInputPartition(private val options: Neo4jOptions,
+                          private val filters: Array[Filter],
+                          private val schema: StructType,
+                          private val jobId: String,
+                          private val partitionSkipLimit: PartitionSkipLimit,
+                          private val scriptResult: java.util.List[java.util.Map[String, AnyRef]],
+                          private val requiredColumns: StructType)
+    extends InputPartition[InternalRow] {
+
+  override def createPartitionReader(): InputPartitionReader[InternalRow] = new Neo4jInputPartitionReader(options, filters, schema,
+    jobId, partitionSkipLimit, scriptResult, requiredColumns)
+}

--- a/spark-2.4/src/main/scala/org/neo4j/spark/reader/Neo4jInputPartitionReader.scala
+++ b/spark-2.4/src/main/scala/org/neo4j/spark/reader/Neo4jInputPartitionReader.scala
@@ -1,17 +1,11 @@
 package org.neo4j.spark.reader
 
-import org.apache.spark.internal.Logging
 import org.apache.spark.sql.catalyst.InternalRow
 import org.apache.spark.sql.sources.Filter
-import org.apache.spark.sql.sources.v2.reader.{InputPartition, InputPartitionReader}
+import org.apache.spark.sql.sources.v2.reader.InputPartitionReader
 import org.apache.spark.sql.types.StructType
-import org.neo4j.driver.{Record, Session, Transaction, Values}
-import org.neo4j.spark.service.{MappingService, Neo4jQueryReadStrategy, Neo4jQueryService, Neo4jQueryStrategy, Neo4jReadMappingStrategy, PartitionSkipLimit}
-import org.neo4j.spark.util.Neo4jImplicits.StructTypeImplicit
-import org.neo4j.spark.util.{DriverCache, Neo4jOptions, Neo4jUtil}
+import org.neo4j.spark.service.PartitionSkipLimit
 import org.neo4j.spark.util.Neo4jOptions
-
-import scala.collection.JavaConverters._
 
 class Neo4jInputPartitionReader(private val options: Neo4jOptions,
                                 private val filters: Array[Filter],
@@ -19,43 +13,6 @@ class Neo4jInputPartitionReader(private val options: Neo4jOptions,
                                 private val jobId: String,
                                 private val partitionSkipLimit: PartitionSkipLimit,
                                 private val scriptResult: java.util.List[java.util.Map[String, AnyRef]],
-                                private val requiredColumns: StructType) extends InputPartition[InternalRow]
-  with InputPartitionReader[InternalRow]
-  with Logging {
-
-  private var result: Iterator[Record] = _
-  private var session: Session = _
-  private var transaction: Transaction = _
-  private val driverCache: DriverCache = new DriverCache(options.connection,
-    if (partitionSkipLimit.partitionNumber > 0) s"$jobId-${partitionSkipLimit.partitionNumber}" else jobId)
-
-  private val query: String = new Neo4jQueryService(options, new Neo4jQueryReadStrategy(filters, partitionSkipLimit, requiredColumns.getFieldsName))
-    .createQuery()
-
-  private val mappingService = new MappingService(new Neo4jReadMappingStrategy(options, requiredColumns), options)
-
-  override def createPartitionReader(): InputPartitionReader[InternalRow] = new Neo4jInputPartitionReader(options, filters, schema,
-    jobId, partitionSkipLimit, scriptResult, requiredColumns)
-
-  def next: Boolean = {
-    if (result == null) {
-      session = driverCache.getOrCreate().session(options.session.toNeo4jSession)
-      transaction = session.beginTransaction()
-      log.info(s"Running the following query on Neo4j: $query")
-      result = transaction.run(query, Values
-        .value(Map[String, AnyRef](Neo4jQueryStrategy.VARIABLE_SCRIPT_RESULT -> scriptResult).asJava))
-        .asScala
-    }
-
-    result.hasNext
-  }
-
-  def get: InternalRow = mappingService.convert(result.next(), schema)
-
-  def close(): Unit = {
-    Neo4jUtil.closeSafety(transaction, log)
-    Neo4jUtil.closeSafety(session, log)
-    driverCache.close()
-  }
-
-}
+                                private val requiredColumns: StructType)
+  extends BasePartitionReader(options, filters, schema, jobId, partitionSkipLimit, scriptResult, requiredColumns)
+    with InputPartitionReader[InternalRow]

--- a/spark-3/src/main/scala/org/neo4j/spark/reader/Neo4jPartitionReader.scala
+++ b/spark-3/src/main/scala/org/neo4j/spark/reader/Neo4jPartitionReader.scala
@@ -1,6 +1,5 @@
 package org.neo4j.spark.reader
 
-import org.apache.spark.internal.Logging
 import org.apache.spark.sql.catalyst.InternalRow
 import org.apache.spark.sql.connector.read.PartitionReader
 import org.apache.spark.sql.sources.Filter


### PR DESCRIPTION
As stated in the title, Neo4jPartitionReader now extends BaseParitionReader to avoid code duplication.