### PR TITLE
Fixes #358: Ensure the same timezone is used across JVM and Neo4j

### DIFF
--- a/.github/workflows/python-ci.yml
+++ b/.github/workflows/python-ci.yml
@@ -37,7 +37,7 @@ jobs:
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
-          pip install pypandoc six
+          pip install pypandoc six tzlocal
           pip install pyspark==${{ matrix.spark-version.ext }} "testcontainers[neo4j]"
       - name: Build artifact
         env:

--- a/spark-2.4/src/test/scala/org/neo4j/spark/DataSourceReaderTSE.scala
+++ b/spark-2.4/src/test/scala/org/neo4j/spark/DataSourceReaderTSE.scala
@@ -1,7 +1,7 @@
 package org.neo4j.spark
 
 import java.sql.Timestamp
-import java.time.{LocalDateTime, OffsetDateTime, ZoneOffset}
+import java.time.{Instant, LocalDateTime, LocalTime, OffsetDateTime, OffsetTime, ZoneOffset}
 import org.apache.spark.sql.catalyst.expressions.GenericRowWithSchema
 import org.apache.spark.sql.types.{DataTypes, StructField, StructType}
 import org.apache.spark.sql.{DataFrame, Row}
@@ -10,6 +10,7 @@ import org.junit.Test
 import org.neo4j.driver.summary.ResultSummary
 import org.neo4j.driver.{Transaction, TransactionWork}
 
