### PR TITLE
fix: use session options from spark driver

### DIFF
--- a/common/src/main/scala/org/neo4j/spark/util/Neo4jOptions.scala
+++ b/common/src/main/scala/org/neo4j/spark/util/Neo4jOptions.scala
@@ -48,30 +48,16 @@ class Neo4jOptions(private val options: java.util.Map[String, String]) extends S
 
   def asMap() = new util.HashMap[String, String](options)
 
-  private def parameters: util.Map[String, String] = {
-    val sparkOptions = SparkSession.getActiveSession
-      .map {
-        _.conf
-          .getAll
-          .filterKeys(k => k.startsWith("neo4j."))
-          .map { elem => (elem._1.substring("neo4j.".length), elem._2) }
-          .toMap
-      }
-      .getOrElse(Map.empty)
-
-    (sparkOptions ++ options.asScala).asJava
-  }
-
   private def getRequiredParameter(parameter: String): String = {
-    if (!parameters.containsKey(parameter) || parameters.get(parameter).isEmpty) {
+    if (!options.containsKey(parameter) || options.get(parameter).isEmpty) {
       throw new IllegalArgumentException(s"Parameter '$parameter' is required")
     }
 
-    parameters.get(parameter)
+    options.get(parameter)
   }
 
   private def getParameter(parameter: String, defaultValue: String = ""): String =
-    Some(parameters.getOrDefault(parameter, defaultValue))
+    Some(options.getOrDefault(parameter, defaultValue))
       .flatMap(Option(_)) // to turn null into None
       .map(_.trim)
       .getOrElse(defaultValue)
@@ -79,7 +65,7 @@ class Neo4jOptions(private val options: java.util.Map[String, String]) extends S
   private def getAuthenticationParameters: Map[String, String] = {
     val authType = getParameter(AUTH_TYPE, DEFAULT_AUTH_TYPE)
     val authNamespace = s"$AUTH.$authType"
-    val providedParameters = parameters.asScala
+    val providedParameters = options.asScala
       .filterKeys(_.startsWith(authNamespace))
       .map(t => (t._1.substring(authNamespace.length + 1), t._2))
       .toMap
@@ -301,7 +287,7 @@ class Neo4jOptions(private val options: java.util.Map[String, String]) extends S
   val queryMetadata: Neo4jQueryMetadata = initNeo4jQueryMetadata()
 
   private def initNeo4jGdsMetadata(): Neo4jGdsMetadata = Neo4jGdsMetadata(
-    parameters.asScala
+    options.asScala
       .filterKeys(k => k.startsWith("gds."))
       .map(t => (t._1.substring("gds.".length), t._2))
       .toMap
@@ -314,7 +300,7 @@ class Neo4jOptions(private val options: java.util.Map[String, String]) extends S
 
   val streamingOrderBy: String = getParameter(ORDER_BY, getParameter(STREAMING_PROPERTY_NAME))
 
-  val apocConfig: Neo4jApocConfig = Neo4jApocConfig(parameters.asScala
+  val apocConfig: Neo4jApocConfig = Neo4jApocConfig(options.asScala
     .filterKeys(_.startsWith("apoc."))
     .mapValues(Neo4jUtil.mapper.readValue(_, classOf[java.util.Map[String, AnyRef]]).asScala)
     .toMap)
@@ -647,6 +633,20 @@ object Neo4jOptions {
   var DEFAULT_AUTH_PARAMETERS: Map[String, String] =
     Seq("username", "password", "ticket", "principal", "credentials", "realm", "scheme", "token")
       .map(name => name -> DEFAULT_EMPTY).toMap
+
+  def fromSession(sparkSession: Option[SparkSession], options: java.util.Map[String, String]): Neo4jOptions = {
+    val sessionLevelOptions = sparkSession
+      .map {
+        _.conf
+          .getAll
+          .filterKeys(k => k.startsWith("neo4j."))
+          .map { elem => (elem._1.substring("neo4j.".length), elem._2) }
+          .toMap
+      }
+      .getOrElse(Map.empty)
+
+    new Neo4jOptions((sessionLevelOptions ++ options.asScala).asJava)
+  }
 }
 
 class CaseInsensitiveEnumeration extends Enumeration {

--- a/spark-3/src/main/scala/org/neo4j/spark/DataSource.scala
+++ b/spark-3/src/main/scala/org/neo4j/spark/DataSource.scala
@@ -16,6 +16,7 @@
  */
 package org.neo4j.spark
 
+import org.apache.spark.sql.SparkSession
 import org.apache.spark.sql.connector.catalog.Table
 import org.apache.spark.sql.connector.catalog.TableProvider
 import org.apache.spark.sql.connector.expressions.Transform
@@ -80,7 +81,8 @@ class DataSource extends TableProvider
 
   private def getNeo4jOptions(caseInsensitiveStringMap: CaseInsensitiveStringMap) = {
     if (neo4jOptions == null) {
-      neo4jOptions = new Neo4jOptions(caseInsensitiveStringMap.asCaseSensitiveMap())
+      neo4jOptions =
+        Neo4jOptions.fromSession(SparkSession.getActiveSession, caseInsensitiveStringMap.asCaseSensitiveMap())
     }
 
     neo4jOptions
@@ -99,7 +101,7 @@ class DataSource extends TableProvider
     }
     val neo4jOpts = getNeo4jOptions(caseInsensitiveStringMapNeo4jOptions)
     val neo4jInfo = getNeo4jInfo(neo4jOpts.connection)
-    new Neo4jTable(neo4jInfo, schema, map, jobId)
+    new Neo4jTable(neo4jInfo, schema, neo4jOpts, jobId)
   }
 
   override def shortName(): String = "neo4j"

--- a/spark-3/src/main/scala/org/neo4j/spark/Neo4jTable.scala
+++ b/spark-3/src/main/scala/org/neo4j/spark/Neo4jTable.scala
@@ -36,13 +36,11 @@ import org.neo4j.spark.writer.Neo4jWriterBuilder
 
 import scala.collection.JavaConverters._
 
-class Neo4jTable(neo4j: Neo4j, schema: StructType, options: java.util.Map[String, String], jobId: String)
+class Neo4jTable(neo4j: Neo4j, schema: StructType, neo4jOptions: Neo4jOptions, jobId: String)
     extends Table
     with SupportsRead
     with SupportsWrite
     with Logging {
-
-  private val neo4jOptions = new Neo4jOptions(options)
 
   override def name(): String = neo4jOptions.getTableName
 
@@ -64,7 +62,7 @@ class Neo4jTable(neo4j: Neo4j, schema: StructType, options: java.util.Map[String
   }
 
   override def newWriteBuilder(info: LogicalWriteInfo): WriteBuilder = {
-    val mapOptions = new java.util.HashMap[String, String](options)
+    val mapOptions = neo4jOptions.asMap()
     mapOptions.put(Neo4jOptions.ACCESS_MODE, AccessMode.WRITE.toString)
     val writeNeo4jOptions = new Neo4jOptions(mapOptions)
     new Neo4jWriterBuilder(neo4j, info.queryId(), info.schema(), SaveMode.Append, writeNeo4jOptions)

--- a/spark-3/src/test/scala/org/neo4j/spark/TransactionTimeoutIT.scala
+++ b/spark-3/src/test/scala/org/neo4j/spark/TransactionTimeoutIT.scala
@@ -16,8 +16,13 @@
  */
 package org.neo4j.spark
 
+import org.apache.spark.SparkException
+import org.apache.spark.sql.SparkSession
 import org.junit.Assert.assertEquals
+import org.junit.Assert.assertThrows
+import org.junit.Assert.assertTrue
 import org.junit.Test
+import org.neo4j.spark.SparkConnectorScalaSuiteWithApocIT.conf
 import org.neo4j.spark.SparkConnectorScalaSuiteWithApocIT.server
 import org.neo4j.spark.SparkConnectorScalaSuiteWithApocIT.ss
 
@@ -41,6 +46,58 @@ class TransactionTimeoutIT extends SparkConnectorScalaSuiteWithApocIT {
     val expected = Range.inclusive(1, 3).map(_.toLong).toList
 
     assertEquals(expected, results)
+  }
+
+  @Test
+  def sparkConnectorFailsWithTransactionTimeoutWhenSetOnSessionLevel(): Unit = {
+    val newConf = conf.clone().set("neo4j.url", server.getBoltUrl)
+      .set("neo4j.authentication.basic.username", "neo4j")
+      .set("neo4j.authentication.basic.password", server.getAdminPassword)
+      .set("neo4j.db.transaction.timeout", "1000")
+    val session = SparkSession.builder.config(newConf).getOrCreate()
+
+    val cypher = "UNWIND range(1, 20) AS i " +
+      "CALL apoc.util.sleep(1000) " +
+      "RETURN i as number"
+
+    val df = session.read.format("org.neo4j.spark.DataSource")
+      .option("query", cypher)
+      .load()
+      .toDF()
+
+    val exc = assertThrows(
+      classOf[SparkException],
+      () => {
+        df.select("number").rdd.map(_.getLong(0)).collect().toList
+      }
+    )
+    assertTrue(exc.getMessage.contains("The transaction has been terminated"))
+  }
+
+  @Test
+  def sparkConnectorFailsWithTransactionTimeoutWhenSetOnDatasourceLevel(): Unit = {
+    val newConf = conf.clone().set("neo4j.url", server.getBoltUrl)
+      .set("neo4j.authentication.basic.username", "neo4j")
+      .set("neo4j.authentication.basic.password", server.getAdminPassword)
+    val session = SparkSession.builder.config(newConf).getOrCreate()
+
+    val cypher = "UNWIND range(1, 20) AS i " +
+      "CALL apoc.util.sleep(1000) " +
+      "RETURN i as number"
+
+    val df = session.read.format("org.neo4j.spark.DataSource")
+      .option("query", cypher)
+      .option("db.transaction.timeout", "1000")
+      .load()
+      .toDF()
+
+    val exc = assertThrows(
+      classOf[SparkException],
+      () => {
+        df.select("number").rdd.map(_.getLong(0)).collect().toList
+      }
+    )
+    assertTrue(exc.getMessage.contains("The transaction has been terminated"))
   }
 
 }


### PR DESCRIPTION
This PR fixes an issue where connector options are evaluated dynamically in the spark worker process where the spark driver session options are no longer visible. It fixes the issue by constructing neo4j options at the spark driver side and re-using it further down the stack.