### PR TITLE
fixes #389: Check Support For Spark 3.2

### DIFF
--- a/.github/workflows/jvm-ci.yml
+++ b/.github/workflows/jvm-ci.yml
@@ -14,27 +14,27 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        scala-version: [2.11, 2.12]
+        scala-version: [2.11, 2.12, 2.13]
         spark-version: ["2.4", "3"]
         neo4j-version: ["3.5", "4.0", "4.1", "4.2", "4.3", "4.4"]
     name: Build with Scala ${{ matrix.scala-version }}, Spark ${{ matrix.spark-version }} and Neo4j ${{ matrix.neo4j-version }}
     steps:
       - uses: actions/checkout@v2
-        if: ${{ !(matrix.spark-version == 3 && matrix.scala-version == 2.11) }}
+        if: ${{ !(matrix.spark-version == 3 && matrix.scala-version == 2.11) && !(matrix.spark-version == 2.4 && matrix.scala-version == 2.13) }}
       - name: Set up JDK 8
-        if: ${{ !(matrix.spark-version == 3 && matrix.scala-version == 2.11) }}
+        if: ${{ !(matrix.spark-version == 3 && matrix.scala-version == 2.11) && !(matrix.spark-version == 2.4 && matrix.scala-version == 2.13) }}
         uses: actions/setup-java@v1
         with:
           java-version: 1.8
       - name: Cache Maven packages
-        if: ${{ !(matrix.spark-version == 3 && matrix.scala-version == 2.11) }}
+        if: ${{ !(matrix.spark-version == 3 && matrix.scala-version == 2.11) && !(matrix.spark-version == 2.4 && matrix.scala-version == 2.13) }}
         uses: actions/cache@v1
         with:
           path: ~/.m2
           key: ${{ runner.os }}-m2-${{ hashFiles('**/pom.xml') }}
           restore-keys: ${{ runner.os }}-m2
       - name: Build with Maven
-        if: ${{ !(matrix.spark-version == 3 && matrix.scala-version == 2.11) }}
+        if: ${{ !(matrix.spark-version == 3 && matrix.scala-version == 2.11) && !(matrix.spark-version == 2.4 && matrix.scala-version == 2.13) }}
         env:
           CI: true
         run: ./mvnw clean verify -Pscala-${{ matrix.scala-version }} -Pspark-${{ matrix.spark-version }} -Pneo4j-${{ matrix.neo4j-version }} --no-transfer-progress

--- a/.github/workflows/python-ci.yml
+++ b/.github/workflows/python-ci.yml
@@ -14,8 +14,8 @@ jobs:
       fail-fast: false
       matrix:
         python-version: [ "3.6", "3.7", "3.8" ]
-        neo4j-version: [ "3.5", "4.0", "4.1", "4.2", "4.3" ]
-        spark-version: [ {short: "2.4", ext: "2.4.5", scala: "2.11" }, {short: "3", ext: "3.0.1", scala: "2.12"}, {short: "3", ext: "3.1.1", scala: "2.12"} ]
+        neo4j-version: [ "3.5", "4.0", "4.1", "4.2", "4.3", "4.4" ]
+        spark-version: [ {short: "2.4", ext: "2.4.8", scala: "2.11" }, {short: "3", ext: "3.0.1", scala: "2.12"}, {short: "3", ext: "3.1.1", scala: "2.12"}, {short: "3", ext: "3.2.0", scala: "2.12"} ]
 
     steps:
       - uses: actions/checkout@v2
@@ -42,7 +42,7 @@ jobs:
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
-          pip install pypandoc six tzlocal==2.1
+          pip install six tzlocal==2.1
           pip install pyspark==${{ matrix.spark-version.ext }} "testcontainers[neo4j]"
       - name: Build artifact
         env:
@@ -50,7 +50,7 @@ jobs:
         run: |
           ./mvnw clean package -DskipTests -P spark-${{ matrix.spark-version.short }} -P scala-${{ matrix.spark-version.scala }} --no-transfer-progress
       - name: Run tests for Spark ${{ matrix.spark-version.ext }} and Neo4j ${{ matrix.neo4j-version }}
