### PR TITLE
fix: do not overflow when computing partition size

### DIFF
--- a/common/src/main/scala/org/neo4j/spark/config/TopN.scala
+++ b/common/src/main/scala/org/neo4j/spark/config/TopN.scala
@@ -18,4 +18,4 @@ package org.neo4j.spark.config
 
 import org.apache.spark.sql.connector.expressions.SortOrder
 
-case class TopN(limit: Int, orders: Array[SortOrder] = Array.empty)
+case class TopN(limit: Long, orders: Array[SortOrder] = Array.empty)

--- a/common/src/main/scala/org/neo4j/spark/service/SchemaService.scala
+++ b/common/src/main/scala/org/neo4j/spark/service/SchemaService.scala
@@ -552,7 +552,7 @@ class SchemaService(
       if (count <= 0) {
         Seq(PartitionPagination.EMPTY)
       } else {
-        val partitionSize = Math.ceil(count.toDouble / options.partitions).toInt
+        val partitionSize = Math.ceil(count.toDouble / options.partitions).toLong
         (0 until options.partitions)
           .map(index => PartitionPagination(index, index * partitionSize, TopN(partitionSize)))
       }

--- a/common/src/main/scala/org/neo4j/spark/service/SchemaService.scala
+++ b/common/src/main/scala/org/neo4j/spark/service/SchemaService.scala
@@ -543,28 +543,6 @@ class SchemaService(
     -1
   }
 
-  def countForQuery(): Long = {
-    val queryCount: String = options.queryMetadata.queryCount
-    if (Neo4jUtil.isLong(queryCount)) {
-      queryCount.toLong
-    } else {
-      val query = if (queryCount.nonEmpty) {
-        options.queryMetadata.queryCount
-      } else {
-        s"""CALL { ${options.query.value} }
-           |RETURN count(*) AS count
-           |""".stripMargin
-      }
-      session.run(query).single().get("count").asLong()
-    }
-  }
-
-  def count(filters: Array[Filter] = this.filters): Long = options.query.queryType match {
-    case QueryType.LABELS       => countForNode(filters)
-    case QueryType.RELATIONSHIP => countForRelationship(filters)
-    case QueryType.QUERY        => countForQuery()
-  }
-
   def skipLimitFromPartition(topN: Option[TopN]): Seq[PartitionPagination] =
     if (options.partitions == 1) {
       val skipLimit = topN.map(top => PartitionPagination(0, 0, top)).getOrElse(PartitionPagination.EMPTY)
@@ -576,9 +554,31 @@ class SchemaService(
       } else {
         val partitionSize = Math.ceil(count.toDouble / options.partitions).toInt
         (0 until options.partitions)
-          .map(index => PartitionPagination(index, index * partitionSize, TopN(partitionSize, Array.empty)))
+          .map(index => PartitionPagination(index, index * partitionSize, TopN(partitionSize)))
       }
     }
+
+  def count(filters: Array[Filter] = this.filters): Long = options.query.queryType match {
+    case QueryType.LABELS       => countForNode(filters)
+    case QueryType.RELATIONSHIP => countForRelationship(filters)
+    case QueryType.QUERY        => countForQuery()
+  }
+
+  private def countForQuery(): Long = {
+    val queryCount: String = options.queryMetadata.queryCount
+    if (Neo4jUtil.isLong(queryCount)) {
+      queryCount.trim.toLong
+    } else {
+      val query = if (queryCount.nonEmpty) {
+        options.queryMetadata.queryCount
+      } else {
+        s"""CALL { ${options.query.value} }
+           |RETURN count(*) AS count
+           |""".stripMargin
+      }
+      session.run(query).single().get("count").asLong()
+    }
+  }
 
   def isGdsProcedure(procName: String): Boolean = {
     val params: util.Map[String, AnyRef] = Map[String, AnyRef]("procName" -> procName).asJava

--- a/common/src/main/scala/org/neo4j/spark/util/Neo4jUtil.scala
+++ b/common/src/main/scala/org/neo4j/spark/util/Neo4jUtil.scala
@@ -118,8 +118,7 @@ object Neo4jUtil {
         str.trim.toLong
         true
       } catch {
-        case nfe: NumberFormatException => false
-        case t: Throwable               => throw t
+        case _: NumberFormatException => false
       }
     }
   }

--- a/common/src/test/scala/org/neo4j/spark/CommonTestSuiteIT.scala
+++ b/common/src/test/scala/org/neo4j/spark/CommonTestSuiteIT.scala
@@ -18,7 +18,6 @@ package org.neo4j.spark
 
 import org.junit.runner.RunWith
 import org.junit.runners.Suite
