### PR TITLE
feat: add retries for reader queries

### DIFF
--- a/common/src/main/scala/org/neo4j/spark/reader/BasePartitionReader.scala
+++ b/common/src/main/scala/org/neo4j/spark/reader/BasePartitionReader.scala
@@ -38,10 +38,10 @@ import org.neo4j.spark.util.Neo4jUtil
 import org.neo4j.spark.util.QueryType
 
 import java.io.IOException
+import java.time.Duration
 import java.util
 import java.util.concurrent.CountDownLatch
 import java.util.concurrent.locks.LockSupport
-import java.time.Duration
 
 import scala.collection.JavaConverters._
 

--- a/common/src/main/scala/org/neo4j/spark/reader/BasePartitionReader.scala
+++ b/common/src/main/scala/org/neo4j/spark/reader/BasePartitionReader.scala
@@ -39,6 +39,9 @@ import org.neo4j.spark.util.QueryType
 
 import java.io.IOException
 import java.util
+import java.util.concurrent.CountDownLatch
+import java.util.concurrent.locks.LockSupport
+import java.time.Duration
 
 import scala.collection.JavaConverters._
 
@@ -81,36 +84,63 @@ abstract class BasePartitionReader(
   @volatile
   private var error: Boolean = false
 
+  private val retries = new CountDownLatch(options.transactionSettings.retries)
+
   @throws(classOf[IOException])
   def next: Boolean =
     try {
-      if (result == null) {
-        session = driverCache.getOrCreate().session(options.session.toNeo4jSession())
-        transaction = session.beginTransaction(options.toNeo4jTransactionConfig)
-
-        val queryText = query()
-        val queryParams = queryParameters
-
-        logInfo(s"Running the following query on Neo4j: $queryText")
-        logDebug(s"with parameters $queryParams")
-
-        result = transaction.run(queryText, Values.value(queryParams))
-          .asScala
-      }
-
-      if (result.hasNext) {
-        nextRow = mappingService.convert(result.next(), schema)
-        true
-      } else {
-        false
-      }
+      nextHandler()
     } catch {
       case t: Throwable => {
-        error = true
-        logInfo("Error while invoking next:", t)
-        throw new IOException(t)
+        if (options.transactionSettings.shouldFailOn(t)) {
+          error = true
+          logError("Error while invoking next due to explicitly configured failure condition:", t)
+          throw new IOException(t)
+        }
+
+        if (Neo4jUtil.isRetryableException(t) && retries.getCount > 0) {
+          retries.countDown()
+          logInfo(
+            s"encountered a transient exception while reading, retrying ${options.transactionSettings.retries - retries.getCount} time",
+            t
+          )
+
+          close()
+          result = null // Reset result to force new query
+          
+          // Wait before retry
+          LockSupport.parkNanos(Duration.ofMillis(options.transactionSettings.retryTimeout).toNanos)
+          nextHandler()
+        } else {
+          error = true
+          logError("Error while invoking next:", t)
+          throw new IOException(t)
+        }
       }
     }
+
+  private def nextHandler(): Boolean = {
+    if (result == null) {
+      session = driverCache.getOrCreate().session(options.session.toNeo4jSession())
+      transaction = session.beginTransaction(options.toNeo4jTransactionConfig)
+
+      val queryText = query()
+      val queryParams = queryParameters
+
+      logInfo(s"Running the following query on Neo4j: $queryText")
+      logDebug(s"with parameters $queryParams")
+
+      result = transaction.run(queryText, Values.value(queryParams))
+        .asScala
+    }
+
+    if (result.hasNext) {
+      nextRow = mappingService.convert(result.next(), schema)
+      true
+    } else {
+      false
+    }
+  }
 
   def get: InternalRow = nextRow
 

--- a/common/src/main/scala/org/neo4j/spark/reader/BasePartitionReader.scala
+++ b/common/src/main/scala/org/neo4j/spark/reader/BasePartitionReader.scala
@@ -40,7 +40,7 @@ import org.neo4j.spark.util.QueryType
 import java.io.IOException
 import java.time.Duration
 import java.util
-import java.util.concurrent.CountDownLatch
+import java.util.concurrent.atomic.AtomicInteger
 import java.util.concurrent.locks.LockSupport
 
 import scala.collection.JavaConverters._
@@ -84,7 +84,7 @@ abstract class BasePartitionReader(
   @volatile
   private var error: Boolean = false
 
-  private val retries = new CountDownLatch(options.transactionSettings.retries)
+  private val retries = new AtomicInteger(options.transactionSettings.retries)
 
   @throws(classOf[IOException])
   def next: Boolean =
@@ -98,10 +98,10 @@ abstract class BasePartitionReader(
           throw new IOException(t)
         }
 
-        if (Neo4jUtil.isRetryableException(t) && retries.getCount > 0) {
-          retries.countDown()
+        if (Neo4jUtil.isRetryableException(t) && retries.get() > 0) {
+          val currentRetry = retries.decrementAndGet
           logInfo(
-            s"encountered a transient exception while reading, retrying ${options.transactionSettings.retries - retries.getCount} time",
+            s"encountered a transient exception while reading, retrying ${options.transactionSettings.retries - currentRetry} time",
             t
           )
 

--- a/common/src/main/scala/org/neo4j/spark/reader/BasePartitionReader.scala
+++ b/common/src/main/scala/org/neo4j/spark/reader/BasePartitionReader.scala
@@ -91,7 +91,7 @@ abstract class BasePartitionReader(
     try {
       nextHandler()
     } catch {
-      case t: Throwable => {
+      case t: Throwable =>
         if (options.transactionSettings.shouldFailOn(t)) {
           error = true
           logError("Error while invoking next due to explicitly configured failure condition:", t)
@@ -107,7 +107,7 @@ abstract class BasePartitionReader(
 
           close()
           result = null // Reset result to force new query
-          
+
           // Wait before retry
           LockSupport.parkNanos(Duration.ofMillis(options.transactionSettings.retryTimeout).toNanos)
           nextHandler()
@@ -116,7 +116,6 @@ abstract class BasePartitionReader(
           logError("Error while invoking next:", t)
           throw new IOException(t)
         }
-      }
     }
 
   private def nextHandler(): Boolean = {

--- a/common/src/main/scala/org/neo4j/spark/reader/BasePartitionReader.scala
+++ b/common/src/main/scala/org/neo4j/spark/reader/BasePartitionReader.scala
@@ -101,7 +101,7 @@ abstract class BasePartitionReader(
         if (Neo4jUtil.isRetryableException(t) && retries.get() > 0) {
           val currentRetry = retries.decrementAndGet
           logInfo(
-            s"encountered a transient exception while reading, retrying ${options.transactionSettings.retries - currentRetry} time",
+            s"encountered a transient exception while reading, retrying ${options.transactionSettings.retries - currentRetry} time(s)",
             t
           )
 
@@ -110,7 +110,7 @@ abstract class BasePartitionReader(
 
           // Wait before retry
           LockSupport.parkNanos(Duration.ofMillis(options.transactionSettings.retryTimeout).toNanos)
-          nextHandler()
+          next
         } else {
           error = true
           logError("Error while invoking next:", t)

--- a/test-support/src/main/scala/org/neo4j/spark/SparkConnectorScalaBaseTSE.scala
+++ b/test-support/src/main/scala/org/neo4j/spark/SparkConnectorScalaBaseTSE.scala
@@ -21,7 +21,7 @@ import org.apache.spark.sql.SparkSession
 import org.junit._
 import org.junit.rules.TestName
 import org.neo4j.Closeables.use
-import org.scalatestplus.junit.JUnitSuite
+import org.scalatestplus.junit.AssertionsForJUnit
 
 import scala.annotation.meta.getter
 
@@ -46,7 +46,7 @@ object SparkConnectorScalaBaseTSE {
 
 }
 
-class SparkConnectorScalaBaseTSE extends JUnitSuite {
+class SparkConnectorScalaBaseTSE extends AssertionsForJUnit {
 
   val conf: SparkConf = SparkConnectorScalaSuiteIT.conf
   val ss: SparkSession = SparkConnectorScalaSuiteIT.ss


### PR DESCRIPTION
## Issue

Retry logic is currently only implemented for write queries.

## Fix
Implement retry logic for reads in `BasePartitionReader.scala`. The same retry amount configuration option is used. 