### PR TITLE
Remove always-false comparison in Spark version checker

### DIFF
--- a/common/src/main/scala/org/neo4j/spark/util/Validations.scala
+++ b/common/src/main/scala/org/neo4j/spark/util/Validations.scala
@@ -53,7 +53,7 @@ case class ValidateSparkVersion(supportedVersions: String*) extends Validation {
     val splittedVersion = sparkVersion.split("\\.")
 
     ValidationUtil.isTrue(
-      supportedVersions
+      sparkVersion == "UNKNOWN" || supportedVersions
         .flatMap(_.split("\\.").zip(splittedVersion))
         .forall(t => compare(t._2, t._1)),
       s"""Your current Spark version $sparkVersion is not supported by the current connector.

--- a/common/src/main/scala/org/neo4j/spark/util/Validations.scala
+++ b/common/src/main/scala/org/neo4j/spark/util/Validations.scala
@@ -53,7 +53,7 @@ case class ValidateSparkVersion(supportedVersions: String*) extends Validation {
     val splittedVersion = sparkVersion.split("\\.")
 
     ValidationUtil.isTrue(
-      sparkVersion(0) == "UNKNOWN" || supportedVersions
+      supportedVersions
         .flatMap(_.split("\\.").zip(splittedVersion))
         .forall(t => compare(t._2, t._1)),
       s"""Your current Spark version $sparkVersion is not supported by the current connector.


### PR DESCRIPTION
Caught via a compiler warning