### PR TITLE
Update faq.adoc

### DIFF
--- a/doc/docs/modules/ROOT/pages/faq.adoc
+++ b/doc/docs/modules/ROOT/pages/faq.adoc
@@ -104,3 +104,5 @@ This might happen when creating a new graph using the GDS library.
 The issue here is that the query is run the first time to extract the DataFrame schema and then is run again to get the data.
 
 To avoid this issue we suggest using the xref:quickstart.adoc#user-defined-schema[user defined schema] approach.
+
+


### PR DESCRIPTION
Writing to Neo4j using pyspark
----------------------------------------
Even though the driver matches the correct version of scala and databricks runtime, the write option fails with error message as 

java.util.NoSuchElementException: None.get

df.write.format("org.neo4j.spark.DataSource")\