### PR TITLE
Fixes #337: Implemented user defined schema on Spark 2.4 and Spark 3

### DIFF
--- a/doc/docs/modules/ROOT/pages/faq.adoc
+++ b/doc/docs/modules/ROOT/pages/faq.adoc
@@ -67,7 +67,7 @@ You can solve it by adding APOC to your Neo4j installation; this will remove the
 all the values for that field will be casted to String. This because Spark is not schema free,
 and need each column to always have the same type.
 
-You can read more <<quickstart.adoc#bookmark-read-known-problem, here>>.
+You can read more <<quickstart.adoc#read-known-problem, here>>.
 
 == The returned columns are not in the same order as I specified in the query
 

--- a/doc/docs/modules/ROOT/pages/faq.adoc
+++ b/doc/docs/modules/ROOT/pages/faq.adoc
@@ -95,3 +95,11 @@ Caused by: ClassNotFoundException: org.apache.spark.sql.sources.v2.ReadSupport
 
 This means that your Spark version doesn't match the Spark version on the connector.
 Please refer to xref:overview.adoc#_spark_compatibility[this page] to know which version you need.
+
+[[graph-already-exists]]
+== Getting "Failed to invoke procedure gds.graph.create.cypher: Caused by: java.lang.IllegalArgumentException: A graph with name [name] already exists."
+
+This might happen when creating a new graph using the GDS library.
+The issue here is that the query is run the first time to extract the DataFrame schema and then is run again to get the data.
+
+To avoid this issue we suggest using the xref:quickstart.adoc#user-defined-schema[user defined schema] approach.

--- a/doc/docs/modules/ROOT/pages/gds.adoc
+++ b/doc/docs/modules/ROOT/pages/gds.adoc
@@ -53,6 +53,8 @@ df = spark.read.format("org.neo4j.spark.DataSource") \
     .load()
 ----
 
+[NOTE]
+If you get a "Graph Already Exists" error, take a look at this xref:faq.adoc#graph-already-exists[FAQ].
 
 [NOTE]
 **Ensure partitions is set to 1.  You do not want to execute this query in parallel, only once.**

--- a/doc/docs/modules/ROOT/pages/quickstart.adoc
+++ b/doc/docs/modules/ROOT/pages/quickstart.adoc
@@ -265,7 +265,7 @@ spark.read.format("org.neo4j.spark.DataSource")
 |1|Jane Doe
 |===
 
-[[bookmark-string-strategy]]
+[[string-strategy]]
 .Using string strategy
 [source,scala]
 ----
@@ -291,7 +291,7 @@ spark.read.format("org.neo4j.spark.DataSource")
 As you can see, the struct returned by the query is made of strings
 that you can then be casted Spark's getters (ie: `getLong`).
 
-[[bookmark-read-known-problem]]
+[[read-known-problem]]
 ===== Known Problem
 
 Being Neo4j a schema less database, this scenario may occur:
@@ -362,7 +362,7 @@ partitions and each one will manage 20 records (we use `SKIP / LIMIT` queries).
 
 Partitioning the dataset makes sense only if you're dealing with a big dataset (>= 10M of records).
 
-[[bookmark-parallelize]]
+[[parallelize]]
 ==== How we parallelize the query execution
 
 Considering that we have three options

--- a/doc/docs/modules/ROOT/pages/quickstart.adoc
+++ b/doc/docs/modules/ROOT/pages/quickstart.adoc
@@ -274,7 +274,7 @@ import org.apache.spark.sql.{SaveMode, SparkSession}
 val spark = SparkSession.builder().getOrCreate()
 
 spark.read.format("org.neo4j.spark.DataSource")
-  .option("query", "MATCH (n:Person) WITH n WITH n LIMIT 2 RETURN id(n) as id, n.name as name")
+  .option("query", "MATCH (n:Person) WITH n LIMIT 2 RETURN id(n) as id, n.name as name")
   .option("schema.strategy", "string")
   .load()
   .show()
