### PR TITLE
fixes #357: transformed isValidQuery severity from ERROR  to DEBUG

### DIFF
--- a/common/src/main/scala/org/neo4j/spark/service/SchemaService.scala
+++ b/common/src/main/scala/org/neo4j/spark/service/SchemaService.scala
@@ -426,7 +426,9 @@ class SchemaService(private val options: Neo4jOptions, private val driverCache: 
     expectedQueryTypes.size == 0 || expectedQueryTypes.contains(queryType)
   } catch {
     case e: Throwable => {
-      log.error("Query not compiled because of the following exception:", e)
+      if (log.isDebugEnabled) {
+        log.error("Query not compiled because of the following exception:", e)
+      }
       false
     }
   }

--- a/common/src/main/scala/org/neo4j/spark/service/SchemaService.scala
+++ b/common/src/main/scala/org/neo4j/spark/service/SchemaService.scala
@@ -427,7 +427,7 @@ class SchemaService(private val options: Neo4jOptions, private val driverCache: 
   } catch {
     case e: Throwable => {
       if (log.isDebugEnabled) {
-        log.error("Query not compiled because of the following exception:", e)
+        log.debug("Query not compiled because of the following exception:", e)
       }
       false
     }


### PR DESCRIPTION
fixes #357

isValidQuery exception now logs a DEBUG log instead of an ERROR log only if DEBUG is enabled.