### PR TITLE
Broken links fix

### DIFF
--- a/doc/docs/modules/ROOT/pages/quickstart.adoc
+++ b/doc/docs/modules/ROOT/pages/quickstart.adoc
@@ -144,7 +144,7 @@ Before going into details, we need to address you to some preliminary considerat
 
 === Complex data types
 
-Spark doesn't natively support all Neo4j data types (i.e., link:https://neo4j.com/docs/cypher-manual/current/syntax/spatial/[`Point`], link:https://neo4j.com/docs/cypher-manual/current/syntax/temporal/#cypher-temporal-instants[`Time`], link:https://neo4j.com/docs/cypher-manual/current/syntax/temporal/#cypher-temporal-durations[`Duration`]). Such types are transformed into Struct types containing all the useful data.
+Spark doesn't natively support all Neo4j data types (i.e., link:https://neo4j.com/docs/cypher-manual/current/values-and-types/spatial/#spatial-values-point-type[`Point`], link:https://neo4j.com/docs/cypher-manual/current/values-and-types/temporal/#cypher-temporal-instants[`Time`], link:https://neo4j.com/docs/cypher-manual/current/values-and-types/temporal/#cypher-temporal-durations[`Duration`]). Such types are transformed into Struct types containing all the useful data.
 
 For complete details on type handling, consult the xref::types.adoc[Data type mapping between Neo4j and Spark].
 

--- a/doc/docs/modules/ROOT/pages/types.adoc
+++ b/doc/docs/modules/ROOT/pages/types.adoc
@@ -32,7 +32,7 @@ In some cases, there are data types that Neo4j provides that Spark does not have
 
 |`Point`
 |`struct { type: string, srid: integer, x: double, y: double, z: double }`
-|For more information on spatial types in Neo4j, see link:https://neo4j.com/docs/cypher-manual/current/syntax/spatial/[Spatial values]
+|For more information on spatial types in Neo4j, see link:https://neo4j.com/docs/cypher-manual/current/values-and-types/spatial/[Spatial values]
 
 |`Date`
 |`date`
@@ -56,7 +56,7 @@ In some cases, there are data types that Neo4j provides that Spark does not have
 
 |`Duration`
 |`struct { type: string, months: long, days: long, seconds: long, nanonseconds: integer, value: string }`
-|See link:https://neo4j.com/docs/cypher-manual/current/functions/temporal/duration/[Temporal functions: duration]
+|See link:https://neo4j.com/docs/cypher-manual/current/values-and-types/temporal/#cypher-temporal-durations[Temporal functions: duration]
 
 |`Node`
 |`struct { <id>: long, <labels>: array[string], (PROPERTIES) }`
@@ -68,7 +68,7 @@ In some cases, there are data types that Neo4j provides that Spark does not have
 
 |`Path`
 |`string`
-|Example: `path[(322)<-[20280:AIRLINE]-(33510)]`.  _For ease of use it is recommended to use link:https://neo4j.com/docs/cypher-manual/current/functions/list/[path functions] to return individual properties/aspects of a path from a query._
+|Example: `path[(322)<-[20280:AIRLINE]-(33510)]`.  _For ease of use it is recommended to use link:https://neo4j.com/docs/cypher-manual/current/values-and-types/lists/[path functions] to return individual properties/aspects of a path from a query._
 
 |`[Array of same type]`
 |`array[element]`

--- a/doc/docs/modules/ROOT/pages/writing.adoc
+++ b/doc/docs/modules/ROOT/pages/writing.adoc
@@ -309,7 +309,7 @@ For example, if you have `.option("node.keys", "name:name,email:email")`, you ca
 `.option("node.keys", "name,email")`.
 
 In case the column value is a Map<String, `Value`> (where `Value` can be any supported
-link:https://neo4j.com/docs/cypher-manual/current/syntax/values/[Neo4j Type]), the connector
+link:https://neo4j.com/docs/cypher-manual/current/values-and-types/[Neo4j Type]), the connector
 automatically tries to flatten it.
 
 Let's consider the following dataset:


### PR DESCRIPTION
The Values and types section was moved in the Cypher manual, thus the broken links being fixed here. There might be the need to cherry-pick this backwards. 