### PR TITLE
fixes #348: repartition(1) - Makes loading very slow

### DIFF
--- a/common/src/main/scala/org/neo4j/spark/reader/BasePartitionReader.scala
+++ b/common/src/main/scala/org/neo4j/spark/reader/BasePartitionReader.scala
@@ -34,7 +34,7 @@ abstract class BasePartitionReader(private val options: Neo4jOptions,
 
   def next: Boolean = {
     if (result == null) {
-      session = driverCache.getOrCreate().session(options.session.toNeo4jSession)
+      session = driverCache.getOrCreate().session(options.session.toNeo4jSession())
       transaction = session.beginTransaction()
       log.info(s"Running the following query on Neo4j: $query")
       result = transaction.run(query, Values.value(getQueryParameters))

--- a/common/src/main/scala/org/neo4j/spark/service/SchemaService.scala
+++ b/common/src/main/scala/org/neo4j/spark/service/SchemaService.scala
@@ -29,7 +29,7 @@ class SchemaService(private val options: Neo4jOptions, private val driverCache: 
 
   private val queryReadStrategy = new Neo4jQueryReadStrategy(filters)
 
-  private val session: Session = driverCache.getOrCreate().session(options.session.toNeo4jSession)
+  private val session: Session = driverCache.getOrCreate().session(options.session.toNeo4jSession())
 
   private def structForNode(labels: Seq[String] = options.nodeMetadata.labels): StructType = {
     var structFields: mutable.Buffer[StructField] = (try {

--- a/common/src/main/scala/org/neo4j/spark/util/Neo4jOptions.scala
+++ b/common/src/main/scala/org/neo4j/spark/util/Neo4jOptions.scala
@@ -227,12 +227,15 @@ case class Neo4jQueryMetadata(query: String, queryCount: String)
 case class Neo4jQueryOptions(queryType: QueryType.Value, value: String)
 
 case class Neo4jSessionOptions(database: String, accessMode: AccessMode = AccessMode.READ) {
-  def toNeo4jSession: SessionConfig = {
+  def toNeo4jSession(bookmarks: Seq[Bookmark] = Seq.empty): SessionConfig = {
     val builder = SessionConfig.builder()
       .withDefaultAccessMode(accessMode)
 
     if (database != null && database != "") {
       builder.withDatabase(database)
+    }
+    if (!bookmarks.isEmpty) {
+      builder.withBookmarks(bookmarks.asJava)
     }
 
     builder.build()

--- a/common/src/main/scala/org/neo4j/spark/util/Validations.scala
+++ b/common/src/main/scala/org/neo4j/spark/util/Validations.scala
@@ -36,7 +36,7 @@ object Validations extends Logging {
     val cache = new DriverCache(neo4jOptions.connection, jobId)
     val schemaService = new SchemaService(neo4jOptions, cache)
     try {
-      validateConnection(cache.getOrCreate().session(neo4jOptions.session.toNeo4jSession))
+      validateConnection(cache.getOrCreate().session(neo4jOptions.session.toNeo4jSession()))
 
       checkOptionsConsistency(neo4jOptions)
 
@@ -121,7 +121,7 @@ object Validations extends Logging {
     val cache = new DriverCache(neo4jOptions.connection, jobId)
     val schemaService = new SchemaService(neo4jOptions, cache)
     try {
-      validateConnection(cache.getOrCreate().session(neo4jOptions.session.toNeo4jSession))
+      validateConnection(cache.getOrCreate().session(neo4jOptions.session.toNeo4jSession()))
 
       checkOptionsConsistency(neo4jOptions)
 

--- a/spark-3/src/main/scala/org/neo4j/spark/DataSource.scala
+++ b/spark-3/src/main/scala/org/neo4j/spark/DataSource.scala
@@ -26,7 +26,7 @@ class DataSource extends TableProvider
   override def inferSchema(caseInsensitiveStringMap: CaseInsensitiveStringMap): StructType = {
     if (schema == null) {
       val neo4jOpts = getNeo4jOptions(caseInsensitiveStringMap)
-      validateConnection(new util.DriverCache(neo4jOpts.connection, jobId).getOrCreate().session(neo4jOptions.session.toNeo4jSession))
+      validateConnection(new util.DriverCache(neo4jOpts.connection, jobId).getOrCreate().session(neo4jOptions.session.toNeo4jSession()))
       schema = Neo4jUtil.callSchemaService(neo4jOpts, jobId, Array.empty[Filter], { schemaService => schemaService.struct() })
     }
 


### PR DESCRIPTION
It should fix the error:

```
Caused by: [CIRCULAR REFERENCE: org.neo4j.driver.exceptions.TransientException: Database 'new1' not up to the requested version: 523. Latest database version is 517]
```

Put it in draft as we're waiting for user's feedback