### PR TITLE
Followup user agent

### DIFF
--- a/common/src/main/scala/org/neo4j/spark/util/Neo4jOptions.scala
+++ b/common/src/main/scala/org/neo4j/spark/util/Neo4jOptions.scala
@@ -295,7 +295,7 @@ case class Neo4jDriverOptions(
 
   def toDriverConfig: Config = {
     val builder = Config.builder()
-      .withUserAgent(s"neo4j-spark-connector/${Neo4jUtil.connectorVersion} ${Neo4jUtil.connectorEnv}")
+      .withUserAgent(s"neo4j-${Neo4jUtil.connectorEnv}-connector/${Neo4jUtil.connectorVersion}")
       .withLogging(Logging.slf4j())
 
     if (lifetime > -1) builder.withMaxConnectionLifetime(lifetime, TimeUnit.MILLISECONDS)

--- a/common/src/main/scala/org/neo4j/spark/util/Neo4jUtil.scala
+++ b/common/src/main/scala/org/neo4j/spark/util/Neo4jUtil.scala
@@ -21,7 +21,7 @@ import org.slf4j.Logger
 import java.time._
 import java.time.format.DateTimeFormatter
 import java.time.temporal.Temporal
-import java.util.Properties
+import java.util.{Optional, Properties}
 import scala.collection.JavaConverters._
 
 object Neo4jUtil {
@@ -239,10 +239,9 @@ object Neo4jUtil {
 
   def connectorVersion: String = properties.getOrDefault("version", "UNKNOWN").toString
 
-  def connectorEnv: String = Some(System.getenv("DATABRICKS_RUNTIME_VERSION"))
-    .map(s"Databricks-" + _)
-    .getOrElse("UNKNOWN")
-    .mkString("(", "", ")")
+  def connectorEnv: String = Option(System.getenv("DATABRICKS_RUNTIME_VERSION"))
+    .map(_ => "databricks")
+    .getOrElse("spark")
 
   def getCorrectProperty(container: PropertyContainer, attribute: String): Property = {
     container.property(attribute.split('.'): _*)

--- a/common/src/test/scala/org/neo4j/spark/util/Neo4jUtilTest.scala
+++ b/common/src/test/scala/org/neo4j/spark/util/Neo4jUtilTest.scala
@@ -1,12 +1,25 @@
 package org.neo4j.spark.util
 
+import org.apache.commons.lang3.StringUtils
 import org.junit.Test
+import org.junit.Assert
 
 class Neo4jUtilTest {
 
   @Test
   def testSafetyCloseShouldNotFailWithNull(): Unit = {
     Neo4jUtil.closeSafely(null)
+  }
+
+  @Test
+  def testConnectorEnv(): Unit = {
+    val expected = if (StringUtils.isNotBlank(System.getenv("DATABRICKS_RUNTIME_VERSION"))) {
+      "databricks"
+    } else {
+      "spark"
+    }
+    val actual = Neo4jUtil.connectorEnv
+    Assert.assertEquals(expected, actual)
   }
 
 }


### PR DESCRIPTION
Databricks says to satisfy ISV partnership requirements we should set the user agent to 
`neo4j-databricks-connector/<version>`

So in case the connection from databricks we have for instance:

`neo4j-databricks-connector/5.0.3`

in other scenarios:

`neo4j-spark-connector/5.0.3`
