### PR TITLE
fix to clean up python in an example program

### DIFF
--- a/doc/docs/modules/ROOT/pages/python.adoc
+++ b/doc/docs/modules/ROOT/pages/python.adoc
@@ -62,12 +62,22 @@ The same program in python is very similar, again just with language syntax diff
 
 [source,python]
 ----
-import org.apache.spark.sql.{SaveMode, SparkSession}
-
 df.write \
   .format("org.neo4j.spark.DataSource") \
   .mode("ErrorIfExists") \
   .option("url", "bolt://localhost:7687") \
   .option("labels", ":Person") \
   .save()
+----
+
+In order to avoid the necessity for backslashes on each line, you can also use parentheses like so:
+
+[source,python]
+----
+result = (df.write 
+  .format("org.neo4j.spark.DataSource")
+  .mode("ErrorIfExists")
+  .option("url", "bolt://localhost:7687")
+  .option("labels", ":Person")
+  .save())
 ----


### PR DESCRIPTION
Fixing feedback from @voutilad who pointed out that one of the sample python examples wasn't python.