### PR TITLE
updated spark version and made it configurable

### DIFF
--- a/examples/neo4j_data_engineering.ipynb
+++ b/examples/neo4j_data_engineering.ipynb
@@ -60,7 +60,18 @@
     {
       "cell_type": "code",
       "source": [
-        "!wget -q https://dlcdn.apache.org/spark/spark-3.3.3/spark-3.3.3-bin-hadoop3.tgz"
+        "spark_version = '3.3.4'"
+      ],
+      "metadata": {
+        "id": "gmEzhrux7Jek"
+      },
+      "execution_count": null,
+      "outputs": []
+    },
+    {
+      "cell_type": "code",
+      "source": [
+        "!wget -q https://dlcdn.apache.org/spark/spark-$spark_version/spark-$spark_version-bin-hadoop3.tgz"
       ],
       "metadata": {
         "id": "Ya6Nj_u3vdTL"
@@ -76,7 +87,7 @@
       },
       "outputs": [],
       "source": [
-        "!tar xf spark-3.3.3-bin-hadoop3.tgz"
+        "!tar xf spark-$spark_version-bin-hadoop3.tgz"
       ]
     },
     {
@@ -100,7 +111,7 @@
       "source": [
         "import os\n",
         "os.environ[\"JAVA_HOME\"] = \"/usr/lib/jvm/java-17-openjdk-amd64\"\n",
-        "os.environ[\"SPARK_HOME\"] = \"/content/spark-3.3.3-bin-hadoop3\""
+        "os.environ[\"SPARK_HOME\"] = f\"/content/spark-{spark_version}-bin-hadoop3\""
       ]
     },
     {

--- a/examples/neo4j_data_science.ipynb
+++ b/examples/neo4j_data_science.ipynb
@@ -130,6 +130,17 @@
     {
       "cell_type": "code",
       "source": [
+        "spark_version = '3.3.4'"
+      ],
+      "metadata": {
+        "id": "OiHMiko1-Qf7"
+      },
+      "execution_count": null,
+      "outputs": []
+    },
+    {
+      "cell_type": "code",
+      "source": [
         "!apt-get install openjdk-17-jdk-headless -qq > /dev/null"
       ],
       "metadata": {
@@ -141,7 +152,7 @@
     {
       "cell_type": "code",
       "source": [
-        "!wget -q https://dlcdn.apache.org/spark/spark-3.3.3/spark-3.3.3-bin-hadoop3.tgz"
+        "!wget -q https://dlcdn.apache.org/spark/spark-$spark_version/spark-$spark_version-bin-hadoop3.tgz"
       ],
       "metadata": {
         "id": "7JT9OKhzG7Lq"
@@ -157,7 +168,7 @@
       },
       "outputs": [],
       "source": [
-        "!tar xf spark-3.3.3-bin-hadoop3.tgz"
+        "!tar xf spark-$spark_version-bin-hadoop3.tgz"
       ]
     },
     {
@@ -181,7 +192,7 @@
       "source": [
         "import os\n",
         "os.environ[\"JAVA_HOME\"] = \"/usr/lib/jvm/java-17-openjdk-amd64\"\n",
-        "os.environ[\"SPARK_HOME\"] = \"/content/spark-3.3.3-bin-hadoop3\""
+        "os.environ[\"SPARK_HOME\"] = f\"/content/spark-{spark_version}-bin-hadoop3\""
       ]
     },
     {


### PR DESCRIPTION
I made the two notebooks configurable for the spark version.
This will make it easy the upgrade to new revisions.

Please check how it looks:
<img width="1373" alt="image" src="https://github.com/neo4j-contrib/neo4j-spark-connector/assets/1833335/df75b17a-1084-444f-b306-b56f774dcc2e">

As you can see, now the user can just change the `spark_version` variable.
