### PR TITLE
feat: add an option to override user agent

### DIFF
--- a/common/src/main/scala/org/neo4j/spark/util/Neo4jUtil.scala
+++ b/common/src/main/scala/org/neo4j/spark/util/Neo4jUtil.scala
@@ -125,7 +125,10 @@ object Neo4jUtil {
 
   def connectorVersion: String = properties.getOrDefault("version", "UNKNOWN").toString
 
-  def connectorEnv: String = Option(System.getenv("DATABRICKS_RUNTIME_VERSION"))
+  def connectorEnv: String = Option(System.getProperty("neo4j.spark.platform"))
+    .getOrElse(defaultConnectorEnv)
+
+  private def defaultConnectorEnv: String = Option(System.getenv("DATABRICKS_RUNTIME_VERSION"))
     .map(_ => "databricks")
     .getOrElse("spark")
 

--- a/common/src/test/scala/org/neo4j/spark/util/Neo4jUtilTest.scala
+++ b/common/src/test/scala/org/neo4j/spark/util/Neo4jUtilTest.scala
@@ -38,4 +38,11 @@ class Neo4jUtilTest {
     Assert.assertEquals(expected, actual)
   }
 
+  @Test
+  def testConnectorEnvForCustom(): Unit = {
+    System.setProperty("neo4j.spark.platform", "abc")
+    val actual = Neo4jUtil.connectorEnv
+    Assert.assertEquals("abc", actual)
+  }
+
 }


### PR DESCRIPTION
This PR introduces a way to override the platform name.