### PR TITLE
Add Neo4j 4.4 test to CI

### DIFF
--- a/.github/workflows/jvm-ci.yml
+++ b/.github/workflows/jvm-ci.yml
@@ -16,7 +16,7 @@ jobs:
       matrix:
         scala-version: [2.11, 2.12]
         spark-version: ["2.4", "3"]
-        neo4j-version: ["3.5", "4.0", "4.1", "4.2", "4.3"]
+        neo4j-version: ["3.5", "4.0", "4.1", "4.2", "4.3", "4.4"]
     name: Build with Scala ${{ matrix.scala-version }}, Spark ${{ matrix.spark-version }} and Neo4j ${{ matrix.neo4j-version }}
     steps:
       - uses: actions/checkout@v2

--- a/pom.xml
+++ b/pom.xml
@@ -145,6 +145,13 @@
                 <neo4j.experimental>false</neo4j.experimental>
             </properties>
         </profile>
+        <profile>
+            <id>neo4j-4.4</id>
+            <properties>
+                <neo4j.version>4.4.0-alpha01</neo4j.version>
+                <neo4j.experimental>true</neo4j.experimental>
+            </properties>
+        </profile>
     </profiles>
 
     <build>

--- a/spark-2.4/src/test/scala/org/neo4j/spark/DataSourceWriterTSE.scala
+++ b/spark-2.4/src/test/scala/org/neo4j/spark/DataSourceWriterTSE.scala
@@ -479,7 +479,13 @@ class DataSourceWriterTSE extends SparkConnectorScalaBaseTSE {
     } catch {
       case sparkException: SparkException => {
         val clientException = ExceptionUtils.getRootCause(sparkException)
-        assertTrue(clientException.getMessage.endsWith("already exists with label `Person` and property `surname` = 'Santurbano'"))
+        if (TestUtil.neo4jVersion().startsWith("4.4")) {
+          assertTrue(clientException.getMessage.endsWith("share the property value ( String(\"Santurbano\") )"))
+        }
+        else {
+          assertTrue(clientException.getMessage.endsWith("already exists with label `Person` and property `surname` = 'Santurbano'"))
+        }
+
         throw sparkException
       }
       case e: Throwable => fail(s"should be thrown a ${classOf[SparkException].getName} but is ${e.getClass.getSimpleName}")

--- a/spark-3/src/test/scala/org/neo4j/spark/DataSourceWriterTSE.scala
+++ b/spark-3/src/test/scala/org/neo4j/spark/DataSourceWriterTSE.scala
@@ -479,7 +479,12 @@ class DataSourceWriterTSE extends SparkConnectorScalaBaseTSE {
     } catch {
       case sparkException: SparkException => {
         val clientException = ExceptionUtils.getRootCause(sparkException)
-        assertTrue(clientException.getMessage.endsWith("already exists with label `Person` and property `surname` = 'Santurbano'"))
+        if (TestUtil.neo4jVersion().startsWith("4.4")) {
+          assertTrue(clientException.getMessage.endsWith("share the property value ( String(\"Santurbano\") )"))
+        }
+        else {
+          assertTrue(clientException.getMessage.endsWith("already exists with label `Person` and property `surname` = 'Santurbano'"))
+        }
         throw sparkException
       }
       case e: Throwable => fail(s"should be thrown a ${classOf[SparkException].getName} but is ${e.getClass.getSimpleName}")


### PR DESCRIPTION
Added Neo4j 4.4 tests to Java CI

**Note**: remember to add "4.4" to Python CI after Neo4j 4.4 is released since Python is not handling the experimental flag

---

![goodbye](https://media.giphy.com/media/12Rgr4DFzKywKI/giphy.gif)
