### PR TITLE
Fixes #369: add parameters to filters

### DIFF
--- a/common/src/main/scala/org/neo4j/spark/reader/BasePartitionReader.scala
+++ b/common/src/main/scala/org/neo4j/spark/reader/BasePartitionReader.scala
@@ -34,10 +34,6 @@ abstract class BasePartitionReader(private val options: Neo4jOptions,
     Neo4jUtil.paramsFromFilters(filters)
       .foreach(p => params.put(p._1, p._2))
 
-    if (log.isDebugEnabled) {
-      log.debug(s"Query Parameters are: $params")
-    }
-
     params.asJava
   }
 
@@ -48,7 +44,13 @@ abstract class BasePartitionReader(private val options: Neo4jOptions,
       session = driverCache.getOrCreate().session(options.session.toNeo4jSession)
       transaction = session.beginTransaction()
       log.info(s"Running the following query on Neo4j: $query")
-      result = transaction.run(query, Values.value(getQueryParameters))
+
+      val queryParams = getQueryParameters
+      if (log.isDebugEnabled) {
+        log.debug(s"Query Parameters are: $queryParams")
+      }
+
+      result = transaction.run(query, Values.value(queryParams))
         .asScala
     }
 

--- a/common/src/main/scala/org/neo4j/spark/reader/BasePartitionReader.scala
+++ b/common/src/main/scala/org/neo4j/spark/reader/BasePartitionReader.scala
@@ -7,17 +7,19 @@ import org.apache.spark.sql.types.StructType
 import org.neo4j.driver.{Record, Session, Transaction, Values}
 import org.neo4j.spark.service.{MappingService, Neo4jQueryReadStrategy, Neo4jQueryService, Neo4jQueryStrategy, Neo4jReadMappingStrategy, PartitionSkipLimit}
 import org.neo4j.spark.util.{DriverCache, Neo4jOptions, Neo4jUtil}
+import org.neo4j.spark.util.Neo4jImplicits.{CypherImplicits, FilterImplicit, StructTypeImplicit}
 
 import java.util
 import scala.collection.JavaConverters._
