### PR TITLE
Make the build script optional - use sensible Maven defaults

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -211,6 +211,26 @@
                     </execution>
                 </executions>
             </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-enforcer-plugin</artifactId>
+                <version>3.3.0</version>
+                <executions>
+                    <execution>
+                        <id>enforce-java</id>
+                        <goals>
+                            <goal>enforce</goal>
+                        </goals>
+                        <configuration>
+                            <rules>
+                                <requireJavaVersion>
+                                    <version>[8,9)</version>
+                                </requireJavaVersion>
+                            </rules>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
         </plugins>
     </build>
 

--- a/pom.xml
+++ b/pom.xml
@@ -75,6 +75,9 @@
         </profile>
         <profile>
             <id>scala-2.13</id>
+            <activation>
+                <activeByDefault>true</activeByDefault>
+            </activation>
             <properties>
                 <scala.version>2.13.4</scala.version>
                 <scala.binary.version>2.13</scala.binary.version>
@@ -93,6 +96,9 @@
         </profile>
         <profile>
             <id>neo4j-5</id>
+            <activation>
+                <activeByDefault>true</activeByDefault>
+            </activation>
             <properties>
                 <neo4j.version>5.4.0</neo4j.version>
                 <neo4j.experimental>false</neo4j.experimental>


### PR DESCRIPTION
This now plays nicer with IDEs (and newcomers like me ^^) by making the build script optional to use locally.