### PR TITLE
Improved Spark version validation

### DIFF
--- a/.github/workflows/python-ci.yml
+++ b/.github/workflows/python-ci.yml
@@ -15,7 +15,7 @@ jobs:
       matrix:
         python-version: [ "3.6", "3.7", "3.8" ]
         neo4j-version: [ "3.5", "4.0", "4.1", "4.2", "4.3", "4.4" ]
-        spark-version: [ {short: "3", ext: "3.2.0", scala: "2.12"} ]
+        spark-version: [ {short: "3", ext: "3.2.2", scala: "2.12"} ]
 
     steps:
       - uses: actions/checkout@v2
@@ -50,7 +50,7 @@ jobs:
         run: |
           ./mvnw clean package -DskipTests -P spark-${{ matrix.spark-version.short }} -P scala-${{ matrix.spark-version.scala }} --no-transfer-progress
       - name: Run tests for Spark ${{ matrix.spark-version.ext }} and Neo4j ${{ matrix.neo4j-version }}
-        if: ${{ !(matrix.spark-version.short == 2.4 && matrix.python-version == 3.8) && !(matrix.spark-version.ext == '3.2.0' && matrix.python-version == 3.5) }}
+        if: ${{ !(matrix.spark-version.short == 2.4 && matrix.python-version == 3.8) && !(matrix.spark-version.ext == '3.2.2' && matrix.python-version == 3.5) }}
         run: |
           cd ./scripts/python
           python test_spark.py "${{ matrix.spark-version.short }}" "${{ matrix.spark-version.scala }}" "${{ matrix.neo4j-version }}" "${{ steps.version.outputs.version }}"

--- a/spark-3/src/main/scala/org/neo4j/spark/DataSource.scala
+++ b/spark-3/src/main/scala/org/neo4j/spark/DataSource.scala
@@ -12,7 +12,7 @@ import java.util.UUID
 class DataSource extends TableProvider
   with DataSourceRegister {
 
-  Validations.validate(ValidateSparkVersion("3.2.2"))
+  Validations.validate(ValidateSparkVersion("3.2.0"))
 
   private val jobId: String = UUID.randomUUID().toString
 

--- a/spark-3/src/main/scala/org/neo4j/spark/DataSource.scala
+++ b/spark-3/src/main/scala/org/neo4j/spark/DataSource.scala
@@ -12,7 +12,7 @@ import java.util.UUID
 class DataSource extends TableProvider
   with DataSourceRegister {
 
-  Validations.validate(ValidateSparkVersion("3.*"))
+  Validations.validate(ValidateSparkVersion("3.2.2"))
 
   private val jobId: String = UUID.randomUUID().toString
 

--- a/spark-3/src/test/scala/org/neo4j/spark/VersionValidationTest.scala
+++ b/spark-3/src/test/scala/org/neo4j/spark/VersionValidationTest.scala
@@ -14,6 +14,7 @@ class VersionValidationTest extends SparkConnectorScalaBaseTSE {
       .getOrElse("UNKNOWN")
     try {
       Validations.validate(ValidateSparkVersion("2.4"))
+      fail(s"should be thrown a ${classOf[IllegalArgumentException].getName}")
     } catch {
       case e: IllegalArgumentException =>
         assertEquals(
@@ -22,6 +23,15 @@ class VersionValidationTest extends SparkConnectorScalaBaseTSE {
             |""".stripMargin, e.getMessage)
       case e: Throwable => fail(s"should be thrown a ${classOf[IllegalArgumentException].getName}, got ${e.getClass} instead")
     }
+  }
+
+
+  @Test
+  def testShouldBeValid(): Unit = {
+    Validations.validate(ValidateSparkVersion("3.2"))
+    Validations.validate(ValidateSparkVersion("3.2.*"))
+    Validations.validate(ValidateSparkVersion("3.2.0"))
+    Validations.validate(ValidateSparkVersion("3.2.2"))
   }
 
 }


### PR DESCRIPTION
Improved Spark version validation, as the Aggregate Pushdown feature works with Spark 3.2.2 we define it as target version, otherwise they can use version `4.1.5`