### PR TITLE
added fixed bug in version validation

### DIFF
--- a/spark-3/src/main/scala/org/neo4j/spark/DataSource.scala
+++ b/spark-3/src/main/scala/org/neo4j/spark/DataSource.scala
@@ -5,14 +5,14 @@ import org.apache.spark.sql.connector.expressions.Transform
 import org.apache.spark.sql.sources.{DataSourceRegister, Filter}
 import org.apache.spark.sql.types.StructType
 import org.apache.spark.sql.util.CaseInsensitiveStringMap
-import org.neo4j.spark.util.{Neo4jOptions, Neo4jUtil, ValidateConnection, ValidateSparkVersion, Validations}
+import org.neo4j.spark.util.{Neo4jOptions, Neo4jUtil, ValidateConnection, ValidateSparkMinVersion, Validations}
 
 import java.util.UUID
 
 class DataSource extends TableProvider
   with DataSourceRegister {
 
-  Validations.validate(ValidateSparkVersion("3.2.*"))
+  Validations.validate(ValidateSparkMinVersion("3.3.0"))
 
   private val jobId: String = UUID.randomUUID().toString
 


### PR DESCRIPTION
The test `testThrowsExceptionSparkVersionIsNotSupported` was a false negative because it was supposed to be valid. In order to check the problem you can just update the Spark version from 3.3.2 to 3.4.2 and magically it's a valid version.

I fixed the problem but also changed the class name to a more meaningful one.