### PR TITLE
Update Neo4j versions used by integration tests

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -87,14 +87,14 @@
         <profile>
             <id>neo4j-4.4</id>
             <properties>
-                <neo4j.version>4.4.0</neo4j.version>
+                <neo4j.version>4.4.19</neo4j.version>
                 <neo4j.experimental>false</neo4j.experimental>
             </properties>
         </profile>
         <profile>
             <id>neo4j-5</id>
             <properties>
-                <neo4j.version>5.4.0</neo4j.version>
+                <neo4j.version>5.6.0</neo4j.version>
                 <neo4j.experimental>false</neo4j.experimental>
             </properties>
         </profile>


### PR DESCRIPTION
This sets the latest 4.x and latest 5.x Neo4j versions.

This only affects container-based tests.