+import java.util.TimeZone
 import scala.collection.JavaConverters._
 
 class DataSourceReaderTSE extends SparkConnectorScalaBaseTSE {
@@ -135,12 +136,16 @@ class DataSourceReaderTSE extends SparkConnectorScalaBaseTSE {
 
   @Test
   def testReadNodeWithTime(): Unit = {
-    val df: DataFrame = initTest(s"CREATE (p:Person {aTime: time({hour:12, minute: 23, second: 0, millisecond: 294})})")
+    val timezone = TimeZone.getDefault
+    val df: DataFrame = initTest(s"CREATE (p:Person {aTime: time({hour:12, minute: 23, second: 0, millisecond: 294, timezone: '${timezone.getID}'})})")
 
     val result = df.select("aTime").collectAsList().get(0).getAs[GenericRowWithSchema](0)
 
+    val localTime = LocalTime.of(12, 23, 0, 294000000)
+    val expectedTime = OffsetTime.of(localTime, timezone.toZoneId.getRules.getOffset(Instant.now()))
+
     assertEquals("offset-time", result.get(0))
-    assertEquals("12:23:00.294Z", result.get(1))
+    assertEquals(expectedTime.toString, result.get(1))
   }
 
   @Test

--- a/spark-2.4/src/test/scala/org/neo4j/spark/DataSourceReaderTSE.scala
+++ b/spark-2.4/src/test/scala/org/neo4j/spark/DataSourceReaderTSE.scala
@@ -137,7 +137,7 @@ class DataSourceReaderTSE extends SparkConnectorScalaBaseTSE {
   @Test
   def testReadNodeWithTime(): Unit = {
     val timezone = TimeZone.getDefault
-    val df: DataFrame = initTest(s"CREATE (p:Person {aTime: time({hour:12, minute: 23, second: 0, millisecond: 294, timezone: '${timezone.getID}'})})")
+    val df: DataFrame = initTest(s"CREATE (p:Person {aTime: time({hour:12, minute: 23, second: 0, millisecond: 294})})")
 
     val result = df.select("aTime").collectAsList().get(0).getAs[GenericRowWithSchema](0)
 

--- a/spark-2.4/src/test/scala/org/neo4j/spark/DataSourceReaderWithApocTSE.scala
+++ b/spark-2.4/src/test/scala/org/neo4j/spark/DataSourceReaderWithApocTSE.scala
@@ -1,15 +1,15 @@
 package org.neo4j.spark
 
 import java.sql.Timestamp
-import java.time.{LocalDateTime, OffsetDateTime, ZoneOffset}
-
+import java.time.{Instant, LocalDateTime, LocalTime, OffsetDateTime, OffsetTime, ZoneOffset}
 import org.apache.spark.sql.DataFrame
 import org.apache.spark.sql.catalyst.expressions.GenericRowWithSchema
 import org.junit.Assert._
 import org.junit.Test
 import org.neo4j.driver.summary.ResultSummary
-import org.neo4j.driver.{SessionConfig, Transaction, TransactionWork}
+import org.neo4j.driver.{Transaction, TransactionWork}
 
+import java.util.TimeZone
 import scala.collection.JavaConverters._
 import scala.collection.mutable
 
@@ -92,12 +92,16 @@ class DataSourceReaderWithApocTSE extends SparkConnectorScalaBaseWithApocTSE {
 
   @Test
   def testReadNodeWithTime(): Unit = {
-    val df: DataFrame = initTest(s"CREATE (p:Person {aTime: time({hour:12, minute: 23, second: 0, millisecond: 294})})")
+    val timezone = TimeZone.getDefault
+    val df: DataFrame = initTest(s"CREATE (p:Person {aTime: time({hour:12, minute: 23, second: 0, millisecond: 294, timezone: '${timezone.getID}'})})")
 
     val result = df.select("aTime").collectAsList().get(0).getAs[GenericRowWithSchema](0)
 
+    val localTime = LocalTime.of(12, 23, 0, 294000000)
+    val expectedTime = OffsetTime.of(localTime, timezone.toZoneId.getRules.getOffset(Instant.now()))
+
     assertEquals("offset-time", result.get(0))
-    assertEquals("12:23:00.294Z", result.get(1))
+    assertEquals(expectedTime.toString, result.get(1))
   }
 
   @Test

--- a/spark-2.4/src/test/scala/org/neo4j/spark/DataSourceReaderWithApocTSE.scala
+++ b/spark-2.4/src/test/scala/org/neo4j/spark/DataSourceReaderWithApocTSE.scala
@@ -93,7 +93,7 @@ class DataSourceReaderWithApocTSE extends SparkConnectorScalaBaseWithApocTSE {
   @Test
   def testReadNodeWithTime(): Unit = {
     val timezone = TimeZone.getDefault
-    val df: DataFrame = initTest(s"CREATE (p:Person {aTime: time({hour:12, minute: 23, second: 0, millisecond: 294, timezone: '${timezone.getID}'})})")
+    val df: DataFrame = initTest(s"CREATE (p:Person {aTime: time({hour:12, minute: 23, second: 0, millisecond: 294})})")
 
     val result = df.select("aTime").collectAsList().get(0).getAs[GenericRowWithSchema](0)
 

--- a/spark-3/src/test/scala/org/neo4j/spark/DataSourceReaderTSE.scala
+++ b/spark-3/src/test/scala/org/neo4j/spark/DataSourceReaderTSE.scala
@@ -140,7 +140,7 @@ class DataSourceReaderTSE extends SparkConnectorScalaBaseTSE {
   @Test
   def testReadNodeWithTime(): Unit = {
     val timezone = TimeZone.getDefault
-    val df: DataFrame = initTest(s"CREATE (p:Person {aTime: time({hour:12, minute: 23, second: 0, millisecond: 294, timezone: '${timezone.getID}'})})")
+    val df: DataFrame = initTest(s"CREATE (p:Person {aTime: time({hour:12, minute: 23, second: 0, millisecond: 294})})")
 
     val result = df.select("aTime").collectAsList().get(0).getAs[GenericRowWithSchema](0)
 

--- a/spark-3/src/test/scala/org/neo4j/spark/DataSourceReaderTSE.scala
+++ b/spark-3/src/test/scala/org/neo4j/spark/DataSourceReaderTSE.scala
@@ -1,7 +1,7 @@
 package org.neo4j.spark
 
 import java.sql.Timestamp
-import java.time.{LocalDateTime, OffsetDateTime, ZoneOffset}
+import java.time.{Instant, LocalDateTime, LocalTime, OffsetDateTime, OffsetTime, ZoneOffset}
 import org.apache.spark.sql.catalyst.expressions.GenericRowWithSchema
 import org.apache.spark.sql.types.{DataTypes, StructField, StructType}
 import org.apache.spark.sql.{DataFrame, Row}
@@ -10,6 +10,7 @@ import org.junit.Test
 import org.neo4j.driver.summary.ResultSummary
 import org.neo4j.driver.{Transaction, TransactionWork}
 
+import java.util.TimeZone
 import scala.collection.JavaConverters._
 
 class DataSourceReaderTSE extends SparkConnectorScalaBaseTSE {
@@ -138,12 +139,16 @@ class DataSourceReaderTSE extends SparkConnectorScalaBaseTSE {
 
   @Test
   def testReadNodeWithTime(): Unit = {
-    val df: DataFrame = initTest(s"CREATE (p:Person {aTime: time({hour:12, minute: 23, second: 0, millisecond: 294})})")
+    val timezone = TimeZone.getDefault
+    val df: DataFrame = initTest(s"CREATE (p:Person {aTime: time({hour:12, minute: 23, second: 0, millisecond: 294, timezone: '${timezone.getID}'})})")
 
     val result = df.select("aTime").collectAsList().get(0).getAs[GenericRowWithSchema](0)
 
+    val localTime = LocalTime.of(12, 23, 0, 294000000)
+    val expectedTime = OffsetTime.of(localTime, timezone.toZoneId.getRules.getOffset(Instant.now()))
+
     assertEquals("offset-time", result.get(0))
-    assertEquals("12:23:00.294Z", result.get(1))
+    assertEquals(expectedTime.toString, result.get(1))
   }
 
   @Test

--- a/spark-3/src/test/scala/org/neo4j/spark/DataSourceReaderWithApocTSE.scala
+++ b/spark-3/src/test/scala/org/neo4j/spark/DataSourceReaderWithApocTSE.scala
@@ -1,15 +1,15 @@
 package org.neo4j.spark
 
 import java.sql.Timestamp
-import java.time.{LocalDateTime, OffsetDateTime, ZoneOffset}
-
+import java.time.{Instant, LocalDateTime, LocalTime, OffsetDateTime, OffsetTime, ZoneOffset}
 import org.apache.spark.sql.DataFrame
 import org.apache.spark.sql.catalyst.expressions.GenericRowWithSchema
 import org.junit.Assert._
 import org.junit.Test
 import org.neo4j.driver.summary.ResultSummary
-import org.neo4j.driver.{SessionConfig, Transaction, TransactionWork}
+import org.neo4j.driver.{Transaction, TransactionWork}
 
+import java.util.TimeZone
 import scala.collection.JavaConverters._
 import scala.collection.mutable
 
@@ -92,12 +92,16 @@ class DataSourceReaderWithApocTSE extends SparkConnectorScalaBaseWithApocTSE {
 
   @Test
   def testReadNodeWithTime(): Unit = {
-    val df: DataFrame = initTest(s"CREATE (p:Person {aTime: time({hour:12, minute: 23, second: 0, millisecond: 294})})")
+    val timezone = TimeZone.getDefault
+    val df: DataFrame = initTest(s"CREATE (p:Person {aTime: time({hour:12, minute: 23, second: 0, millisecond: 294, timezone: '${timezone.getID}'})})")
 
     val result = df.select("aTime").collectAsList().get(0).getAs[GenericRowWithSchema](0)
 
+    val localTime = LocalTime.of(12, 23, 0, 294000000)
+    val expectedTime = OffsetTime.of(localTime, timezone.toZoneId.getRules.getOffset(Instant.now()))
+
     assertEquals("offset-time", result.get(0))
-    assertEquals("12:23:00.294Z", result.get(1))
+    assertEquals(expectedTime.toString, result.get(1))
   }
 
   @Test

--- a/spark-3/src/test/scala/org/neo4j/spark/DataSourceReaderWithApocTSE.scala
+++ b/spark-3/src/test/scala/org/neo4j/spark/DataSourceReaderWithApocTSE.scala
@@ -93,7 +93,7 @@ class DataSourceReaderWithApocTSE extends SparkConnectorScalaBaseWithApocTSE {
   @Test
   def testReadNodeWithTime(): Unit = {
     val timezone = TimeZone.getDefault
-    val df: DataFrame = initTest(s"CREATE (p:Person {aTime: time({hour:12, minute: 23, second: 0, millisecond: 294, timezone: '${timezone.getID}'})})")
+    val df: DataFrame = initTest(s"CREATE (p:Person {aTime: time({hour:12, minute: 23, second: 0, millisecond: 294})})")
 
     val result = df.select("aTime").collectAsList().get(0).getAs[GenericRowWithSchema](0)
 

--- a/test-support/src/main/scala/org/neo4j/spark/SparkConnectorScalaSuiteIT.scala
+++ b/test-support/src/main/scala/org/neo4j/spark/SparkConnectorScalaSuiteIT.scala
@@ -7,11 +7,14 @@ import org.neo4j.Neo4jContainerExtension
 import org.neo4j.driver._
 import org.neo4j.driver.summary.ResultSummary
 
+import java.util.TimeZone
+
 
 object SparkConnectorScalaSuiteIT {
   val server: Neo4jContainerExtension = new Neo4jContainerExtension(s"neo4j:${TestUtil.neo4jVersion()}-enterprise")
     .withNeo4jConfig("dbms.security.auth_enabled", "false")
     .withEnv("NEO4J_ACCEPT_LICENSE_AGREEMENT", "yes")
+    .withEnv("NEO4J_db_temporal_timezone", TimeZone.getDefault.getID)
     .withDatabases(Seq("db1", "db2"))
 
   var conf: SparkConf = _

--- a/test-support/src/main/scala/org/neo4j/spark/SparkConnectorScalaSuiteWithApocIT.scala
+++ b/test-support/src/main/scala/org/neo4j/spark/SparkConnectorScalaSuiteWithApocIT.scala
@@ -7,11 +7,14 @@ import org.neo4j.Neo4jContainerExtension
 import org.neo4j.driver._
 import org.neo4j.driver.summary.ResultSummary
 
+import java.util.TimeZone
+
 object SparkConnectorScalaSuiteWithApocIT {
   val server: Neo4jContainerExtension = new Neo4jContainerExtension()
     .withNeo4jConfig("dbms.security.auth_enabled", "false")
     .withEnv("NEO4J_ACCEPT_LICENSE_AGREEMENT", "yes")
     .withEnv("NEO4JLABS_PLUGINS", "[\"apoc\"]")
+    .withEnv("NEO4J_db_temporal_timezone", TimeZone.getDefault.getID)
     .withDatabases(Seq("db1", "db2"))
 
   var conf: SparkConf = _


### PR DESCRIPTION
Fixes #358 

Using `.withEnv("NEO4J_db_temporal_timezone", TimeZone.getDefault.getID)` we ensure the same timezone is used across the single units used for running the integration tests.

A bit of test tweaking is required. 

Doing the same on Python.