### PR TITLE
Add playbooks for docs build processes

### DIFF
--- a/doc/package.json
+++ b/doc/package.json
@@ -15,14 +15,17 @@
     "server": "forever start server.js",
     "start": "npm run server && npm-watch",
     "stop": "forever stop server.js",
-    "build:docs": "antora --fetch --stacktrace docs.yml",
+    "build:docs": "antora --fetch --stacktrace preview.yml",
     "lint:links": "node tasks/lint-links.js"
   },
   "license": "ISC",
   "dependencies": {
     "@antora/cli": "^2.3.3",
     "@antora/site-generator-default": "^2.3.3",
-    "cheerio": "^1.0.0-rc.3"
+    "cheerio": "^1.0.0-rc.3",
+    "@neo4j-antora/antora-listing-roles": "^0.1.0",
+    "@neo4j-documentation/macros": "^1.0.0",
+    "@neo4j-documentation/remote-include": "^1.0.0"
   },
   "devDependencies": {
     "express": "^4.17.1",

--- a/doc/preview.yml
+++ b/doc/preview.yml
@@ -1,0 +1,46 @@
+site:
+  title: Neo4j Connector for Apache Spark User Guide
+  url: https://neo4j.com/docs
+  start_page: spark:ROOT:index.adoc
+
+content:
+  sources:
+    - url: ../
+      branches: ['HEAD']
+      start_path: doc/docs
+      edit_url: https://github.com/neo4j-contrib/neo4j-spark-connector/tree/{refname}/{path}
+      exclude:
+      - '!**/_includes/*'
+      - '!**/readme.adoc'
+      - '!**/README.adoc'
+
+ui:
+  bundle:
+    url: https://s3-eu-west-1.amazonaws.com/static-content.neo4j.com/build/ui-bundle-latest.zip
+    snapshot: true
+  output_dir: /assets
+
+urls:
+  html_extension_style: indexify
+
+asciidoc:
+  extensions:
+  - "@neo4j-documentation/remote-include"
+  - "@neo4j-documentation/macros"
+  - "@neo4j-antora/antora-listing-roles"
+  attributes:
+    page-theme: docs
+    page-type: Docs
+    page-search-type: Docs
+    page-search-site: Reference Docs
+    page-canonical-root: /docs
+    page-pagination: true
+    page-no-canonical: true
+    page-origin-private: false
+    page-hide-toc: false
+    page-mixpanel: 4bfb2414ab973c741b6f067bf06d5575
+    includePDF: false
+    nonhtmloutput: ""
+    experimental: ''
+    copyright: 2021
+    common-license-page-uri: https://neo4j.com/docs/license/

--- a/doc/publish.yml
+++ b/doc/publish.yml
@@ -1,0 +1,46 @@
+site:
+  title: Neo4j Connector for Apache Spark User Guide
+  url: https://neo4j.com/docs
+  start_page: spark:ROOT:index.adoc
+
+content:
+  sources:
+    - url: "https://github.com/neo4j-contrib/neo4j-spark-connector"
+      branches: ['4.1', '4.0']
+      start_path: doc/docs
+      edit_url: https://github.com/neo4j-contrib/neo4j-spark-connector/tree/{refname}/{path}
+      exclude:
+      - '!**/_includes/*'
+      - '!**/readme.adoc'
+      - '!**/README.adoc'
+
+ui:
+  bundle:
+    url: https://s3-eu-west-1.amazonaws.com/static-content.neo4j.com/build/ui-bundle-latest.zip
+    snapshot: true
+  output_dir: /assets
+
+urls:
+  html_extension_style: indexify
+
+asciidoc:
+  extensions:
+  - "@neo4j-documentation/remote-include"
+  - "@neo4j-documentation/macros"
+  - "@neo4j-antora/antora-listing-roles"
+  attributes:
+    page-theme: docs
+    page-type: Docs
+    page-search-type: Docs
+    page-search-site: Reference Docs
+    page-canonical-root: /docs
+    page-pagination: true
+    page-no-canonical: true
+    page-origin-private: false
+    page-hide-toc: false
+    page-mixpanel: 4bfb2414ab973c741b6f067bf06d5575
+    includePDF: false
+    nonhtmloutput: ""
+    experimental: ''
+    copyright: 2021
+    common-license-page-uri: https://neo4j.com/docs/license/


### PR DESCRIPTION
Adds two playbooks:
- preview.yml - for local builds, to generate HTML from locally checked out content in the current branch
- publish.yml - for CI builds, to generate HTML direct from the git branches, for all released versions
