### PR TITLE
build: use neo4j as the new group id

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,3 +1,3 @@
-*       @neo4j-contrib/team-connectors
+*       @neo4j/team-connectors
 
 /.github/   @ali-ince @fbiville @venikkin

--- a/examples/neo4j_data_engineering.ipynb
+++ b/examples/neo4j_data_engineering.ipynb
@@ -3,7 +3,7 @@
     {
       "cell_type": "markdown",
       "source": [
-        "Open this notebook in Google Colab <a target=\"_blank\" href=\"https://colab.research.google.com/github/neo4j-contrib/neo4j-spark-connector/blob/5.0/examples/neo4j_data_engineering.ipynb\">\n",
+        "Open this notebook in Google Colab <a target=\"_blank\" href=\"https://colab.research.google.com/github/neo4j/neo4j-spark-connector/blob/5.0/examples/neo4j_data_engineering.ipynb\">\n",
         "  <img src=\"https://colab.research.google.com/assets/colab-badge.svg\" alt=\"Open In Colab\"/>\n",
         "</a>"
       ],
@@ -29,7 +29,7 @@
         "\n",
         "If you have any questions or problems feel free to write a post in the [Neo4j community forum](https://community.neo4j.com/) or in [Discord](https://discord.com/invite/neo4j).\n",
         "\n",
-        "If you want more exercises feel free to open an issue in the [GitHub repository](https://github.com/neo4j-contrib/neo4j-spark-connector).\n",
+        "If you want more exercises feel free to open an issue in the [GitHub repository](https://github.com/neo4j/neo4j-spark-connector).\n",
         "\n",
         "Enjoy!"
       ],

--- a/examples/neo4j_data_science.ipynb
+++ b/examples/neo4j_data_science.ipynb
@@ -18,7 +18,7 @@
     {
       "cell_type": "markdown",
       "source": [
-        "Open this notebook in Google Colab <a target=\"_blank\" href=\"https://colab.research.google.com/github/neo4j-contrib/neo4j-spark-connector/blob/5.0/examples/neo4j_data_science.ipynb\">\n",
+        "Open this notebook in Google Colab <a target=\"_blank\" href=\"https://colab.research.google.com/github/neo4j/neo4j-spark-connector/blob/5.0/examples/neo4j_data_science.ipynb\">\n",
         "  <img src=\"https://colab.research.google.com/assets/colab-badge.svg\" alt=\"Open In Colab\"/>\n",
         "</a>"
       ],
@@ -42,7 +42,7 @@
         "\n",
         "If you have any questions or problems feel free to write a post in the [Neo4j community forum](https://community.neo4j.com/) or in [Discord](https://discord.com/invite/neo4j).\n",
         "\n",
-        "If you want more exercises feel free to open an issue in the [GitHub repository](https://github.com/neo4j-contrib/neo4j-spark-connector).\n",
+        "If you want more exercises feel free to open an issue in the [GitHub repository](https://github.com/neo4j/neo4j-spark-connector).\n",
         "\n",
         "Enjoy!"
       ],

--- a/scripts/release/upload_to_spark_packages.sh
+++ b/scripts/release/upload_to_spark_packages.sh
@@ -32,5 +32,5 @@ curl -X POST 'https://spark-packages.org/api/submit-release' \
   -F "git_commit_sha1=$GIT_HASH" \
   -F "version=$VERSION" \
   -F "license_id=$LICENSE" \
-  -F "name=neo4j-contrib/neo4j-spark-connector" \
-  -F "artifact_zip=@$PATH_TO_PACKAGE_FILE"
+  -F "name=neo4j/neo4j-spark-connector" \
+  -F "artifact_zip=@$PATH_TO_PACKAGE_FILE;type=application/zip"

--- a/spark-3/pom.xml
+++ b/spark-3/pom.xml
@@ -13,7 +13,7 @@
     <description>Spark ${spark.version} for Neo4j Connector for Apache Spark using the binary Bolt Driver</description>
     <properties>
         <spark-packages.artifactId>neo4j-spark-connector</spark-packages.artifactId>
-        <spark-packages.groupId>neo4j-contrib</spark-packages.groupId>
+        <spark-packages.groupId>neo4j</spark-packages.groupId>
         <spark-packages.packageName>${spark-packages.artifactId}-${spark-packages.version}</spark-packages.packageName>
         <spark-packages.version/>
     </properties>


### PR DESCRIPTION
This PR updates spark package descriptor to use `neo4j` instead of `neo4j-contrib`, and also updates the references to the new repository.