### PR TITLE
fixes #442: Support Neo4j Java Driver URL resolvers

### DIFF
--- a/common/src/test/scala/org/neo4j/spark/util/Neo4jOptionsTest.scala
+++ b/common/src/test/scala/org/neo4j/spark/util/Neo4jOptionsTest.scala
@@ -3,7 +3,9 @@ package org.neo4j.spark.util
 import org.junit.Assert._
 import org.junit.Test
 import org.neo4j.driver.AccessMode
+import org.neo4j.driver.net.ServerAddress
 
+import java.net.URI
 import scala.collection.JavaConverters._
 
 class Neo4jOptionsTest {
@@ -189,5 +191,17 @@ class Neo4jOptionsTest {
     val neo4jOptions: Neo4jOptions = new Neo4jOptions(options)
 
     assertEquals(neo4jOptions.relationshipMetadata.properties, Map.empty)
+  }
+
+  @Test
+  def testUrls(): Unit = {
+    val options: java.util.Map[String, String] = new java.util.HashMap[String, String]()
+    options.put(Neo4jOptions.URL, "neo4j://localhost,neo4j://foo.bar,neo4j://foo.bar.baz:7783")
+
+    val neo4jOptions: Neo4jOptions = new Neo4jOptions(options)
+    val (baseUrl, resolvers) = neo4jOptions.connection.connectionUrls
+
+    assertEquals(URI.create("neo4j://localhost"), baseUrl)
+    assertEquals(Set(ServerAddress.of("foo.bar", 7687), ServerAddress.of("foo.bar.baz", 7783)), resolvers)
   }
 }

--- a/doc/docs/modules/ROOT/pages/configuration.adoc
+++ b/doc/docs/modules/ROOT/pages/configuration.adoc
@@ -77,7 +77,10 @@ documentation on all possible configuration options for Neo4j Drivers, see the l
 4+|*Driver options*
 
 |`url`
-|The url of the Neo4j instance to connect to
+|The url of the Neo4j instance to connect to.
+You can provide a comma-separated list of valid Neo4j URIs like: `neo4j://localhost,neo4j://foo.bar,neo4j://foo.bar.baz:7783`, the first one
+will be used as base URL and the others as resolvers just as explained
+link:https://neo4j.com/docs/java-manual/current/client-applications/#java-driver-resolver-function[here, window=_blank]
 |_(none)_
 |Yes
 


### PR DESCRIPTION
Now in `url` property you can provide a comma-separated list of valid Neo4j URIs like: `neo4j://localhost,neo4j://foo.bar,neo4j://foo.bar.baz:7783`; the first one
will be used as a base URL and the others as resolvers just as explained
[here](https://neo4j.com/docs/java-manual/current/client-applications/#java-driver-resolver-function)