@@ -289,7 +289,37 @@ spark.read.format("org.neo4j.spark.DataSource")
 |===
 
 As you can see, the struct returned by the query is made of strings
-that you can then be casted Spark's getters (ie: `getLong`).
+that you can then be cast Spark's getters (ie: `getLong`).
+
+[[user-defined-schema]]
+===== User Defined Schema
+
+You can skip the automatic schema extraction process by providing a user defined schema using the `.schema()` method.
+
+.Using user defined schema
+[source,scala]
+----
+import org.apache.spark.sql.types.{DataTypes, StructType, StructField}
+import org.apache.spark.sql.{SaveMode, SparkSession}
+
+val spark = SparkSession.builder().getOrCreate()
+
+spark.read.format("org.neo4j.spark.DataSource")
+  .schema(StructType(StructField("id", DataTypes.StringType), StructField("name", DataTypes.StringType)))
+  .option("query", "MATCH (n:Person) WITH n LIMIT 2 RETURN id(n) as id, n.name as name")
+  .load()
+  .show()
+----
+
+.Result of the above code
+|===
+|id |name
+
+|"0"|"John Doe"
+|"1"|"Jane Doe"
+|===
+
+In this way we have total control over the schema.
 
 [[read-known-problem]]
 ===== Known Problem

--- a/doc/docs/modules/ROOT/pages/reading.adoc
+++ b/doc/docs/modules/ROOT/pages/reading.adoc
@@ -123,11 +123,11 @@ every single node property as column prefixed by `source` or `target`
 
 Reading data from a Neo4j Database can be done in 3 ways:
 
- * <<bookmark-read-query,Custom Cypher Query>>
- * <<bookmark-read-node,Node>>
- * <<bookmark-read-rel,Relationship>>
+ * <<read-query,Custom Cypher Query>>
+ * <<read-node,Node>>
+ * <<read-rel,Relationship>>
 
-[[bookmark-read-query]]
+[[read-query]]
 === Custom Cypher Query
 
 You can specify a Cypher query in this way:
@@ -161,7 +161,7 @@ If your query returns a graph entity please use the `labels` or `relationship` m
 
 The struct of the Dataset returned by the query is influenced by the query itself,
 in this particular context it could happen that the connector won't be able to sample the Schema from the query,
-in these cases we suggest trying with the option `schema.strategy` set to `string` as described xref:quickstart.adoc#bookmark-string-strategy[here].
+in these cases we suggest trying with the option `schema.strategy` set to `string` as described xref:quickstart.adoc#string-strategy[here].
 
 [NOTE]
 Read query *must always* return some data (read: *must always* have a return statement).
@@ -225,7 +225,7 @@ The created schema will be
 The returned column order is not guarantee to match the RETURN statement for Neo4j 3.* and Neo4j 4.0.
 Starting from Neo4j 4.1 it the order will be the same.
 
-[[bookmark-limit-query]]
+[[limit-query]]
 ==== Limit the results
 
 This connector does not permit using SKIP or LIMIT at the end of a Cypher query.
@@ -260,9 +260,9 @@ RETURN p.name
 
 The queries return the exact same data, but only the second one is usable with the spark connector, and partition-able, because of the WITH clause, and the simple final RETURN clause. If you choose to reformulate queries to use "internal SKIP/LIMIT" take careful notice of ordering operations to guarantee the same result set.
 
