### PR TITLE
fix: update commons library to support java 8

### DIFF
--- a/common/src/main/scala/org/neo4j/spark/util/Neo4jOptions.scala
+++ b/common/src/main/scala/org/neo4j/spark/util/Neo4jOptions.scala
@@ -492,7 +492,7 @@ case class Neo4jDriverOptions(
   }
 
   private def createAuthTokenSupplier: Supplier[AuthenticationToken] = {
-    if (auth == null || auth.isBlank) {
+    if (auth == null || auth.isEmpty) {
       throw new IllegalArgumentException(s"Authentication type name is required")
     }
     val supplierFactories = ServiceLoader.load(

--- a/pom.xml
+++ b/pom.xml
@@ -682,12 +682,6 @@
                         <groupId>com.github.dasniko</groupId>
                         <artifactId>testcontainers-keycloak</artifactId>
                         <version>1.9.0</version>
-                        <!--exclusions>
-                            <exclusion>
-                                <groupId>io.quarkus</groupId>
-                                <artifactId>quarkus-junit4-mock</artifactId>
-                            </exclusion>
-                        </exclusions-->
                     </dependency>
                 </dependencies>
             </dependencyManagement>

--- a/pom.xml
+++ b/pom.xml
@@ -41,7 +41,7 @@
         <caniuse.version>1.3.0</caniuse.version>
         <commons-compress.version>1.28.0</commons-compress.version>
         <commons-lang3.version>3.18.0</commons-lang3.version>
-        <connectors-commons.version>1.0.0-rc1</connectors-commons.version>
+        <connectors-commons.version>1.0.0-rc2</connectors-commons.version>
         <cypherdsl.version>2022.11.0</cypherdsl.version>
         <driver.version>4.4.20</driver.version>
         <java.version>1.8</java.version>
@@ -670,6 +670,27 @@
                     </plugin>
                 </plugins>
             </build>
+        </profile>
+        <profile>
+            <id>jdk8</id>
+            <activation>
+                <jdk>1.8</jdk>
+            </activation>
+            <dependencyManagement>
+                <dependencies>
+                    <dependency>
+                        <groupId>com.github.dasniko</groupId>
+                        <artifactId>testcontainers-keycloak</artifactId>
+                        <version>1.9.0</version>
+                        <!--exclusions>
+                            <exclusion>
+                                <groupId>io.quarkus</groupId>
+                                <artifactId>quarkus-junit4-mock</artifactId>
+                            </exclusion>
+                        </exclusions-->
+                    </dependency>
+                </dependencies>
+            </dependencyManagement>
         </profile>
     </profiles>
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -73,7 +73,6 @@
         <spark.version>3.5.6</spark.version>
         <spotless-maven-plugin.version>2.46.1</spotless-maven-plugin.version>
         <surefire.jvm.args/>
-        <testcontainers-keycloak.version>3.8.0</testcontainers-keycloak.version>
         <testcontainers.version>1.21.3</testcontainers.version>
     </properties>
     <dependencyManagement>
@@ -91,27 +90,6 @@
                 <version>${testcontainers.version}</version>
                 <type>pom</type>
                 <scope>import</scope>
-            </dependency>
-            <dependency>
-                <groupId>com.github.dasniko</groupId>
-                <artifactId>testcontainers-keycloak</artifactId>
-                <version>${testcontainers-keycloak.version}</version>
-                <exclusions>
-                    <exclusion>
-                        <groupId>io.quarkus</groupId>
-                        <artifactId>quarkus-junit4-mock</artifactId>
-                    </exclusion>
-                </exclusions>
-            </dependency>
-            <!--
-                Required for com.github.dasniko:testcontainers-keycloak.
-                Version 3.6.9 is a minimal version supporting JDK 11.
-                See rules in: .github/dependabot.yml
-            -->
-            <dependency>
-                <groupId>io.quarkus</groupId>
-                <artifactId>quarkus-junit4-mock</artifactId>
-                <version>3.26.0</version>
             </dependency>
             <dependency>
                 <groupId>junit</groupId>
@@ -679,9 +657,9 @@
             <dependencyManagement>
                 <dependencies>
                     <dependency>
-                        <groupId>com.github.dasniko</groupId>
-                        <artifactId>testcontainers-keycloak</artifactId>
-                        <version>1.9.0</version>
+                        <groupId>org.jboss.logging</groupId>
+                        <artifactId>jboss-logging</artifactId>
+                        <version>3.4.3.Final</version>
                     </dependency>
                 </dependencies>
             </dependencyManagement>

--- a/spark-3/pom.xml
+++ b/spark-3/pom.xml
@@ -48,11 +48,6 @@
             <scope>provided</scope>
         </dependency>
         <dependency>
-            <groupId>com.github.dasniko</groupId>
-            <artifactId>testcontainers-keycloak</artifactId>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
             <groupId>org.neo4j</groupId>
             <artifactId>neo4j-connector-apache-spark_test-support</artifactId>
             <version>${project.version}</version>

--- a/spark-3/src/test/scala/org/neo4j/spark/ReauthenticationIT.scala
+++ b/spark-3/src/test/scala/org/neo4j/spark/ReauthenticationIT.scala
@@ -27,7 +27,6 @@ import org.neo4j.driver.Driver
 import org.neo4j.driver.GraphDatabase
 import org.neo4j.spark.ReauthenticationIT.KEYCLOAK
 import org.neo4j.spark.ReauthenticationIT.NEO4J
-import org.neo4j.spark.SparkConnectorScalaSuiteIT.server
 import org.neo4j.spark.SparkConnectorScalaSuiteIT.ss
 import org.testcontainers.containers.Network
 import org.testcontainers.utility.MountableFile
@@ -38,7 +37,12 @@ object ReauthenticationIT {
 
   private val KEYCLOAK = new KeycloakContainer("quay.io/keycloak/keycloak:26.2.5")
     .withNetwork(NETWORK).withNetworkAliases("keycloak")
-    .useTlsKeystore("/neo4j-keycloak.jks", "testpwd")
+    .withCopyFileToContainer(
+      MountableFile.forClasspathResource("/neo4j-keycloak.jks"),
+      "/opt/keycloak/conf/server.keystore"
+    )
+    .withEnv("KC_HTTPS_KEY_STORE_FILE", "/opt/keycloak/conf/server.keystore")
+    .withEnv("KC_HTTPS_KEY_STORE_PASSWORD", "testpwd")
     .withRealmImportFile("neo4j-sso-test-realm.json")
     .withEnv("KC_HOSTNAME", "https://keycloak:8443")
     .withEnv("KC_HOSTNAME_BACKCHANNEL_DYNAMIC", "true")

--- a/spark-3/src/test/scala/org/neo4j/spark/ReauthenticationIT.scala
+++ b/spark-3/src/test/scala/org/neo4j/spark/ReauthenticationIT.scala
@@ -16,7 +16,6 @@
  */
 package org.neo4j.spark
 
-import dasniko.testcontainers.keycloak.KeycloakContainer
 import org.junit.AfterClass
 import org.junit.Assert.assertEquals
 import org.junit.BeforeClass
@@ -28,24 +27,46 @@ import org.neo4j.driver.GraphDatabase
 import org.neo4j.spark.ReauthenticationIT.KEYCLOAK
 import org.neo4j.spark.ReauthenticationIT.NEO4J
 import org.neo4j.spark.SparkConnectorScalaSuiteIT.ss
+import org.slf4j.LoggerFactory
+import org.testcontainers.containers.GenericContainer
 import org.testcontainers.containers.Network
+import org.testcontainers.containers.output.Slf4jLogConsumer
+import org.testcontainers.containers.wait.strategy.Wait
 import org.testcontainers.utility.MountableFile
 
 object ReauthenticationIT {
 
+  private val log = LoggerFactory.getLogger(classOf[ReauthenticationIT])
+
+  private class TestKeycloakContainer(image: String) extends GenericContainer[TestKeycloakContainer](image) {
+    def getHttpPort: Integer = this.getMappedPort(8080)
+  }
+
   private val NETWORK = Network.newNetwork
 
-  private val KEYCLOAK = new KeycloakContainer("quay.io/keycloak/keycloak:26.2.5")
-    .withNetwork(NETWORK).withNetworkAliases("keycloak")
+  private val KEYCLOAK = new TestKeycloakContainer("quay.io/keycloak/keycloak:26.2.5")
+    .withNetwork(NETWORK)
+    .withEnv("KC_BOOTSTRAP_ADMIN_USERNAME", "admin")
+    .withEnv("KC_BOOTSTRAP_ADMIN_PASSWORD", "admin")
+    .withNetworkAliases("keycloak")
+    .withExposedPorts(8080, 9000, 8443)
     .withCopyFileToContainer(
       MountableFile.forClasspathResource("/neo4j-keycloak.jks"),
       "/opt/keycloak/conf/server.keystore"
     )
     .withEnv("KC_HTTPS_KEY_STORE_FILE", "/opt/keycloak/conf/server.keystore")
     .withEnv("KC_HTTPS_KEY_STORE_PASSWORD", "testpwd")
-    .withRealmImportFile("neo4j-sso-test-realm.json")
+    .withEnv("KC_HTTPS_KEY_PASSWORD", "testpwd")
+    .withEnv("KC_HEALTH_ENABLED", "true")
+    .withCopyFileToContainer(
+      MountableFile.forClasspathResource("/neo4j-sso-test-realm.json"),
+      "/opt/keycloak/data/import/neo4j-sso-test-realm.json"
+    )
     .withEnv("KC_HOSTNAME", "https://keycloak:8443")
     .withEnv("KC_HOSTNAME_BACKCHANNEL_DYNAMIC", "true")
+    .waitingFor(Wait.forHttp("/health/started").forPort(9000).usingTls().allowInsecure())
+    .withCommand("start-dev --import-realm")
+    .withLogConsumer(new Slf4jLogConsumer(log))
 
   private val NEO4J = new Neo4jContainerExtension()
     .withNetwork(NETWORK)


### PR DESCRIPTION
Update auth token provider to support JVM 8

* update connectors-commons dependency to rc2
* downgrade keycloak container dependency conditionally for jdk 8
* replace `isBlank` with `isEmpty` 