### PR TITLE
fixes #498: spark version validation fails on EMR / EMR Serverless

### DIFF
--- a/common/src/main/scala/org/neo4j/spark/util/Validations.scala
+++ b/common/src/main/scala/org/neo4j/spark/util/Validations.scala
@@ -50,16 +50,21 @@ case class ValidateSparkVersion(supportedVersions: String*) extends Validation {
     val sparkVersion = SparkSession.getActiveSession
       .map(_.version)
       .getOrElse("UNKNOWN")
-    val splittedVersion = sparkVersion.split("\\.")
 
     ValidationUtil.isTrue(
-      sparkVersion == "UNKNOWN" || supportedVersions
-        .flatMap(_.split("\\.").zip(splittedVersion))
-        .forall(t => compare(t._2, t._1)),
+      isSupported(sparkVersion),
       s"""Your current Spark version $sparkVersion is not supported by the current connector.
          |Please visit https://neo4j.com/developer/spark/overview/#_spark_compatibility to know which connector version you need.
          |""".stripMargin
     )
+  }
+
+  def isSupported(sparkVersion: String): Boolean = {
+    val splittedVersion = sparkVersion.split("\\.")
+    val supported = sparkVersion == "UNKNOWN" || supportedVersions
+      .flatMap(_.split("\\.").zip(splittedVersion))
+      .forall(t => compare(t._2, t._1))
+    supported
   }
 }
 

--- a/spark-3/src/main/scala/org/neo4j/spark/DataSource.scala
+++ b/spark-3/src/main/scala/org/neo4j/spark/DataSource.scala
@@ -12,7 +12,7 @@ import java.util.UUID
 class DataSource extends TableProvider
   with DataSourceRegister {
 
-  Validations.validate(ValidateSparkVersion("3.2.0"))
+  Validations.validate(ValidateSparkVersion("3.2.*"))
 
   private val jobId: String = UUID.randomUUID().toString
 

--- a/spark-3/src/test/scala/org/neo4j/spark/VersionValidationTest.scala
+++ b/spark-3/src/test/scala/org/neo4j/spark/VersionValidationTest.scala
@@ -1,6 +1,7 @@
 package org.neo4j.spark
 
 import org.apache.spark.sql.SparkSession
+import org.junit
 import org.junit.Assert.{assertEquals, fail}
 import org.junit.Test
 import org.neo4j.spark.util.{ValidateSparkVersion, Validations}
@@ -39,6 +40,15 @@ class VersionValidationTest extends SparkConnectorScalaBaseTSE {
     Validations.validate(ValidateSparkVersion(s"$baseVersion.*"))
     Validations.validate(ValidateSparkVersion(s"$baseVersion.0"))
     Validations.validate(ValidateSparkVersion(s"$baseVersion.1-amzn-0"))
+  }
+
+
+  @Test
+  def testShouldValidateTheVersion(): Unit = {
+    val version = ValidateSparkVersion("3.2.*")
+    junit.Assert.assertTrue(version.isSupported("3.3.0-amzn-1"))
+    junit.Assert.assertTrue(version.isSupported("3.3.0"))
+    junit.Assert.assertFalse(version.isSupported("3.1.0"))
   }
 
 }


### PR DESCRIPTION
fixes #498 by adding wildcard on version.

Added tests