-You may also use the `query.count` option rather than reformulating your query (more on it <<quickstart.adoc#bookmark-parallelize,here>>).
+You may also use the `query.count` option rather than reformulating your query (more on it <<quickstart.adoc#parallelize,here>>).
 
-[[bookmark-read-node]]
+[[read-node]]
 === Node
 
 You can read nodes by specifiying a single label, or multiple labels. Like so:
@@ -349,7 +349,7 @@ Will create this schema
 
 |===
 
-[[bookmark-read-rel]]
+[[read-rel]]
 === Relationship
 
 To read a relationship you must specify the relationship name, the source node labels, and the target node labels.
@@ -384,7 +384,7 @@ prefixed with `source.` or `target.` (ie: `source.name`, `target.price`)
 
 When set to `true` the source and target properties will be returned as Map[String, String] in two columns named `source`and `target`.
 
-[[bookmark-rel-schema-no-map]]
+[[rel-schema-no-map]]
 .Nodes map set to false
 [source,scala]
 ----
@@ -477,7 +477,7 @@ a|[.small]
 ----
 |===
 
-[[bookmark-rel-schema-columns]]
+[[rel-schema-columns]]
 ==== Columns
 When reading data with this method, the Dataframe will contain the following columns:
 

--- a/doc/docs/modules/ROOT/pages/writing.adoc
+++ b/doc/docs/modules/ROOT/pages/writing.adoc
@@ -43,7 +43,7 @@ Will insert 10 nodes into Neo4j via Spark, and each of these will have:
 * 2 labels: `Person` and `Customer`
 * 4 properties: `name`, `surname`, `age` and `livesIn`
 
-[[bookmark-save-mode]]
+[[save-mode]]
 == Save Mode
 
 In order to persist data into Neo4j the Spark Connector supports two save modes that will
@@ -53,7 +53,7 @@ work only if `UNIQUE` or `NODE KEY` constraints are defined into Neo4j for the g
 These SaveMode examples apply to the Scala class `org.apache.spark.sql.SaveMode`.  For PySpark, simply
 use a static string with the name of the SaveMode.  So instead of `SaveMode.Overwrite`, use `"Overwrite"` for pyspark.
 
-For <<bookmark-write-node,Node>> type
+For <<write-node,Node>> type
 
 * `SaveMode.ErrorIfExists`: this will build a `CREATE` query
 * `SaveMode.Overwrite`: this will build a `MERGE` query
@@ -61,7 +61,7 @@ For <<bookmark-write-node,Node>> type
 [NOTE]
 For `SaveMode.Overwrite` mode you *need to have unique constrains on the keys*.
 
-For <<bookmark-write-rel,Relationship>> type
+For <<write-rel,Relationship>> type
 
 * `SaveMode.ErrorIfExists`: this will build a `CREATE` query
 * `SaveMode.Append`: this will build a `MERGE` query
@@ -125,7 +125,7 @@ The DataSource Writer has several options in order to connect and persist data i
 |No
 
 |`relationship.save.strategy`
-|<<bookmark-strategies,Save strategy>> to be used
+|<<strategies,Save strategy>> to be used
 |`native`
 |Yes
 
@@ -140,7 +140,7 @@ The DataSource Writer has several options in order to connect and persist data i
 |No
 
 |`relationship.source.save.mode`
-|Source <<bookmark-node-save-modes,node Save Mode>>
+|Source <<node-save-modes,node Save Mode>>
 |`Match`
 |No
 
@@ -160,7 +160,7 @@ The DataSource Writer has several options in order to connect and persist data i
 |No
 
 |`relationship.target.save.mode`
-|Target <<bookmark-node-save-modes,node Save Mode>>
+|Target <<node-save-modes,node Save Mode>>
 |`Match`
 |No
 
@@ -179,11 +179,11 @@ so if in the process at some point fails all the previous data is already persis
 
 Writing data to a Neo4j Database can be done in 3 ways:
 
-* <<bookmark-write-query,Custom Cypher Query>>
-* <<bookmark-write-node,Node>>
-* <<bookmark-write-rel,Relationship>>
+* <<write-query,Custom Cypher Query>>
+* <<write-node,Node>>
+* <<write-rel,Relationship>>
 
-[[bookmark-write-query]]
+[[write-query]]
 === Custom Cypher Query
 
 In case you use the option `query` the Spark Connector will persist the entire Dataset by using the provided query.
@@ -217,11 +217,11 @@ CREATE (n:Person {fullName: event.name + event.surname})
 
 Where `events` is the batch created from your dataset.
 
-[[bookmark-write-node]]
+[[write-node]]
 === Node
 
 In case you use the option `labels` the Spark Connector will persist the entire Dataset as nodes.
-Depending on the <<bookmark-save-mode,SaveMode>> it will `CREATE` or `MERGE` nodes (in the last case using the `node.keys`
+Depending on the <<save-mode,SaveMode>> it will `CREATE` or `MERGE` nodes (in the last case using the `node.keys`
 properties).
 
 The nodes will be sent to Neo4j in a batch of rows defined in the `batch.size` property and we will
@@ -346,7 +346,7 @@ Neo4j Connector for Apache Spark will flatten the maps and each map value will b
 
 |===
 
-[[bookmark-write-rel]]
+[[write-rel]]
 === Relationship
 
 You can write a dataframe to Neo4j by specifying source, target and relation.
@@ -372,33 +372,33 @@ SET rel += event.rel
 ----
 
 The `CREATE` keyword for the source and target nodes can be replaced by a `MERGE` or a `MATCH`.
-To control this you can use the <<bookmark-node-save-modes,node save modes>>.
+To control this you can use the <<node-save-modes,node save modes>>.
 
 You can set source and target independently by using `relationship.source.save.mode` or ``relationship.target.save.mode`.
 
 These options accept a case insensitive string as a value, that can be one of `ErrorIfExists`, `Overwrite`, `Append`;
-they work in the exact same way as the <<bookmark-write-node,Node Save Modes>>.
+they work in the exact same way as the <<write-node,Node Save Modes>>.
 
 When using `MATCH` or `MERGE` you will need to specify keys that identify the nodes.
 This is what the options `relationship.source.node.keys` and `relationship.target.node.keys`.
-More on this <<bookmark-rel-specify-keys,here>>.
+More on this <<rel-specify-keys,here>>.
 
 The `CREATE` keyword for the relationship can be replaced by a `MERGE`.
-You can control this with <<bookmark-save-mode,Save Mode>>.
+You can control this with <<save-mode,Save Mode>>.
 
-You are also required to specify one of the two <<bookmark-strategies,Save Strategies>>.
+You are also required to specify one of the two <<strategies,Save Strategies>>.
 This will identify which method will be used to create the Cypher query
 and can have additional options available.
 
-[[bookmark-strategies]]
+[[strategies]]
 ==== Save Strategies
 
-There are two strategies you can use to write relationships: <<bookmark-strategy-native,Native>> (default strategy) and <<bookmark-strategy-keys,Keys>>.
+There are two strategies you can use to write relationships: <<strategy-native,Native>> (default strategy) and <<strategy-keys,Keys>>.
 
-[[bookmark-strategy-native]]
+[[strategy-native]]
 ==== Native Strategy
 
-This strategy is useful when you have a schema that conforms with the <<reading.adoc#bookmark-rel-schema-no-map,Relationship Read Schema>>, with the `relationship.nodes.map` set to false.
+This strategy is useful when you have a schema that conforms with the <<reading.adoc#rel-schema-no-map,Relationship Read Schema>>, with the `relationship.nodes.map` set to false.
 
 Let's say we want to read relationship from a Database, filter them, and write the result to another Database:
 
@@ -443,12 +443,12 @@ CREATE (source)-[rel:BOUGHT]->(target)
 SET rel += event.rel
 ----
 
-`event.source`, `event.target`, and `event.rel` will contain the column described <<reading.adoc#bookmark-rel-schema-columns,here>>.
+`event.source`, `event.target`, and `event.rel` will contain the column described <<reading.adoc#rel-schema-columns,here>>.
 
 [NOTE]
 The default save mode for source and target nodes is `Match`.
 This means that the relationship will be created only if the nodes are already in your DB.
-Look at <<bookmark-node-save-modes,here>> for more info about node save modes.
+Look at <<node-save-modes,here>> for more info about node save modes.
 
 When using `Overwrite` or `Match` node save mode, you should specify which keys should be used to identify the nodes.
 
@@ -505,13 +505,13 @@ SET rel += event.rel
 ----
 
 [NOTE]
-Remember that you can choose to `CREATE` or `MERGE` the relationship with the <<bookmark-save-mode,save mode>>.
+Remember that you can choose to `CREATE` or `MERGE` the relationship with the <<save-mode,save mode>>.
 
 [NOTE]
 If the provided dataframe schema doesn't conform the required schema, meaning that none of the required column is present,
 the write will fail.
 
-[[bookmark-strategy-keys]]
+[[strategy-keys]]
 ==== Keys Strategy
 
 When you want more control on the relationship writing you can use the *KEYS* strategy.
@@ -519,7 +519,7 @@ When you want more control on the relationship writing you can use the *KEYS* st
 As the native strategy, you can specify node keys to identify nodes.
 In addition, you can also specify which columns should be written as nodes properties.
 
-[[bookmark-rel-specify-keys]]
+[[rel-specify-keys]]
 .Specify keys
 [source,scala]
 ----
@@ -596,7 +596,7 @@ musicDf.write
     .save()
 ----
 
-[[bookmark-node-save-modes]]
+[[node-save-modes]]
 ===== Node Save Modes
 
 You can specify 3 different modes to use for saving the nodes:

--- a/spark-2.4/src/main/scala/org/neo4j/spark/DataSource.scala
+++ b/spark-2.4/src/main/scala/org/neo4j/spark/DataSource.scala
@@ -3,6 +3,7 @@ package org.neo4j.spark
 import java.util.{Optional, UUID}
 import org.apache.spark.sql.SaveMode
 import org.apache.spark.sql.sources.DataSourceRegister
+import org.apache.spark.sql.sources.v2.reader.DataSourceReader
 import org.apache.spark.sql.sources.v2.writer.DataSourceWriter
 import org.apache.spark.sql.sources.v2.{DataSourceOptions, DataSourceV2, ReadSupport, WriteSupport}
 import org.apache.spark.sql.types.StructType
@@ -17,6 +18,8 @@ class DataSource extends DataSourceV2 with ReadSupport with DataSourceRegister w
   private val jobId: String = UUID.randomUUID().toString
 
   def createReader(options: DataSourceOptions) = new Neo4jDataSourceReader(options, jobId)
+
+  override def createReader(schema: StructType, options: DataSourceOptions): DataSourceReader = new Neo4jDataSourceReader(options, jobId, schema)
 
   override def shortName: String = "neo4j"
 

--- a/spark-2.4/src/main/scala/org/neo4j/spark/reader/Neo4jDataSourceReader.scala
+++ b/spark-2.4/src/main/scala/org/neo4j/spark/reader/Neo4jDataSourceReader.scala
@@ -12,7 +12,7 @@ import org.neo4j.spark.util.{DriverCache, Neo4jOptions, Validations}
 
 import scala.collection.JavaConverters._
 
-class Neo4jDataSourceReader(private val options: DataSourceOptions, private val jobId: String) extends DataSourceReader
+class Neo4jDataSourceReader(private val options: DataSourceOptions, private val jobId: String, private val userDefinedSchema: StructType = null) extends DataSourceReader
   with SupportsPushDownFilters
   with SupportsPushDownRequiredColumns {
 
@@ -23,8 +23,12 @@ class Neo4jDataSourceReader(private val options: DataSourceOptions, private val 
   private val neo4jOptions: Neo4jOptions = new Neo4jOptions(options.asMap())
     .validate(options => Validations.read(options, jobId))
 
-  private val structType = callSchemaService { schemaService => schemaService
-    .struct() }
+  private val structType = if (userDefinedSchema != null) {
+    userDefinedSchema
+  } else {
+    callSchemaService { schemaService => schemaService
+      .struct() }
+  }
 
   override def readSchema(): StructType = structType
 

--- a/spark-3/src/main/scala/org/neo4j/spark/DataSource.scala
+++ b/spark-3/src/main/scala/org/neo4j/spark/DataSource.scala
@@ -55,12 +55,13 @@ class DataSource extends TableProvider
   }
 
   override def getTable(structType: StructType, transforms: Array[Transform], map: java.util.Map[String, String]): Table = {
-    val caseInsensitiveStringMapNeo4jOptions = new CaseInsensitiveStringMap(map);
-    new Neo4jTable(if(structType != null) {
+    val caseInsensitiveStringMapNeo4jOptions = new CaseInsensitiveStringMap(map)
+    val schema = if (structType != null) {
       structType
     } else {
       inferSchema(caseInsensitiveStringMapNeo4jOptions)
-    }, map, jobId)
+    }
+    new Neo4jTable(schema, map, jobId)
   }
 
   override def shortName(): String = "neo4j"

--- a/spark-3/src/main/scala/org/neo4j/spark/DataSource.scala
+++ b/spark-3/src/main/scala/org/neo4j/spark/DataSource.scala
@@ -36,6 +36,8 @@ class DataSource extends TableProvider
     }
   }
 
+  override def supportsExternalMetadata(): Boolean = true
+
   override def inferSchema(caseInsensitiveStringMap: CaseInsensitiveStringMap): StructType = {
     if (schema == null) {
       schema = callSchemaService(getNeo4jOptions(caseInsensitiveStringMap),  { schemaService => schemaService.struct() })
@@ -54,7 +56,11 @@ class DataSource extends TableProvider
 
   override def getTable(structType: StructType, transforms: Array[Transform], map: java.util.Map[String, String]): Table = {
     val caseInsensitiveStringMapNeo4jOptions = new CaseInsensitiveStringMap(map);
-    new Neo4jTable(inferSchema(caseInsensitiveStringMapNeo4jOptions), map, jobId)
+    new Neo4jTable(if(structType != null) {
+      structType
+    } else {
+      inferSchema(caseInsensitiveStringMapNeo4jOptions)
+    }, map, jobId)
   }
 
   override def shortName(): String = "neo4j"

--- a/spark-3/src/test/scala/org/neo4j/spark/DataSourceReaderTSE.scala
+++ b/spark-3/src/test/scala/org/neo4j/spark/DataSourceReaderTSE.scala
@@ -2,8 +2,8 @@ package org.neo4j.spark
 
 import java.sql.Timestamp
 import java.time.{LocalDateTime, OffsetDateTime, ZoneOffset}
-
 import org.apache.spark.sql.catalyst.expressions.GenericRowWithSchema
+import org.apache.spark.sql.types.{DataTypes, StructField, StructType}
 import org.apache.spark.sql.{DataFrame, Row}
 import org.junit.Assert._
 import org.junit.Test
@@ -1597,6 +1597,23 @@ class DataSourceReaderTSE extends SparkConnectorScalaBaseTSE {
     df.count()
 
     assertEquals(Set("target.name", "target.id"), df.columns.toSet)
+  }
+
+  @Test
+  def testShouldUseTheUserSpecifiedSchema(): Unit = {
+    SparkConnectorScalaSuiteIT.session()
+      .writeTransaction(
+        new TransactionWork[ResultSummary] {
+          override def execute(tx: Transaction): ResultSummary = tx.run("CREATE (p:Person {name: 'Foo Bar', age: 8})").consume()
+        })
+
+    val df = ss.read.format(classOf[DataSource].getName)
+      .schema(StructType(Seq(StructField("age", DataTypes.StringType))))
+      .option("url", SparkConnectorScalaSuiteIT.server.getBoltUrl)
+      .option("query", "MATCH (n:Person) RETURN n.age AS age")
+      .load()
+
+    assertEquals("8", df.collect().head.get(0))
   }
 
   private def initTest(query: String): DataFrame = {


### PR DESCRIPTION
Fixes #337 

Implemented user defined schema on Spark 2.4 and Spark 3

```scala
val df = ss.read.format(classOf[DataSource].getName)
      .schema(StructType(Seq(StructField("age", DataTypes.StringType)))) // <--
      .option("url", SparkConnectorScalaSuiteIT.server.getBoltUrl)
      .option("query", "MATCH (n:Person) RETURN n.age AS age")
      .load()
```

This allows to skip the schema generation, avoiding the run of an additional query.