### PR TITLE
GitHub Issue: 444  Fixing issue where LocalTime and Time are being written as individual fields instead of single Struct Field

### DIFF
--- a/common/src/main/scala/org/neo4j/spark/util/Neo4jUtil.scala
+++ b/common/src/main/scala/org/neo4j/spark/util/Neo4jUtil.scala
@@ -184,8 +184,8 @@ object Neo4jUtil {
             struct.getAs[Number]("days").longValue(),
             struct.getAs[Number]("seconds").longValue(),
             struct.getAs[Number]("nanoseconds").intValue())
-          case SchemaService.TIME_TYPE_OFFSET => Values.value(OffsetTime.parse(struct.getAs[String]("value")))
-          case SchemaService.TIME_TYPE_LOCAL => Values.value(LocalTime.parse(struct.getAs[String]("value")))
+          case SchemaService.TIME_TYPE_OFFSET => Values.value(OffsetTime.parse(struct.getAs[UTF8String]("value").toString))
+          case SchemaService.TIME_TYPE_LOCAL => Values.value(LocalTime.parse(struct.getAs[UTF8String]("value").toString))
           case _ => toMap(struct)
         }
       } catch {

--- a/spark-3/src/test/scala/org/neo4j/spark/DataSourceWriterTSE.scala
+++ b/spark-3/src/test/scala/org/neo4j/spark/DataSourceWriterTSE.scala
@@ -35,6 +35,12 @@ case class Point3d(`type`: String = "point-3d",
                    y: Double,
                    z: Double) extends Neo4jType(`type`)
 
+case class Time(`type`: String = "offset-time",
+                 value: String) extends Neo4jType(`type`)
+
+case class LocalTime(`type`: String = "local-time",
+                     value: String) extends Neo4jType(`type`)
+
 case class Person(name: String, surname: String, age: Int, livesIn: Point3d)
 
 case class SimplePerson(name: String, surname: String)


### PR DESCRIPTION
Github Issue: 444 - 

Issue: Fields in Neo4j Types of LocalTime and Time are being written as individual fields instead of single Struct Field

More details here https://github.com/neo4j-contrib/neo4j-spark-connector/issues/444

Fix: Reading Spark String as UTF8String and then converting to String. Spark strings are stored as UTF8String.