-        if: ${{ ! (matrix.spark-version.short == 2.4 && matrix.python-version == 3.8) }}
+        if: ${{ !(matrix.spark-version.short == 2.4 && matrix.python-version == 3.8) && !(matrix.spark-version.ext == '3.2.0' && matrix.python-version == 3.5) }}
         run: |
           cd ./scripts/python
           python test_spark.py "${{ matrix.spark-version.short }}" "${{ matrix.spark-version.scala }}" "${{ matrix.neo4j-version }}" "${{ steps.version.outputs.version }}"

--- a/README.md
+++ b/README.md
@@ -38,13 +38,17 @@ These commands will generate the corresponding targets
 
 ### Building for Spark 3
 
-You can build for Spark 3 by running
+You can build for Spark 2.4 with both Scala 2.12 and Scala 2.13
 
 ```
 ./maven-release.sh package 2.12 3
+./maven-release.sh package 2.13 3
 ```
 
-This will generate `spark-3/target/neo4j-connector-apache-spark_2.12-<version>_for_spark_3.jar`
+This will generate:
+These commands will generate the corresponding targets
+* `spark-3/target/neo4j-connector-apache-spark_2.12-<version>_for_spark_3.jar`
+* `spark-3/target/neo4j-connector-apache-spark_2.13-<version>_for_spark_3.jar`
 
 
 ## Integration with Apache Spark Applications

--- a/common/src/main/scala/org/neo4j/spark/service/SchemaService.scala
+++ b/common/src/main/scala/org/neo4j/spark/service/SchemaService.scala
@@ -62,7 +62,7 @@ class SchemaService(private val options: Neo4jOptions, private val driverCache: 
 
     structFields += StructField(Neo4jUtil.INTERNAL_LABELS_FIELD, DataTypes.createArrayType(DataTypes.StringType), nullable = true)
     structFields += StructField(Neo4jUtil.INTERNAL_ID_FIELD, DataTypes.LongType, nullable = false)
-    StructType(structFields.reverse)
+    StructType(structFields.reverse.toSeq)
   }
 
   private def retrieveSchemaFromApoc(query: String, params: java.util.Map[String, AnyRef]): mutable.Buffer[StructField] = {
@@ -187,7 +187,7 @@ class SchemaService(private val options: Neo4jOptions, private val driverCache: 
     })
       .map(field => StructField(s"rel.${field.name}", field.dataType, field.nullable, field.metadata))
       .sortBy(t => t.name)
