### PR TITLE
ci: retry package acquisition during apt install

### DIFF
--- a/.teamcity/builds/PythonIntegrationTests.kt
+++ b/.teamcity/builds/PythonIntegrationTests.kt
@@ -42,7 +42,7 @@ class PythonIntegrationTests(
               #!/bin/bash -eu
               
               apt-get update
-              apt-get install --yes build-essential libssl-dev zlib1g-dev libbz2-dev libreadline-dev libsqlite3-dev curl git libncursesw5-dev xz-utils tk-dev libxml2-dev libxmlsec1-dev libffi-dev liblzma-dev
+              apt-get install -o Acquire::Retries=10 --yes build-essential libssl-dev zlib1g-dev libbz2-dev libreadline-dev libsqlite3-dev curl git libncursesw5-dev xz-utils tk-dev libxml2-dev libxmlsec1-dev libffi-dev liblzma-dev
               curl -fsSL https://pyenv.run | bash
               
               export PYENV_ROOT="${'$'}HOME/.pyenv"

--- a/.teamcity/builds/Release.kt
+++ b/.teamcity/builds/Release.kt
@@ -77,7 +77,7 @@ class Release(id: String, name: String, javaVersion: JavaVersion) :
                 set -eux
                 
                 apt-get update
-                apt-get install --yes build-essential curl git unzip zip
+                apt-get install -o Acquire::Retries=10 --yes build-essential curl git unzip zip
                 
                 # Get the jreleaser downloader
                 curl -sL https://raw.githubusercontent.com/jreleaser/release-action/refs/tags/2.4.2/get_jreleaser.java > get_jreleaser.java


### PR DESCRIPTION
This PR adds `-o Acquire::Retries=10` arguments to `apt-get install` as a workaround to 503 errors for the build pipeline.