### PR TITLE
ci: fix compat build scheduling and notifications

### DIFF
--- a/.teamcity/builds/Build.kt
+++ b/.teamcity/builds/Build.kt
@@ -140,8 +140,7 @@ class Build(
               queuedBuildRequiresApproval = forPullRequests
               buildFailedToStart = !forPullRequests
               buildFailed = !forPullRequests
-              firstFailureAfterSuccess = !forPullRequests
-              firstSuccessAfterFailure = !forPullRequests
+              buildFinishedSuccessfully = !forPullRequests
               buildProbablyHanging = !forPullRequests
 
               notifierSettings = slackNotifier {

--- a/.teamcity/builds/Common.kt
+++ b/.teamcity/builds/Common.kt
@@ -118,12 +118,12 @@ enum class Neo4jVersion(val version: String, val dockerImage: String) {
   V_5("5", "neo4j:5-enterprise"),
   V_5_DEV(
       "5-dev",
-      "535893049302.dkr.ecr.eu-west-1.amazonaws.com/build-service/neo4j:5-enterprise-debian-nightly",
+      "535893049302.dkr.ecr.eu-west-1.amazonaws.com/build-service/neo4j:5-enterprise-debian-nightly-bundle",
   ),
   V_2025("2025", "neo4j:2025-enterprise"),
   V_2025_DEV(
       "2025-dev",
-      "535893049302.dkr.ecr.eu-west-1.amazonaws.com/build-service/neo4j:2025-enterprise-debian-nightly",
+      "535893049302.dkr.ecr.eu-west-1.amazonaws.com/build-service/neo4j:2025-enterprise-debian-nightly-bundle",
   ),
 }
 

--- a/.teamcity/settings.kts
+++ b/.teamcity/settings.kts
@@ -84,7 +84,7 @@ project {
                   schedule {
                     branchFilter = "+:$DEFAULT_BRANCH"
                     schedulingPolicy = daily {
-                      hour = 8
+                      hour = 7
                       minute = 0
                     }
                     triggerBuild = always()

--- a/.teamcity/settings.kts
+++ b/.teamcity/settings.kts
@@ -88,6 +88,9 @@ project {
                       minute = 0
                     }
                     triggerBuild = always()
+                    withPendingChangesOnly = false
+                    enforceCleanCheckout = true
+                    enforceCleanCheckoutForDependencies = true
                   }
                 }
               },


### PR DESCRIPTION
This PR fixes CI so that compat builds run every day without checking for changes and also notifies on each day.