-    StructType(structFields)
+    StructType(structFields.toSeq)
   }
 
   def structForQuery(): StructType = {
@@ -208,7 +208,7 @@ class SchemaService(private val options: Neo4jOptions, private val driverCache: 
     }
 
     if (columns.isEmpty) {
-      return StructType(structFields)
+      return StructType(structFields.toSeq)
     }
 
     val sortedStructFields = if (structFields.isEmpty) {
@@ -429,7 +429,7 @@ class SchemaService(private val options: Neo4jOptions, private val driverCache: 
     .asMap()
     .asScala
     .mapResult[Neo4jVersion](m => Neo4jVersion(m("name").asInstanceOf[String],
-      m("versions").asInstanceOf[util.List[String]].asScala,
+      m("versions").asInstanceOf[util.List[String]].asScala.toSeq,
       m("edition").asInstanceOf[String]))
     .result()
 

--- a/common/src/main/scala/org/neo4j/spark/streaming/OffsetStorage.scala
+++ b/common/src/main/scala/org/neo4j/spark/streaming/OffsetStorage.scala
@@ -157,7 +157,7 @@ class Neo4jAccumulator(private val neo4jOptions: Neo4jOptions,
 
   override def isZero: Boolean = true
 
-  override def reset(): Unit = Unit
+  override def reset(): Unit = ()
 }
 
 class SparkAccumulator(private val initialValue: lang.Long = null)
@@ -183,6 +183,6 @@ class SparkAccumulator(private val initialValue: lang.Long = null)
 
   override def value(): lang.Long = offset.get()
 
-  override def close(): Unit = Unit
+  override def close(): Unit = ()
 
 }

--- a/common/src/main/scala/org/neo4j/spark/util/Neo4jOptions.scala
+++ b/common/src/main/scala/org/neo4j/spark/util/Neo4jOptions.scala
@@ -267,7 +267,7 @@ case class Neo4jDriverOptions(
     if (livenessCheckTimeout > -1) builder.withConnectionLivenessCheckTimeout(livenessCheckTimeout, TimeUnit.MILLISECONDS)
     if (connectionTimeout > -1) builder.withConnectionTimeout(connectionTimeout, TimeUnit.MILLISECONDS)
     URI.create(url).getScheme match {
-      case "neo4j+s" | "neo4j+ssc" | "bolt+s" | "bolt+ssc" => Unit
+      case "neo4j+s" | "neo4j+ssc" | "bolt+s" | "bolt+ssc" => ()
       case _ => {
         if (!encryption) {
           builder.withoutEncryption()

--- a/common/src/main/scala/org/neo4j/spark/util/Validations.scala
+++ b/common/src/main/scala/org/neo4j/spark/util/Validations.scala
@@ -94,7 +94,7 @@ case class ValidateSaveMode(saveMode: String) extends Validation {
 case class ValidateWrite(neo4jOptions: Neo4jOptions,
                          jobId: String,
                          saveMode: SaveMode,
-                         customValidation: Neo4jOptions => Unit = _ => Unit) extends Validation {
+                         customValidation: Neo4jOptions => Unit = _ => ()) extends Validation {
   override def validate(): Unit = {
     ValidationUtil.isFalse(neo4jOptions.session.accessMode == AccessMode.READ,
       s"Mode READ not supported for Data Source writer")
@@ -127,7 +127,7 @@ case class ValidateWrite(neo4jOptions: Neo4jOptions,
               ValidationUtil.isNotEmpty(neo4jOptions.nodeMetadata.nodeKeys,
                 s"${Neo4jOptions.NODE_KEYS} is required when Save Mode is Overwrite")
             }
-            case _ => Unit
+            case _ => ()
           }
         }
         case QueryType.RELATIONSHIP => {

--- a/common/src/main/scala/org/neo4j/spark/writer/BaseDataWriter.scala
+++ b/common/src/main/scala/org/neo4j/spark/writer/BaseDataWriter.scala
@@ -96,7 +96,7 @@ abstract class BaseDataWriter(jobId: String,
         }
       case e: Exception => logAndThrowException(e)
     }
-    Unit
+    ()
   }
 
   /**
@@ -135,7 +135,7 @@ abstract class BaseDataWriter(jobId: String,
       }
     }
     close()
-    Unit
+    ()
   }
 
   protected def close(): Unit = {

--- a/pom.xml
+++ b/pom.xml
@@ -56,8 +56,10 @@
         <node.version>v12.16.0</node.version>
         <npm.version>6.13.7</npm.version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+        <java.version>1.8</java.version>
         <!-- This is empty because we use it for the deploy process -->
         <scala.binary.version />
+        <scala-maven-plugin.version>4.5.4</scala-maven-plugin.version>
     </properties>
 
     <profiles>
@@ -82,13 +84,44 @@
                 <scala.version>2.11.12</scala.version>
                 <scala.binary.version>2.11</scala.binary.version>
             </properties>
+            <build>
+                <plugins>
+                    <plugin>
+                        <groupId>net.alchim31.maven</groupId>
+                        <artifactId>scala-maven-plugin</artifactId>
+                        <version>${scala-maven-plugin.version}</version>
+                        <executions>
+                            <execution>
+                                <id>scala-compile</id>
+                                <goals>
+                                    <goal>doc-jar</goal>
+                                </goals>
+                                <phase>process-resources</phase>
+                            </execution>
+                        </executions>
+                        <configuration>
+                            <scalaVersion>${scala.version}</scalaVersion>
+                            <scalaCompatVersion>${scala.binary.version}</scalaCompatVersion>
+                            <args>
+                                <arg>-Xmax-classfile-name</arg>
+                                <arg>100</arg>
+                                <arg>-target:jvm-1.8</arg>
+                            </args>
+                            <jvmArgs>
+                                <jvmArg>-Xms64m</jvmArg>
+                                <jvmArg>-Xmx1024m</jvmArg>
+                            </jvmArgs>
+                        </configuration>
+                    </plugin>
+                </plugins>
+            </build>
         </profile>
         <!-- end scala profiles -->
         <!-- spark profiles -->
         <profile>
             <id>spark-3</id>
             <properties>
-                <spark.version>3.1.1</spark.version>
+                <spark.version>3.2.0</spark.version>
             </properties>
             <modules>
                 <module>spark-3</module>
@@ -146,8 +179,8 @@
         <profile>
             <id>neo4j-4.4</id>
             <properties>
-                <neo4j.version>4.4.0-alpha01</neo4j.version>
-                <neo4j.experimental>true</neo4j.experimental>
+                <neo4j.version>4.4.0</neo4j.version>
+                <neo4j.experimental>false</neo4j.experimental>
             </properties>
         </profile>
         <!-- end neo4j profiles -->
@@ -169,7 +202,7 @@
         <plugins>
             <plugin>
                 <artifactId>maven-surefire-plugin</artifactId>
-                <version>3.0.0-M4</version>
+                <version>3.0.0-M5</version>
                 <configuration>
                     <forkCount>1</forkCount>
                     <reuseForks>false</reuseForks>
@@ -184,15 +217,15 @@
                 <artifactId>maven-compiler-plugin</artifactId>
                 <version>3.8.1</version>
                 <configuration>
-                    <source>1.8</source>
-                    <target>1.8</target>
+                    <source>${java.version}</source>
+                    <target>${java.version}</target>
                     <encoding>UTF-8</encoding>
                 </configuration>
             </plugin>
             <plugin>
                 <groupId>net.alchim31.maven</groupId>
                 <artifactId>scala-maven-plugin</artifactId>
-                <version>4.3.0</version>
+                <version>${scala-maven-plugin.version}</version>
                 <executions>
                     <execution>
                         <id>scala-compile</id>
@@ -216,8 +249,6 @@
                     <scalaVersion>${scala.version}</scalaVersion>
                     <scalaCompatVersion>${scala.binary.version}</scalaCompatVersion>
                     <args>
-                        <arg>-Xmax-classfile-name</arg>
-                        <arg>100</arg>
                         <arg>-target:jvm-1.8</arg>
                         <!-- arg>-deprecation</arg -->
                     </args>

--- a/scripts/python/test_spark.py
+++ b/scripts/python/test_spark.py
@@ -295,7 +295,7 @@ scala_version = str(sys.argv.pop())
 spark_version = str(sys.argv.pop())
 current_time_zone = get_localzone().zone
 
-print("Running tests for Connector %s,  Neo4j %s, Scala %s, Spark %s, TimeZone %s"
+print("Running tests for Connector %s, Neo4j %s, Scala %s, Spark %s, TimeZone %s"
       % (connector_version, neo4j_version, scala_version, spark_version, current_time_zone))
 
 

--- a/spark-2.4/src/main/scala/org/neo4j/spark/streaming/Neo4jDataSourceStreamWriter.scala
+++ b/spark-2.4/src/main/scala/org/neo4j/spark/streaming/Neo4jDataSourceStreamWriter.scala
@@ -54,9 +54,9 @@ class Neo4jDataSourceStreamWriter(val queryId: String,
     scriptResult
   }
 
-  override def commit(epochId: Long, messages: Array[WriterCommitMessage]): Unit = Unit
+  override def commit(epochId: Long, messages: Array[WriterCommitMessage]): Unit = ()
 
-  override def abort(epochId: Long, messages: Array[WriterCommitMessage]): Unit = Unit
+  override def abort(epochId: Long, messages: Array[WriterCommitMessage]): Unit = ()
 
   override def createWriterFactory(): DataWriterFactory[InternalRow] = new Neo4jDataWriterFactory(queryId, schema, streamingSaveMode, neo4jOptions, scriptResult)
 

--- a/spark-2.4/src/main/scala/org/neo4j/spark/streaming/Neo4jMicroBatchReader.scala
+++ b/spark-2.4/src/main/scala/org/neo4j/spark/streaming/Neo4jMicroBatchReader.scala
@@ -103,7 +103,7 @@ class Neo4jMicroBatchReader(private val optionalSchema: Optional[StructType],
 
   override def deserializeOffset(json: String): Offset = Neo4jOffset24(json.toLong)
 
-  override def commit(end: Offset): Unit = Unit
+  override def commit(end: Offset): Unit = ()
 
   override def planInputPartitions: util.ArrayList[InputPartition[InternalRow]] = {
     startedExecution = true

--- a/spark-3/src/main/scala/org/neo4j/spark/streaming/Neo4jStreamingWriter.scala
+++ b/spark-3/src/main/scala/org/neo4j/spark/streaming/Neo4jStreamingWriter.scala
@@ -17,18 +17,18 @@ class Neo4jStreamingWriter(val queryId: String,
   private val self = this
 
   private val listener = new StreamingQueryListener {
-    override def onQueryStarted(event: StreamingQueryListener.QueryStartedEvent): Unit = {}
+    override def onQueryStarted(event: StreamingQueryListener.QueryStartedEvent): Unit = ()
 
-    override def onQueryProgress(event: StreamingQueryListener.QueryProgressEvent): Unit = {}
+    override def onQueryProgress(event: StreamingQueryListener.QueryProgressEvent): Unit = ()
 
     override def onQueryTerminated(event: StreamingQueryListener.QueryTerminatedEvent): Unit = {
       if (event.id.toString == queryId) {
         self.close()
-        SparkSession.active.streams.removeListener(this)
+        SparkSession.getDefaultSession.get.streams.removeListener(this)
       }
     }
   }
-  SparkSession.active.streams.addListener(listener)
+  SparkSession.getDefaultSession.get.streams.addListener(listener)
 
   private val driverCache = new DriverCache(neo4jOptions.connection, queryId)
 

--- a/spark-3/src/test/scala/org/neo4j/spark/DataSourceReaderTSE.scala
+++ b/spark-3/src/test/scala/org/neo4j/spark/DataSourceReaderTSE.scala
@@ -12,6 +12,7 @@ import org.neo4j.driver.{Transaction, TransactionWork}
 
 import java.util.TimeZone
 import scala.collection.JavaConverters._
+import scala.collection.mutable.Seq
 
 class DataSourceReaderTSE extends SparkConnectorScalaBaseTSE {
 
@@ -980,11 +981,11 @@ class DataSourceReaderTSE extends SparkConnectorScalaBaseTSE {
         && row.getAs[Long]("rel.quantity") != null
         && row.getAs[Long]("<source.id>") != null
         && row.getAs[Long]("source.id") != null
-        && !row.getAs[List[String]]("<source.labels>").isEmpty
+        && !row.getAs[Seq[String]]("<source.labels>").isEmpty
         && row.getAs[String]("source.fullName") != null
         && row.getAs[Long]("<target.id>") != null
         && row.getAs[Long]("target.id") != null
-        && !row.getAs[List[String]]("<target.labels>").isEmpty
+        && !row.getAs[Seq[String]]("<target.labels>").isEmpty
         && row.getAs[String]("target.name") != null)
       .size
     assertEquals(total, count)
@@ -1613,7 +1614,7 @@ class DataSourceReaderTSE extends SparkConnectorScalaBaseTSE {
         })
 
     val df = ss.read.format(classOf[DataSource].getName)
-      .schema(StructType(Seq(StructField("age", DataTypes.StringType))))
+      .schema(StructType(Seq(StructField("age", DataTypes.StringType)).toSeq))
       .option("url", SparkConnectorScalaSuiteIT.server.getBoltUrl)
       .option("query", "MATCH (n:Person) RETURN n.age AS age")
       .load()

--- a/spark-3/src/test/scala/org/neo4j/spark/DataSourceReaderWithApocTSE.scala
+++ b/spark-3/src/test/scala/org/neo4j/spark/DataSourceReaderWithApocTSE.scala
@@ -11,7 +11,7 @@ import org.neo4j.driver.{Transaction, TransactionWork}
 
 import java.util.TimeZone
 import scala.collection.JavaConverters._
-import scala.collection.mutable
+import scala.collection.mutable.{Seq, ArraySeq}
 
 class DataSourceReaderWithApocTSE extends SparkConnectorScalaBaseWithApocTSE {
 
@@ -682,11 +682,11 @@ class DataSourceReaderWithApocTSE extends SparkConnectorScalaBaseWithApocTSE {
         && row.getAs[Long]("rel.quantity") != null
         && row.getAs[Long]("<source.id>") != null
         && row.getAs[Long]("source.id") != null
-        && !row.getAs[List[String]]("<source.labels>").isEmpty
+        && !row.getAs[Seq[String]]("<source.labels>").isEmpty
         && row.getAs[String]("source.fullName") != null
         && row.getAs[Long]("<target.id>") != null
         && row.getAs[Long]("target.id") != null
-        && !row.getAs[List[String]]("<target.labels>").isEmpty
+        && !row.getAs[Seq[String]]("<target.labels>").isEmpty
         && row.getAs[String]("target.name") != null)
       .size
     assertEquals(total, count)
@@ -807,9 +807,9 @@ class DataSourceReaderWithApocTSE extends SparkConnectorScalaBaseWithApocTSE {
         }
       }))
     val expectedData = Seq(
-      Seq(mutable.WrappedArray.make(Array("Person", "Actor")), true, 1964, "Keanu Reeves", null, null),
-      Seq(mutable.WrappedArray.make(Array("Person", "Writer")), null, 1928, "Philip K. Dick", null, true),
-        Seq(mutable.WrappedArray.make(Array("Person", "SoccerPlayer")), null, 1981, "Zlatan Ibrahimović", true, null)
+      Seq(ArraySeq("Person", "Actor"), true, 1964, "Keanu Reeves", null, null),
+      Seq(ArraySeq("Person", "Writer"), null, 1928, "Philip K. Dick", null, true),
+      Seq(ArraySeq("Person", "SoccerPlayer"), null, 1981, "Zlatan Ibrahimović", true, null)
     ).toBuffer
     assertEquals(expectedData, data)
   }
@@ -848,10 +848,10 @@ class DataSourceReaderWithApocTSE extends SparkConnectorScalaBaseWithApocTSE {
         }
       }))
     val expectedData = Seq(
-      Seq(mutable.WrappedArray.make(Array("Person")), "25"),
-      Seq(mutable.WrappedArray.make(Array("Person", "Player")), "hello"),
-      Seq(mutable.WrappedArray.make(Array("Person", "Player", "Weirdo")), "true")
-    ).toBuffer
+      Seq(ArraySeq("Person"), "25"),
+      Seq(ArraySeq("Person", "Player"), "hello"),
+      Seq(ArraySeq("Person", "Player", "Weirdo"), "true")
+    )
     assertEquals(expectedData, data)
   }
 

--- a/spark-3/src/test/scala/org/neo4j/spark/DataSourceStreamingWriterTSE.scala
+++ b/spark-3/src/test/scala/org/neo4j/spark/DataSourceStreamingWriterTSE.scala
@@ -4,7 +4,7 @@ import org.apache.spark.sql.execution.streaming.MemoryStream
 import org.apache.spark.sql.streaming.StreamingQuery
 import org.hamcrest.Matchers
 import org.junit.{After, Test}
-import org.neo4j.driver.{SessionConfig, Transaction, TransactionWork}
+import org.neo4j.driver.{Transaction, TransactionWork}
 import org.neo4j.spark.Assert.ThrowingSupplier
 
 import java.util.UUID

--- a/test-support/src/main/scala/org/neo4j/spark/SparkConnectorScalaBaseTSE.scala
+++ b/test-support/src/main/scala/org/neo4j/spark/SparkConnectorScalaBaseTSE.scala
@@ -7,6 +7,7 @@ import org.junit._
 import org.junit.rules.TestName
 import org.neo4j.driver.summary.ResultSummary
 import org.neo4j.driver.{Transaction, TransactionWork}
+import org.neo4j.spark
 
 import java.util.concurrent.TimeUnit
 
@@ -53,7 +54,7 @@ class SparkConnectorScalaBaseTSE {
   def after() {
     if (!TestUtil.isCI()) {
       try {
-        Assert.assertEventually(new Assert.ThrowingSupplier[Boolean, Exception] {
+        spark.Assert.assertEventually(new spark.Assert.ThrowingSupplier[Boolean, Exception] {
           override def get(): Boolean = {
             val afterConnections = SparkConnectorScalaSuiteIT.getActiveConnections
             SparkConnectorScalaSuiteIT.connections == afterConnections

--- a/test-support/src/main/scala/org/neo4j/spark/SparkConnectorScalaBaseWithApocTSE.scala
+++ b/test-support/src/main/scala/org/neo4j/spark/SparkConnectorScalaBaseWithApocTSE.scala
@@ -7,6 +7,7 @@ import org.junit._
 import org.junit.rules.TestName
 import org.neo4j.driver.summary.ResultSummary
 import org.neo4j.driver.{Transaction, TransactionWork}
+import org.neo4j.spark
 
 import java.util.concurrent.TimeUnit
 
@@ -53,7 +54,7 @@ class SparkConnectorScalaBaseWithApocTSE {
   def after() {
     if (!TestUtil.isCI()) {
       try {
-        Assert.assertEventually(new Assert.ThrowingSupplier[Boolean, Exception] {
+        spark.Assert.assertEventually(new spark.Assert.ThrowingSupplier[Boolean, Exception] {
           override def get(): Boolean = {
             val afterConnections = SparkConnectorScalaSuiteWithApocIT.getActiveConnections
             SparkConnectorScalaSuiteWithApocIT.connections == afterConnections

--- a/test-support/src/main/scala/org/neo4j/spark/SparkConnectorScalaSuiteIT.scala
+++ b/test-support/src/main/scala/org/neo4j/spark/SparkConnectorScalaSuiteIT.scala
@@ -49,7 +49,7 @@ object SparkConnectorScalaSuiteIT {
           override def execute(tx: Transaction): ResultSummary = tx.run("RETURN 1").consume() // we init the session so the count is consistent
         })
       connections = getActiveConnections
-      Unit
+      ()
     }
   }
 
@@ -73,8 +73,8 @@ object SparkConnectorScalaSuiteIT {
   def getActiveConnections = session()
     .readTransaction(new TransactionWork[Long] {
       override def execute(tx: Transaction): Long = tx.run(
-        """|CALL dbms.listConnections() YIELD connectionId, connector
-           |WHERE connector = 'bolt'
+        """|CALL dbms.listConnections() YIELD connectionId, connector, userAgent
+           |WHERE connector = 'bolt' AND userAgent STARTS WITH 'neo4j-spark-connector'
            |RETURN count(*) AS connections""".stripMargin)
         .single()
         .get("connections")

--- a/test-support/src/main/scala/org/neo4j/spark/SparkConnectorScalaSuiteWithApocIT.scala
+++ b/test-support/src/main/scala/org/neo4j/spark/SparkConnectorScalaSuiteWithApocIT.scala
@@ -50,7 +50,7 @@ object SparkConnectorScalaSuiteWithApocIT {
           override def execute(tx: Transaction): ResultSummary = tx.run("RETURN 1").consume() // we init the session so the count is consistent
         })
       connections = getActiveConnections
-      Unit
+      ()
     }
   }
 

--- a/test-support/src/main/scala/org/neo4j/spark/TestUtil.scala
+++ b/test-support/src/main/scala/org/neo4j/spark/TestUtil.scala
@@ -21,7 +21,7 @@ object TestUtil {
       autoCloseable match {
         case s: Session => if (s.isOpen) s.close()
         case t: Transaction => if (t.isOpen) t.close()
-        case null => Unit
+        case null => ()
         case _ => autoCloseable.close()
       }
     } catch {


### PR DESCRIPTION
This PR adds the Support for Spark 3.2 and in particular for Scala 2.13 that has been introduced in that version.

Once merged we'll support :
* 2.4.5+ with Scala 2.11 and 2.12
* 3.0+ with Scala 2.12 and 2.13