+import scala.collection.mutable
 
 abstract class BasePartitionReader(private val options: Neo4jOptions,
-                          private val filters: Array[Filter],
-                          private val schema: StructType,
-                          private val jobId: String,
-                          private val partitionSkipLimit: PartitionSkipLimit,
-                          private val scriptResult: java.util.List[java.util.Map[String, AnyRef]],
-                          private val requiredColumns: StructType) extends Logging {
+                                   private val filters: Array[Filter],
+                                   private val schema: StructType,
+                                   private val jobId: String,
+                                   private val partitionSkipLimit: PartitionSkipLimit,
+                                   private val scriptResult: java.util.List[java.util.Map[String, AnyRef]],
+                                   private val requiredColumns: StructType) extends Logging {
   private var result: Iterator[Record] = _
   private var session: Session = _
   private var transaction: Transaction = _
@@ -44,13 +46,6 @@ abstract class BasePartitionReader(private val options: Neo4jOptions,
     result.hasNext
   }
 
-  protected def getQueryParameters: util.Map[String, AnyRef] = {
-    if (log.isDebugEnabled) {
-      log.debug(s"Query Parameters are: $values")
-    }
-    values
-  }
-
   def get: InternalRow = mappingService.convert(result.next(), schema)
 
   def close(): Unit = {
@@ -59,4 +54,19 @@ abstract class BasePartitionReader(private val options: Neo4jOptions,
     driverCache.close()
   }
 
+  protected def getQueryParameters: util.Map[String, Any] = {
+    val params = mutable.HashMap[String, Any]()
+    params.put(Neo4jQueryStrategy.VARIABLE_SCRIPT_RESULT, scriptResult)
+    val flatten = filters.flatMap(f => f.flattenFilters)
+
+    flatten.map(Neo4jUtil.getAttributeAndValue)
+      .filter(_.nonEmpty)
+      .foreach(valAndAtt => params.put(valAndAtt.head.toString.unquote(), valAndAtt(1)))
+
+    if (log.isDebugEnabled) {
+      log.debug(s"Query Parameters are: $params")
+    }
+
+    params.asJava
+  }
 }

--- a/common/src/main/scala/org/neo4j/spark/service/SchemaService.scala
+++ b/common/src/main/scala/org/neo4j/spark/service/SchemaService.scala
@@ -5,7 +5,7 @@ import org.apache.spark.sql.sources.Filter
 import org.apache.spark.sql.types.{DataType, DataTypes, StructField, StructType}
 import org.neo4j.driver.exceptions.ClientException
 import org.neo4j.driver.types.Entity
-import org.neo4j.driver.{Record, Session, Transaction, TransactionWork, Value, summary}
+import org.neo4j.driver.{Record, Session, Transaction, TransactionWork, Value, Values, summary}
 import org.neo4j.spark.service.SchemaService.{cypherToSparkType, normalizedClassName, normalizedClassNameFromGraphEntity}
 import org.neo4j.spark.util.Neo4jImplicits.{CypherImplicits, EntityImplicits}
 import org.neo4j.spark.util._
@@ -252,7 +252,7 @@ class SchemaService(private val options: Neo4jOptions, private val driverCache: 
       queryReadStrategy.createStatementForNodeCount(options)
     }
     log.info(s"Executing the following counting query on Neo4j: $query")
-    session.run(query)
+    session.run(query, Values.value(Neo4jUtil.paramsFromFilters(filters).asJava))
       .list()
       .asScala
       .map(_.get("count"))

--- a/common/src/main/scala/org/neo4j/spark/streaming/BaseStreamingPartitionReader.scala
+++ b/common/src/main/scala/org/neo4j/spark/streaming/BaseStreamingPartitionReader.scala
@@ -30,9 +30,8 @@ class BaseStreamingPartitionReader(private val options: Neo4jOptions,
   private val field = filters.find(f => f.getAttribute
       .map(name => name == prop).getOrElse(false))
 
-
   private lazy val values = {
-    val map = new util.HashMap[String, AnyRef](super.getQueryParameters)
+    val map = new util.HashMap[String, Any](super.getQueryParameters)
     val value: Long = field
       .flatMap(f => f.getValue)
       .getOrElse(StreamingFrom.ALL.value())
@@ -57,6 +56,6 @@ class BaseStreamingPartitionReader(private val options: Neo4jOptions,
     OffsetStorage.setLastOffset(jobId, timestamp)
   }
 
-  override protected def getQueryParameters: util.Map[String, AnyRef] = values
+  override protected def getQueryParameters: util.Map[String, Any] = values
 
 }

--- a/common/src/main/scala/org/neo4j/spark/streaming/BaseStreamingPartitionReader.scala
+++ b/common/src/main/scala/org/neo4j/spark/streaming/BaseStreamingPartitionReader.scala
@@ -36,7 +36,7 @@ class BaseStreamingPartitionReader(private val options: Neo4jOptions,
       .flatMap(f => f.getValue)
       .getOrElse(StreamingFrom.ALL.value())
       .asInstanceOf[Long]
-    map.put(Neo4jQueryStrategy.VARIABLE_STREAM, Collections.singletonMap("offset", value))
+    map.put(Neo4jUtil.createParameterName(Neo4jQueryStrategy.VARIABLE_STREAM, value), Collections.singletonMap("offset", value))
     map
   }
 

--- a/common/src/main/scala/org/neo4j/spark/streaming/BaseStreamingPartitionReader.scala
+++ b/common/src/main/scala/org/neo4j/spark/streaming/BaseStreamingPartitionReader.scala
@@ -36,7 +36,7 @@ class BaseStreamingPartitionReader(private val options: Neo4jOptions,
       .flatMap(f => f.getValue)
       .getOrElse(StreamingFrom.ALL.value())
       .asInstanceOf[Long]
-    map.put(Neo4jUtil.createParameterName(Neo4jQueryStrategy.VARIABLE_STREAM, value), Collections.singletonMap("offset", value))
+    map.put(Neo4jQueryStrategy.VARIABLE_STREAM, Collections.singletonMap("offset", value))
     map
   }
 

--- a/common/src/main/scala/org/neo4j/spark/util/Neo4jImplicits.scala
+++ b/common/src/main/scala/org/neo4j/spark/util/Neo4jImplicits.scala
@@ -140,8 +140,15 @@ object Neo4jImplicits {
 
     def getAttributeWithoutEntityName: Option[String] = filter.getAttribute.map(_.unquote().split('.').tail.mkString("."))
 
+    /**
+     * df: we are not handling AND/OR because they are not actually filters
+     * and have a different internal structure. Before calling this function on the filters
+     * it's highly suggested FilterImplicit::flattenFilter() which returns a collection
+     * of filters, including the one contained in the ANDs/ORs objects.
+     */
     def getAttributeAndValue: Seq[Any] = {
       filter match {
+        case f: EqualNullSafe => Seq(f.attribute.toParameterName(f.value), f.value)
         case f: EqualTo => Seq(f.attribute.toParameterName(f.value), f.value)
         case f: GreaterThan => Seq(f.attribute.toParameterName(f.value), f.value)
         case f: GreaterThanOrEqual => Seq(f.attribute.toParameterName(f.value), f.value)

--- a/common/src/main/scala/org/neo4j/spark/util/Neo4jImplicits.scala
+++ b/common/src/main/scala/org/neo4j/spark/util/Neo4jImplicits.scala
@@ -29,6 +29,24 @@ object Neo4jImplicits {
         str
       }
     }
+
+    /**
+     * df: we need this to handle scenarios like `WHERE age > 19 and age < 22`,
+     * so we can't basically add a parameter named $age.
+     * So we base64 encode the value to ensure a unique parameter name
+     */
+    def toParameterName(value: Any): String = {
+      val attributeValue = if (value == null) {
+        "NULL"
+      }
+      else {
+        value.toString
+      }
+
+      val base64ed = java.util.Base64.getEncoder.encodeToString(attributeValue.getBytes())
+
+      s"${base64ed}_${str.unquote()}".quote()
+    }
   }
 
   implicit class EntityImplicits(entity: Entity) {

--- a/common/src/main/scala/org/neo4j/spark/util/Neo4jImplicits.scala
+++ b/common/src/main/scala/org/neo4j/spark/util/Neo4jImplicits.scala
@@ -151,7 +151,7 @@ object Neo4jImplicits {
         case f: StringStartsWith => Seq(f.attribute.toParameterName(f.value), f.value)
         case f: StringEndsWith => Seq(f.attribute.toParameterName(f.value), f.value)
         case f: StringContains => Seq(f.attribute.toParameterName(f.value), f.value)
-        case f: Not => f.getAttributeAndValue
+        case f: Not => f.child.getAttributeAndValue
         case _ => Seq()
       }
     }

--- a/common/src/main/scala/org/neo4j/spark/util/Neo4jUtil.scala
+++ b/common/src/main/scala/org/neo4j/spark/util/Neo4jUtil.scala
@@ -22,12 +22,9 @@ import java.time._
 import java.time.format.DateTimeFormatter
 import java.util.Properties
 import org.neo4j.spark.util.Neo4jImplicits._
-import org.spark_project.guava.io.BaseEncoding
 
-import java.util
 import scala.annotation.tailrec
 import scala.collection.JavaConverters._
-import scala.collection.mutable
 
 object Neo4jUtil {
 
@@ -285,7 +282,10 @@ object Neo4jUtil {
     else {
       value.toString
     }
-    s"${BaseEncoding.base64().encode(attributeValue.getBytes(Charsets.UTF_8))}_$attribute".quote()
+
+    val base64ed = java.util.Base64.getEncoder.encodeToString(attributeValue.getBytes())
+
+    s"${base64ed}_$attribute".quote()
   }
 
   def mapSparkFiltersToCypher(filter: Filter, container: PropertyContainer, attributeAlias: Option[String] = None): Condition = {

--- a/common/src/main/scala/org/neo4j/spark/util/Neo4jUtil.scala
+++ b/common/src/main/scala/org/neo4j/spark/util/Neo4jUtil.scala
@@ -11,7 +11,7 @@ import org.apache.spark.sql.catalyst.util.{ArrayBasedMapData, ArrayData, DateTim
 import org.apache.spark.sql.sources._
 import org.apache.spark.sql.types._
 import org.apache.spark.unsafe.types.UTF8String
-import org.neo4j.cypherdsl.core.{Condition, Cypher, Expression, Functions, Parameter, Property, PropertyContainer}
+import org.neo4j.cypherdsl.core.{Condition, Cypher, Property, PropertyContainer}
 import org.neo4j.driver.internal._
 import org.neo4j.driver.types.{Entity, Path}
 import org.neo4j.driver.{Session, Transaction, Value, Values}
@@ -313,6 +313,7 @@ object Neo4jUtil {
       case not: Not => mapSparkFiltersToCypher(not.child, container, attributeAlias).not()
       case filter@(_: Filter) => throw new IllegalArgumentException(s"Filter of type `$filter` is not supported.")
     }
+  }
 
   def getStreamingPropertyName(options: Neo4jOptions) = options.query.queryType match {
     case QueryType.RELATIONSHIP => s"rel.${options.streamingOptions.propertyName}"

--- a/common/src/main/scala/org/neo4j/spark/util/Neo4jUtil.scala
+++ b/common/src/main/scala/org/neo4j/spark/util/Neo4jUtil.scala
@@ -24,8 +24,10 @@ import java.util.Properties
 import org.neo4j.spark.util.Neo4jImplicits._
 import org.spark_project.guava.io.BaseEncoding
 
+import java.util
 import scala.annotation.tailrec
 import scala.collection.JavaConverters._
+import scala.collection.mutable
 
 object Neo4jUtil {
 
@@ -262,6 +264,13 @@ object Neo4jUtil {
       case f: Not => getAttributeAndValue(f.child)
       case _ => Seq()
     }
+  }
+
+  def paramsFromFilters(filters: Array[Filter]): Map[String, Any] = {
+    filters.flatMap(f => f.flattenFilters).map(Neo4jUtil.getAttributeAndValue)
+      .filter(_.nonEmpty)
+      .map(valAndAtt => valAndAtt.head.toString.unquote() -> valAndAtt(1))
+      .toMap
   }
 
   /**

--- a/common/src/main/scala/org/neo4j/spark/util/Neo4jUtil.scala
+++ b/common/src/main/scala/org/neo4j/spark/util/Neo4jUtil.scala
@@ -4,7 +4,6 @@ import com.fasterxml.jackson.core.JsonGenerator
 import com.fasterxml.jackson.databind.module.SimpleModule
 import com.fasterxml.jackson.databind.{JsonSerializer, ObjectMapper, SerializerProvider}
 import com.google.common.base.Charsets
-import com.google.common.io.BaseEncoding
 import org.apache.spark.sql.catalyst.InternalRow
 import org.apache.spark.sql.catalyst.expressions.{GenericRowWithSchema, UnsafeArrayData, UnsafeMapData, UnsafeRow}
 import org.apache.spark.sql.catalyst.util.{ArrayBasedMapData, ArrayData, DateTimeUtils}
@@ -23,6 +22,7 @@ import java.time._
 import java.time.format.DateTimeFormatter
 import java.util.Properties
 import org.neo4j.spark.util.Neo4jImplicits._
+import org.spark_project.guava.io.BaseEncoding
 
 import scala.annotation.tailrec
 import scala.collection.JavaConverters._

--- a/common/src/test/scala/org/neo4j/spark/service/Neo4jQueryServiceTest.scala
+++ b/common/src/test/scala/org/neo4j/spark/service/Neo4jQueryServiceTest.scala
@@ -4,6 +4,7 @@ import org.apache.spark.sql.SaveMode
 import org.apache.spark.sql.sources._
 import org.junit.Assert._
 import org.junit.Test
+import org.neo4j.spark.util.Neo4jImplicits.CypherImplicits
 import org.neo4j.spark.util.{Neo4jOptions, Neo4jUtil, QueryType}
 
 import scala.collection.immutable.HashMap
@@ -107,7 +108,7 @@ class Neo4jQueryServiceTest {
 
     val query: String = new Neo4jQueryService(neo4jOptions, new Neo4jQueryReadStrategy(filters)).createQuery()
 
-    val paramName = "$" + Neo4jUtil.createParameterName("name", "John Doe")
+    val paramName = "$" + "name".toParameterName("John Doe")
 
     assertEquals(s"MATCH (n:`Person`) WHERE n.name = $paramName RETURN n", query)
   }
@@ -126,8 +127,8 @@ class Neo4jQueryServiceTest {
 
     val query: String = new Neo4jQueryService(neo4jOptions, new Neo4jQueryReadStrategy(filters)).createQuery()
 
-    val nameParameterName = "$" + Neo4jUtil.createParameterName("name", "John Doe")
-    val ageParameterName = "$" + Neo4jUtil.createParameterName("age", 36)
+    val nameParameterName = "$" + "name".toParameterName("John Doe")
+    val ageParameterName = "$" + "age".toParameterName(36)
 
     assertEquals(
       s"""MATCH (n:`Person`)
@@ -150,8 +151,8 @@ class Neo4jQueryServiceTest {
 
     val query: String = new Neo4jQueryService(neo4jOptions, new Neo4jQueryReadStrategy(filters)).createQuery()
 
-    val nameParameterName = "$" + Neo4jUtil.createParameterName("name", null)
-    val ageParameterName = "$" + Neo4jUtil.createParameterName("age", 36)
+    val nameParameterName = "$" + "name".toParameterName(null)
+    val ageParameterName = "$" + "age".toParameterName(36)
 
     assertEquals(s"MATCH (n:`Person`) WHERE (((n.name IS NULL AND $nameParameterName IS NULL) OR n.name = $nameParameterName) AND n.age = $ageParameterName) RETURN n", query)
   }
@@ -170,8 +171,8 @@ class Neo4jQueryServiceTest {
 
     val query: String = new Neo4jQueryService(neo4jOptions, new Neo4jQueryReadStrategy(filters)).createQuery()
 
-    val nameOneParameterName = "$" + Neo4jUtil.createParameterName("name", "Person Name")
-    val nameTwoParameterName = "$" + Neo4jUtil.createParameterName("name", "Person Surname")
+    val nameOneParameterName = "$" + "name".toParameterName("Person Name")
+    val nameTwoParameterName = "$" + "name".toParameterName("Person Surname")
 
     assertEquals(
       s"""MATCH (n:`Person`)
@@ -259,7 +260,7 @@ class Neo4jQueryServiceTest {
 
     val query: String = new Neo4jQueryService(neo4jOptions, new Neo4jQueryReadStrategy(filters)).createQuery()
 
-    val parameterName = "$" + Neo4jUtil.createParameterName("source.name", "John Doe")
+    val parameterName = "$" + "source.name".toParameterName("John Doe")
 
     assertEquals("MATCH (source:`Person`) " +
       "MATCH (target:`Person`) " +
@@ -282,8 +283,8 @@ class Neo4jQueryServiceTest {
 
     val query: String = new Neo4jQueryService(neo4jOptions, new Neo4jQueryReadStrategy(filters)).createQuery()
 
-    val paramOneName = "$" + Neo4jUtil.createParameterName("source.name", "John Doe")
-    val paramTwoName = "$" + Neo4jUtil.createParameterName("target.name", "John Doe")
+    val paramOneName = "$" + "source.name".toParameterName("John Doe")
+    val paramTwoName = "$" + "target.name".toParameterName("John Doe")
 
     assertEquals("MATCH (source:`Person`) " +
       "MATCH (target:`Person`) " +
@@ -307,8 +308,8 @@ class Neo4jQueryServiceTest {
 
     val query: String = new Neo4jQueryService(neo4jOptions, new Neo4jQueryReadStrategy(filters)).createQuery()
 
-    val sourceIdParameterName = "$" + Neo4jUtil.createParameterName("source.id", 14)
-    val targetIdParameterName = "$" + Neo4jUtil.createParameterName("target.id", 16)
+    val sourceIdParameterName = "$" + "source.id".toParameterName(14)
+    val targetIdParameterName = "$" + "target.id".toParameterName(16)
 
     assertEquals(
       s"""MATCH (source:`Person`)
@@ -335,12 +336,12 @@ class Neo4jQueryServiceTest {
     val query: String = new Neo4jQueryService(neo4jOptions, new Neo4jQueryReadStrategy(filters)).createQuery()
 
     val parameterNames: Map[String, String] = HashMap(
-      "name_1" -> "$".concat(Neo4jUtil.createParameterName("name", "John Doe")),
-      "name_2" -> "$".concat(Neo4jUtil.createParameterName("name", "John Scofield")),
-      "age_1" -> "$".concat(Neo4jUtil.createParameterName("age", 15)),
-      "age_2" -> "$".concat(Neo4jUtil.createParameterName("age", 18)),
-      "age_3" -> "$".concat(Neo4jUtil.createParameterName("age", 22)),
-      "age_4" -> "$".concat(Neo4jUtil.createParameterName("age", 11))
+      "name_1" -> "$".concat("name".toParameterName("John Doe")),
+      "name_2" -> "$".concat("name".toParameterName("John Scofield")),
+      "age_1" -> "$".concat("age".toParameterName(15)),
+      "age_2" -> "$".concat("age".toParameterName(18)),
+      "age_3" -> "$".concat("age".toParameterName(22)),
+      "age_4" -> "$".concat("age".toParameterName(11))
     )
 
     assertEquals(
@@ -370,12 +371,12 @@ class Neo4jQueryServiceTest {
     val query: String = new Neo4jQueryService(neo4jOptions, new Neo4jQueryReadStrategy(filters)).createQuery()
 
     val parameterNames = Map(
-      "source.name_1" -> "$".concat(Neo4jUtil.createParameterName("source.name", "John Doe")),
-      "target.name_1" -> "$".concat(Neo4jUtil.createParameterName("target.name", "John Doraemon")),
-      "source.name_2" -> "$".concat(Neo4jUtil.createParameterName("source.name", "Jane Doe")),
-      "target.age_1" -> "$".concat(Neo4jUtil.createParameterName("target.age", 34)),
-      "target.age_2" -> "$".concat(Neo4jUtil.createParameterName("target.age", 18)),
-      "rel.score" -> "$".concat(Neo4jUtil.createParameterName("rel.score", 12))
+      "source.name_1" -> "$".concat("source.name".toParameterName("John Doe")),
+      "target.name_1" -> "$".concat("target.name".toParameterName("John Doraemon")),
+      "source.name_2" -> "$".concat("source.name".toParameterName("Jane Doe")),
+      "target.age_1" -> "$".concat("target.age".toParameterName(34)),
+      "target.age_2" -> "$".concat("target.age".toParameterName(18)),
+      "rel.score" -> "$".concat("rel.score".toParameterName(12))
     )
 
     assertEquals(
@@ -407,12 +408,12 @@ class Neo4jQueryServiceTest {
     val query: String = new Neo4jQueryService(neo4jOptions, new Neo4jQueryReadStrategy(filters)).createQuery()
 
     val parameterNames = Map(
-      "source.name_1" -> "$".concat(Neo4jUtil.createParameterName("source.name", "John Doe")),
-      "target.name_1" -> "$".concat(Neo4jUtil.createParameterName("target.name", "John Doraemon")),
-      "source.name_2" -> "$".concat(Neo4jUtil.createParameterName("source.name", "Jane Doe")),
-      "target.age_1" -> "$".concat(Neo4jUtil.createParameterName("target.age", 34)),
-      "target.age_2" -> "$".concat(Neo4jUtil.createParameterName("target.age", 18)),
-      "rel.score" -> "$".concat(Neo4jUtil.createParameterName("rel.score", 12))
+      "source.name_1" -> "$".concat("source.name".toParameterName("John Doe")),
+      "target.name_1" -> "$".concat("target.name".toParameterName("John Doraemon")),
+      "source.name_2" -> "$".concat("source.name".toParameterName("Jane Doe")),
+      "target.age_1" -> "$".concat("target.age".toParameterName(34)),
+      "target.age_2" -> "$".concat("target.age".toParameterName(18)),
+      "rel.score" -> "$".concat("rel.score".toParameterName(12))
     )
 
     assertEquals(

--- a/pom.xml
+++ b/pom.xml
@@ -335,6 +335,12 @@
             <version>1.7.30</version>
             <scope>test</scope>
         </dependency>-->
+
+        <dependency>
+            <groupId>com.google.guava</groupId>
+            <artifactId>guava</artifactId>
+            <version>11.0.2</version>
+        </dependency>
     </dependencies>
 
     <repositories>

--- a/pom.xml
+++ b/pom.xml
@@ -335,12 +335,6 @@
             <version>1.7.30</version>
             <scope>test</scope>
         </dependency>-->
-
-        <dependency>
-            <groupId>com.google.guava</groupId>
-            <artifactId>guava</artifactId>
-            <version>11.0.2</version>
-        </dependency>
     </dependencies>
 
     <repositories>


### PR DESCRIPTION
This handles the following cases:

* `WHERE age > 10 AND age < 20` can't have a parameter with the same name for both age values
* OR and AND are particular filters that contains other fillers (or.left, or.right), and each filter can be either an OR or an AND
* parameters name with a dot inside
* count query on streaming read (added parameters to count query since it has `timestamp`)
* quoted attribues
* `WHERE date > date($dateParam)`
* `$stream.offset` parameter