### PR TITLE
Improved query error management

### DIFF
--- a/common/src/test/scala/org/neo4j/spark/util/Neo4jOptionsTest.scala
+++ b/common/src/test/scala/org/neo4j/spark/util/Neo4jOptionsTest.scala
@@ -6,6 +6,7 @@ import org.neo4j.driver.AccessMode
 import org.neo4j.driver.net.ServerAddress
 
 import java.net.URI
+import scala.annotation.meta.getter
 import scala.collection.JavaConverters._
 
 class Neo4jOptionsTest {
@@ -13,10 +14,8 @@ class Neo4jOptionsTest {
   import org.junit.Rule
   import org.junit.rules.ExpectedException
 
+  @(Rule@getter)
   val _expectedException: ExpectedException = ExpectedException.none
-
-  @Rule
-  def exceptionRule: ExpectedException = _expectedException
 
   @Test
   def testUrlIsRequired(): Unit = {

--- a/common/src/test/scala/org/neo4j/spark/util/ValidationsIT.scala
+++ b/common/src/test/scala/org/neo4j/spark/util/ValidationsIT.scala
@@ -7,21 +7,20 @@ import org.neo4j.driver.AccessMode
 import org.neo4j.spark.{SparkConnectorScalaSuiteIT, TestUtil}
 
 import java.util.regex.Pattern
+import scala.annotation.meta.getter
 
 class ValidationsIT extends SparkConnectorScalaSuiteIT {
 
-  val _expectedException: ExpectedException = ExpectedException.none
-
-  @Rule
-  def exceptionRule: ExpectedException = _expectedException
+  @(Rule@getter)
+  val expectedException: ExpectedException = ExpectedException.none
 
   @Test
   def testReadQueryShouldBeSyntacticallyInvalid(): Unit = {
     // then
-    _expectedException.expect(classOf[IllegalArgumentException])
-    _expectedException.expectMessage(CoreMatchers.containsString("Query not compiled for the following exception: ClientException: Invalid input "))
+    expectedException.expect(classOf[IllegalArgumentException])
+    expectedException.expectMessage(CoreMatchers.containsString("Query not compiled for the following exception: ClientException: Invalid input "))
     val query = "MATCH (f{) RETURN f"
-    _expectedException.expectMessage(CoreMatchers.containsString(query))
+    expectedException.expectMessage(CoreMatchers.containsString(query))
 
     // given
     val readOpts: java.util.Map[String, String] = new java.util.HashMap[String, String]()
@@ -36,8 +35,8 @@ class ValidationsIT extends SparkConnectorScalaSuiteIT {
   def testReadQueryShouldBeSemanticallyInvalid(): Unit = {
     // then
     val query = "MERGE (n:TestNode{id: 1}) RETURN n"
-    _expectedException.expect(classOf[IllegalArgumentException])
-    _expectedException.expectMessage(s"Invalid query `$query` because the accepted types are [READ_ONLY], but the actual type is READ_WRITE")
+    expectedException.expect(classOf[IllegalArgumentException])
+    expectedException.expectMessage(s"Invalid query `$query` because the accepted types are [READ_ONLY], but the actual type is READ_WRITE")
 
     // given
     val readOpts: java.util.Map[String, String] = new java.util.HashMap[String, String]()
@@ -52,9 +51,9 @@ class ValidationsIT extends SparkConnectorScalaSuiteIT {
   def testReadQueryCountBeSyntacticallyInvalid(): Unit = {
     // then
     val query = "MATCH (f{) RETURN f"
-    _expectedException.expect(classOf[IllegalArgumentException])
-    _expectedException.expectMessage(CoreMatchers.containsString("Query count not compiled for the following exception: ClientException: Invalid input "))
-    _expectedException.expectMessage(CoreMatchers.containsString(s"EXPLAIN $query"))
+    expectedException.expect(classOf[IllegalArgumentException])
+    expectedException.expectMessage(CoreMatchers.containsString("Query count not compiled for the following exception: ClientException: Invalid input "))
+    expectedException.expectMessage(CoreMatchers.containsString(s"EXPLAIN $query"))
 
     // given
     val readOpts: java.util.Map[String, String] = new java.util.HashMap[String, String]()
@@ -69,10 +68,10 @@ class ValidationsIT extends SparkConnectorScalaSuiteIT {
   @Test
   def testScriptQueryCountShouldContainAnInvalidQuery(): Unit = {
     // then
-    _expectedException.expect(classOf[IllegalArgumentException])
-    _expectedException.expectMessage(CoreMatchers.containsString("The following queries inside the `script` are not valid,"))
-    _expectedException.expectMessage(CoreMatchers.containsString("Query not compiled for the following exception: ClientException: Invalid input "))
-    _expectedException.expectMessage(CoreMatchers.containsString("EXPLAIN RETUR 2 AS two"))
+    expectedException.expect(classOf[IllegalArgumentException])
+    expectedException.expectMessage(CoreMatchers.containsString("The following queries inside the `script` are not valid,"))
+    expectedException.expectMessage(CoreMatchers.containsString("Query not compiled for the following exception: ClientException: Invalid input "))
+    expectedException.expectMessage(CoreMatchers.containsString("EXPLAIN RETUR 2 AS two"))
 
     // given
     val readOpts: java.util.Map[String, String] = new java.util.HashMap[String, String]()
@@ -88,9 +87,9 @@ class ValidationsIT extends SparkConnectorScalaSuiteIT {
   def testWriteQueryShouldBeSyntacticallyInvalid(): Unit = {
     // then
     val query = "MERGE (f{) RETURN f"
-    _expectedException.expect(classOf[IllegalArgumentException])
-    _expectedException.expectMessage(CoreMatchers.containsString("Query not compiled for the following exception: ClientException: Invalid input "))
-    _expectedException.expectMessage(CoreMatchers.containsString(query))
+    expectedException.expect(classOf[IllegalArgumentException])
+    expectedException.expectMessage(CoreMatchers.containsString("Query not compiled for the following exception: ClientException: Invalid input "))
+    expectedException.expectMessage(CoreMatchers.containsString(query))
 
     // given
     val writeOpts: java.util.Map[String, String] = new java.util.HashMap[String, String]()
@@ -106,8 +105,8 @@ class ValidationsIT extends SparkConnectorScalaSuiteIT {
   def testWriteQueryShouldBeSemanticallyInvalid(): Unit = {
     // then
     val query = "MATCH (n:TestNode{id: 1}) RETURN n"
-    _expectedException.expect(classOf[IllegalArgumentException])
-    _expectedException.expectMessage(s"Invalid query `$query` because the accepted types are [WRITE_ONLY, READ_WRITE], but the actual type is READ_ONLY")
+    expectedException.expect(classOf[IllegalArgumentException])
+    expectedException.expectMessage(s"Invalid query `$query` because the accepted types are [WRITE_ONLY, READ_WRITE], but the actual type is READ_ONLY")
 
     // given
     val writeOpts: java.util.Map[String, String] = new java.util.HashMap[String, String]()

--- a/common/src/test/scala/org/neo4j/spark/util/ValidationsIT.scala
+++ b/common/src/test/scala/org/neo4j/spark/util/ValidationsIT.scala
@@ -1,0 +1,122 @@
+package org.neo4j.spark.util
+
+import org.hamcrest.CoreMatchers
+import org.junit.rules.ExpectedException
+import org.junit.{Rule, Test}
+import org.neo4j.driver.AccessMode
+import org.neo4j.spark.{SparkConnectorScalaSuiteIT, TestUtil}
+
+import java.util.regex.Pattern
+
+class ValidationsIT extends SparkConnectorScalaSuiteIT {
+
+  val _expectedException: ExpectedException = ExpectedException.none
+
+  @Rule
+  def exceptionRule: ExpectedException = _expectedException
+
+  @Test
+  def testReadQueryShouldBeSyntacticallyInvalid(): Unit = {
+    // then
+    _expectedException.expect(classOf[IllegalArgumentException])
+    _expectedException.expectMessage(CoreMatchers.containsString("Query not compiled for the following exception: ClientException: Invalid input "))
+    val query = "MATCH (f{) RETURN f"
+    _expectedException.expectMessage(CoreMatchers.containsString(query))
+
+    // given
+    val readOpts: java.util.Map[String, String] = new java.util.HashMap[String, String]()
+    readOpts.put(Neo4jOptions.URL, SparkConnectorScalaSuiteIT.server.getBoltUrl)
+    readOpts.put("query", query)
+
+    // when
+    Validations.validate(ValidateRead(new Neo4jOptions(readOpts), "1"))
+  }
+
+  @Test
+  def testReadQueryShouldBeSemanticallyInvalid(): Unit = {
+    // then
+    val query = "MERGE (n:TestNode{id: 1}) RETURN n"
+    _expectedException.expect(classOf[IllegalArgumentException])
+    _expectedException.expectMessage(s"Invalid query `$query` because the accepted types are [READ_ONLY], but the actual type is READ_WRITE")
+
+    // given
+    val readOpts: java.util.Map[String, String] = new java.util.HashMap[String, String]()
+    readOpts.put(Neo4jOptions.URL, SparkConnectorScalaSuiteIT.server.getBoltUrl)
+    readOpts.put("query", query)
+
+    // when
+    Validations.validate(ValidateRead(new Neo4jOptions(readOpts), "1"))
+  }
+
+  @Test
+  def testReadQueryCountBeSyntacticallyInvalid(): Unit = {
+    // then
+    val query = "MATCH (f{) RETURN f"
+    _expectedException.expect(classOf[IllegalArgumentException])
+    _expectedException.expectMessage(CoreMatchers.containsString("Query count not compiled for the following exception: ClientException: Invalid input "))
+    _expectedException.expectMessage(CoreMatchers.containsString(s"EXPLAIN $query"))
+
+    // given
+    val readOpts: java.util.Map[String, String] = new java.util.HashMap[String, String]()
+    readOpts.put(Neo4jOptions.URL, SparkConnectorScalaSuiteIT.server.getBoltUrl)
+    readOpts.put("query", "MATCH (f) RETURN f")
+    readOpts.put("query.count", query)
+
+    // when
+    Validations.validate(ValidateRead(new Neo4jOptions(readOpts), "1"))
+  }
+
+  @Test
+  def testScriptQueryCountShouldContainAnInvalidQuery(): Unit = {
+    // then
+    _expectedException.expect(classOf[IllegalArgumentException])
+    _expectedException.expectMessage(CoreMatchers.containsString("The following queries inside the `script` are not valid,"))
+    _expectedException.expectMessage(CoreMatchers.containsString("Query not compiled for the following exception: ClientException: Invalid input "))
+    _expectedException.expectMessage(CoreMatchers.containsString("EXPLAIN RETUR 2 AS two"))
+
+    // given
+    val readOpts: java.util.Map[String, String] = new java.util.HashMap[String, String]()
+    readOpts.put(Neo4jOptions.URL, SparkConnectorScalaSuiteIT.server.getBoltUrl)
+    readOpts.put("query", "MATCH (f) RETURN f")
+    readOpts.put("script", "RETURN 1 AS one; RETUR 2 AS two; RETURN 3 AS three")
+
+    // when
+    Validations.validate(ValidateRead(new Neo4jOptions(readOpts), "1"))
+  }
+
+  @Test
+  def testWriteQueryShouldBeSyntacticallyInvalid(): Unit = {
+    // then
+    val query = "MERGE (f{) RETURN f"
+    _expectedException.expect(classOf[IllegalArgumentException])
+    _expectedException.expectMessage(CoreMatchers.containsString("Query not compiled for the following exception: ClientException: Invalid input "))
+    _expectedException.expectMessage(CoreMatchers.containsString(query))
+
+    // given
+    val writeOpts: java.util.Map[String, String] = new java.util.HashMap[String, String]()
+    writeOpts.put(Neo4jOptions.URL, SparkConnectorScalaSuiteIT.server.getBoltUrl)
+    writeOpts.put(Neo4jOptions.ACCESS_MODE, AccessMode.WRITE.toString)
+    writeOpts.put("query", query)
+
+    // when
+    Validations.validate(ValidateWrite(new Neo4jOptions(writeOpts), "1", null))
+  }
+
+  @Test
+  def testWriteQueryShouldBeSemanticallyInvalid(): Unit = {
+    // then
+    val query = "MATCH (n:TestNode{id: 1}) RETURN n"
+    _expectedException.expect(classOf[IllegalArgumentException])
+    _expectedException.expectMessage(s"Invalid query `$query` because the accepted types are [WRITE_ONLY, READ_WRITE], but the actual type is READ_ONLY")
+
+    // given
+    val writeOpts: java.util.Map[String, String] = new java.util.HashMap[String, String]()
+    writeOpts.put(Neo4jOptions.URL, SparkConnectorScalaSuiteIT.server.getBoltUrl)
+    writeOpts.put(Neo4jOptions.ACCESS_MODE, AccessMode.WRITE.toString)
+    writeOpts.put("query", query)
+
+    // when
+    Validations.validate(ValidateWrite(new Neo4jOptions(writeOpts), "1", null))
+  }
+
+}

--- a/common/src/test/scala/org/neo4j/spark/util/ValidationsTest.scala
+++ b/common/src/test/scala/org/neo4j/spark/util/ValidationsTest.scala
@@ -1,15 +1,15 @@
-package org.neo4j.spark
+package org.neo4j.spark.util
 
 import org.apache.spark.sql.SparkSession
 import org.junit
 import org.junit.Assert.{assertEquals, fail}
 import org.junit.Test
-import org.neo4j.spark.util.{ValidateSparkMinVersion, Validations}
+import org.neo4j.spark.SparkConnectorScalaBaseTSE
 
-class VersionValidationTest extends SparkConnectorScalaBaseTSE {
+class ValidationsTest extends SparkConnectorScalaBaseTSE {
 
   @Test
-  def testThrowsExceptionSparkVersionIsNotSupported(): Unit = {
+  def testVersionThrowsExceptionSparkVersionIsNotSupported(): Unit = {
     val sparkVersion = SparkSession.getActiveSession
       .map { _.version }
       .getOrElse("UNKNOWN")
@@ -26,9 +26,8 @@ class VersionValidationTest extends SparkConnectorScalaBaseTSE {
     }
   }
 
-
   @Test
-  def testShouldBeValid(): Unit = {
+  def testVersionShouldBeValid(): Unit = {
     val fullVersion = SparkSession
       .getDefaultSession
       .map(_.version)
@@ -42,9 +41,8 @@ class VersionValidationTest extends SparkConnectorScalaBaseTSE {
     Validations.validate(ValidateSparkMinVersion(s"$fullVersion-amzn-0"))
   }
 
-
   @Test
-  def testShouldValidateTheVersion(): Unit = {
+  def testVersionShouldValidateTheVersion(): Unit = {
     val version = ValidateSparkMinVersion("2.3.0")
     junit.Assert.assertTrue(version.isSupported("2.3.0-amzn-1"))
     junit.Assert.assertTrue(version.isSupported("2.3.1-amzn-1"))

--- a/spark-3/src/test/scala/org/neo4j/spark/DataSourceReaderTSE.scala
+++ b/spark-3/src/test/scala/org/neo4j/spark/DataSourceReaderTSE.scala
@@ -1136,23 +1136,6 @@ class DataSourceReaderTSE extends SparkConnectorScalaBaseTSE {
     assertEquals(100, countRel)
   }
 
-  @Test()
-  def testThrowsExceptionOnWriteQuery(): Unit = {
-    try {
-      ss.read.format(classOf[DataSource].getName)
-        .option("url", SparkConnectorScalaSuiteIT.server.getBoltUrl)
-        .option("query", "CREATE (p:Person)")
-        .load()
-        .show()  // we need the action to be able to trigger the exception because of the changes in Spark 3
-      org.junit.Assert.fail("Expected to throw an exception")
-    } catch {
-      case iae: IllegalArgumentException => {
-        assertTrue(iae.getMessage.endsWith("Please provide a valid READ query"))
-      }
-      case e: Throwable => fail(s"should be thrown a ${classOf[IllegalArgumentException].getName}, e: ${e.getMessage}")
-    }
-  }
-
   @Test
   def testShouldCreateTheCorrectDataframeWithTwoPartitions(): Unit = {
     SparkConnectorScalaSuiteIT.session()

--- a/test-support/src/main/scala/org/neo4j/spark/SparkConnectorScalaBaseTSE.scala
+++ b/test-support/src/main/scala/org/neo4j/spark/SparkConnectorScalaBaseTSE.scala
@@ -4,12 +4,13 @@ import org.apache.spark.SparkConf
 import org.apache.spark.sql.SparkSession
 import org.hamcrest.Matchers
 import org.junit._
-import org.junit.rules.TestName
+import org.junit.rules.{ExpectedException, TestName}
 import org.neo4j.driver.summary.ResultSummary
 import org.neo4j.driver.{Transaction, TransactionWork}
 import org.neo4j.spark
 
 import java.util.concurrent.TimeUnit
+import scala.annotation.meta.getter
 
 object SparkConnectorScalaBaseTSE {
 
@@ -37,10 +38,8 @@ class SparkConnectorScalaBaseTSE {
   val conf: SparkConf = SparkConnectorScalaSuiteIT.conf
   val ss: SparkSession = SparkConnectorScalaSuiteIT.ss
 
-  val _testName: TestName = new TestName
-
-  @Rule
-  def testName = _testName
+  @(Rule@getter)
+  val testName: TestName = new TestName
 
   @Before
   def before() {

--- a/test-support/src/main/scala/org/neo4j/spark/SparkConnectorScalaBaseWithApocTSE.scala
+++ b/test-support/src/main/scala/org/neo4j/spark/SparkConnectorScalaBaseWithApocTSE.scala
@@ -10,6 +10,7 @@ import org.neo4j.driver.{Transaction, TransactionWork}
 import org.neo4j.spark
 
 import java.util.concurrent.TimeUnit
+import scala.annotation.meta.getter
 
 object SparkConnectorScalaBaseWithApocTSE {
 
@@ -37,10 +38,8 @@ class SparkConnectorScalaBaseWithApocTSE {
   val conf: SparkConf = SparkConnectorScalaSuiteWithApocIT.conf
   val ss: SparkSession = SparkConnectorScalaSuiteWithApocIT.ss
 
-  val _testName: TestName = new TestName
-
-  @Rule
-  def testName = _testName
+  @(Rule@getter)
+  val testName: TestName = new TestName
 
   @Before
   def before() {

--- a/test-support/src/main/scala/org/neo4j/spark/SparkConnectorScalaSuiteWithGdsBase.scala
+++ b/test-support/src/main/scala/org/neo4j/spark/SparkConnectorScalaSuiteWithGdsBase.scala
@@ -11,6 +11,7 @@ import org.neo4j.driver.summary.ResultSummary
 
 import java.util.TimeZone
 import java.util.concurrent.TimeUnit
+import scala.annotation.meta.getter
 
 object SparkConnectorScalaSuiteWithGdsBase {
   val server: Neo4jContainerExtension = new Neo4jContainerExtension()
@@ -84,10 +85,8 @@ class SparkConnectorScalaSuiteWithGdsBase {
   val conf: SparkConf = SparkConnectorScalaSuiteWithGdsBase.conf
   val ss: SparkSession = SparkConnectorScalaSuiteWithGdsBase.ss
 
-  val _testName: TestName = new TestName
-
-  @Rule
-  def testName: TestName = _testName
+  @(Rule@getter)
+  val testName: TestName = new TestName
 
   @Before
   def before(): Unit = {


### PR DESCRIPTION
Improved query error management now, if a query has an error we don't return only `Please provide a valid <TYPE> query` but a more elaborate message like `Query count not compiled for the following exception: <error from the compiler>`