### PR TITLE
Disable lint:links task for now

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -24,5 +24,6 @@ jobs:
         working-directory: 'doc'
       - run: npm run build:docs
         working-directory: 'doc'
-      - run: npm run lint:links
-        working-directory: 'doc'
+      # REMIND: lint:links task is unreliable, enable again when we found a solution
+      #- run: npm run lint:links
+      #  working-directory: 'doc'


### PR DESCRIPTION
## Proposed Changes

- Disable `npm run lint:links` task from "Docs" workflow. The task is unreliable and slow(ish). Enable it again when we found a solution.