-import org.neo4j.spark.service.Neo4jQueryServiceIT
 import org.neo4j.spark.service.SchemaServiceTSE
 
 @RunWith(classOf[Suite])

--- a/common/src/test/scala/org/neo4j/spark/service/SchemaServiceTest.scala
+++ b/common/src/test/scala/org/neo4j/spark/service/SchemaServiceTest.scala
@@ -52,7 +52,6 @@ class SchemaServiceTest {
     assertEquals(List(0, 0), pages.map(_.topN.orders.size).toList)
   }
 
-  @nowarn // deprecated only in Scala 2.13, but 2.12 is our baseline
   private def options(kv: (String, String)*): Neo4jOptions = {
     new Neo4jOptions(
       JavaConverters.mapAsJavaMap(kv.toMap)

--- a/common/src/test/scala/org/neo4j/spark/service/SchemaServiceTest.scala
+++ b/common/src/test/scala/org/neo4j/spark/service/SchemaServiceTest.scala
@@ -18,26 +18,24 @@ package org.neo4j.spark.service
 
 import org.junit.Assert.assertEquals
 import org.junit.Test
-import org.mockito.Mockito.RETURNS_DEEP_STUBS
-import org.mockito.Mockito.mock
-import org.neo4j.caniuse.Neo4j
-import org.neo4j.caniuse.Neo4jDeploymentType
-import org.neo4j.caniuse.Neo4jEdition
-import org.neo4j.caniuse.Neo4jVersion
+import org.mockito.Mockito.{RETURNS_DEEP_STUBS, mock}
+import org.neo4j.caniuse.{Neo4j, Neo4jDeploymentType, Neo4jEdition, Neo4jVersion}
 import org.neo4j.spark.config.TopN
-import org.neo4j.spark.util.DriverCache
-import org.neo4j.spark.util.Neo4jOptions
+import org.neo4j.spark.util.{DriverCache, Neo4jOptions}
 
-import scala.jdk.javaapi.CollectionConverters
+import scala.annotation.nowarn
+import scala.collection.JavaConverters
+
 
 class SchemaServiceTest {
 
   @Test
   def does_not_overflow_when_partition_size_is_over_max_value_of_32bit_integers(): Unit = {
+    // note: _ cannot be used to separate digit groups, as this requires Scala 2.13+
     val opts = options(
       "url" -> "bolt://example.com",
       "partitions" -> 2.toString,
-      "query.count" -> (2L * 2_147_483_648L).toString, // 2 * (Integer.MAX_VALUE + 1)
+      "query.count" -> (2L * 2147483648L).toString, // 2 * (Integer.MAX_VALUE + 1)
       "query" -> "MERGE (:Node)"
     )
     val schemaService = new SchemaService(neo4j(), opts, mock(classOf[DriverCache], RETURNS_DEEP_STUBS))
@@ -45,14 +43,15 @@ class SchemaServiceTest {
     val pages = schemaService.skipLimitFromPartition(Some(TopN(1024)))
 
     assertEquals(List(0, 1), pages.map(_.partitionNumber).toList)
-    assertEquals(List(0, 2_147_483_648L), pages.map(_.skip).toList)
-    assertEquals(List(2_147_483_648L, 2_147_483_648L), pages.map(_.topN.limit).toList)
+    assertEquals(List(0, 2147483648L), pages.map(_.skip).toList)
+    assertEquals(List(2147483648L, 2147483648L), pages.map(_.topN.limit).toList)
     assertEquals(List(0, 0), pages.map(_.topN.orders.size).toList)
   }
 
+  @nowarn // deprecated only in Scala 2.13, but 2.12 is our baseline
   private def options(kv: (String, String)*): Neo4jOptions = {
     new Neo4jOptions(
-      CollectionConverters.asJava(kv.toMap)
+      JavaConverters.mapAsJavaMap(kv.toMap)
     )
   }
 

--- a/common/src/test/scala/org/neo4j/spark/service/SchemaServiceTest.scala
+++ b/common/src/test/scala/org/neo4j/spark/service/SchemaServiceTest.scala
@@ -18,14 +18,18 @@ package org.neo4j.spark.service
 
 import org.junit.Assert.assertEquals
 import org.junit.Test
-import org.mockito.Mockito.{RETURNS_DEEP_STUBS, mock}
-import org.neo4j.caniuse.{Neo4j, Neo4jDeploymentType, Neo4jEdition, Neo4jVersion}
+import org.mockito.Mockito.RETURNS_DEEP_STUBS
+import org.mockito.Mockito.mock
+import org.neo4j.caniuse.Neo4j
+import org.neo4j.caniuse.Neo4jDeploymentType
+import org.neo4j.caniuse.Neo4jEdition
+import org.neo4j.caniuse.Neo4jVersion
 import org.neo4j.spark.config.TopN
-import org.neo4j.spark.util.{DriverCache, Neo4jOptions}
+import org.neo4j.spark.util.DriverCache
+import org.neo4j.spark.util.Neo4jOptions
 
 import scala.annotation.nowarn
 import scala.collection.JavaConverters
-
 
 class SchemaServiceTest {
 

--- a/common/src/test/scala/org/neo4j/spark/service/SchemaServiceTest.scala
+++ b/common/src/test/scala/org/neo4j/spark/service/SchemaServiceTest.scala
@@ -1,14 +1,34 @@
+/*
+ * Copyright (c) "Neo4j"
+ * Neo4j Sweden AB [https://neo4j.com]
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.neo4j.spark.service
 
 import org.junit.Assert.assertEquals
 import org.junit.Test
-import org.mockito.Mockito.{RETURNS_DEEP_STUBS, mock}
-import org.neo4j.caniuse.{Neo4j, Neo4jDeploymentType, Neo4jEdition, Neo4jVersion}
+import org.mockito.Mockito.RETURNS_DEEP_STUBS
+import org.mockito.Mockito.mock
+import org.neo4j.caniuse.Neo4j
+import org.neo4j.caniuse.Neo4jDeploymentType
+import org.neo4j.caniuse.Neo4jEdition
+import org.neo4j.caniuse.Neo4jVersion
 import org.neo4j.spark.config.TopN
-import org.neo4j.spark.util.{DriverCache, Neo4jOptions}
+import org.neo4j.spark.util.DriverCache
+import org.neo4j.spark.util.Neo4jOptions
 
 import scala.jdk.javaapi.CollectionConverters
-
 
 class SchemaServiceTest {
 
@@ -18,7 +38,7 @@ class SchemaServiceTest {
       "url" -> "bolt://example.com",
       "partitions" -> 2.toString,
       "query.count" -> (2L * 2_147_483_648L).toString, // 2 * (Integer.MAX_VALUE + 1)
-      "query" -> "MERGE (:Node)",
+      "query" -> "MERGE (:Node)"
     )
     val schemaService = new SchemaService(neo4j(), opts, mock(classOf[DriverCache], RETURNS_DEEP_STUBS))
 

--- a/common/src/test/scala/org/neo4j/spark/service/SchemaServiceTest.scala
+++ b/common/src/test/scala/org/neo4j/spark/service/SchemaServiceTest.scala
@@ -1,0 +1,42 @@
+package org.neo4j.spark.service
+
+import org.junit.Assert.assertEquals
+import org.junit.Test
+import org.mockito.Mockito.{RETURNS_DEEP_STUBS, mock}
+import org.neo4j.caniuse.{Neo4j, Neo4jDeploymentType, Neo4jEdition, Neo4jVersion}
+import org.neo4j.spark.config.TopN
+import org.neo4j.spark.util.{DriverCache, Neo4jOptions}
+
+import scala.jdk.javaapi.CollectionConverters
+
+
+class SchemaServiceTest {
+
+  @Test
+  def does_not_overflow_when_partition_size_is_over_max_value_of_32bit_integers(): Unit = {
+    val opts = options(
+      "url" -> "bolt://example.com",
+      "partitions" -> 2.toString,
+      "query.count" -> (2L * 2_147_483_648L).toString, // 2 * (Integer.MAX_VALUE + 1)
+      "query" -> "MERGE (:Node)",
+    )
+    val schemaService = new SchemaService(neo4j(), opts, mock(classOf[DriverCache], RETURNS_DEEP_STUBS))
+
+    val pages = schemaService.skipLimitFromPartition(Some(TopN(1024)))
+
+    assertEquals(List(0, 1), pages.map(_.partitionNumber).toList)
+    assertEquals(List(0, 2_147_483_648L), pages.map(_.skip).toList)
+    assertEquals(List(2_147_483_648L, 2_147_483_648L), pages.map(_.topN.limit).toList)
+    assertEquals(List(0, 0), pages.map(_.topN.orders.size).toList)
+  }
+
+  private def options(kv: (String, String)*): Neo4jOptions = {
+    new Neo4jOptions(
+      CollectionConverters.asJava(kv.toMap)
+    )
+  }
+
+  private def neo4j(): Neo4j = {
+    new Neo4j(new Neo4jVersion(2025, 1, 0), Neo4jEdition.COMMUNITY, Neo4jDeploymentType.SELF_MANAGED)
+  }
+}


### PR DESCRIPTION
Make sure partition size is computed properly when using the query strategy, more than 1 partition and a custom query count.