### PR TITLE
Fixes #375: Error while using spark-shell with Spark 2.4 and Scala 2.11

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -47,8 +47,6 @@
     </licenses>
 
     <properties>
-        <scala.version>2.12.13</scala.version>
-        <scala.binary.version>2.12</scala.binary.version>
         <neo4j.version>4.0.8</neo4j.version>
         <driver.version>4.2.5</driver.version>
         <spark.version>2.4.7</spark.version>


### PR DESCRIPTION
We are currently getting this error when running `spark-shell --packages …` (and consequently on Databricks as well)


```
java.text.ParseException: inconsistent module descriptor file found in 'https://repo1.maven.org/maven2/org/neo4j/neo4j-connector-apache-spark_2.11/4.0.2_for_spark_2.4/neo4j-connector-apache-spark_2.11-4.0.2_for_spark_2.4.pom': bad module name: expected='neo4j-connector-apache-spark_2.11' found='neo4j-connector-apache-spark_2.12'
```

This happens just for Spark 2.4 with Scala 2.11. 

Solution is to try to remove the default scala version properties in the main pom, in this way the profile properties would be used instead.

If this solution doesn't work we'll create a separate spark-2.4-2.11 directory with a pom extending the spark-2.4 pom and just changing the scala version.