### PR TITLE
feat: introduce skip.null.keys options

### DIFF
--- a/common/src/main/scala/org/neo4j/spark/service/MappingService.scala
+++ b/common/src/main/scala/org/neo4j/spark/service/MappingService.scala
@@ -34,8 +34,6 @@ import org.neo4j.spark.util.Neo4jOptions
 import org.neo4j.spark.util.Neo4jUtil
 import org.neo4j.spark.util.QueryType
 import org.neo4j.spark.util.RelationshipSaveStrategy
-import org.neo4j.spark.util.ValidateSchemaOptions
-import org.neo4j.spark.util.Validations
 
 import java.util
 import java.util.function
@@ -68,7 +66,7 @@ class Neo4jWriteMappingStrategy(private val options: Neo4jOptions)
       })
 
     if (options.skipNullKeys && keys.containsValue(Values.NULL)) {
-      logWarning(
+      logTrace(
         s"Skipping row because it contains null value for one of the node keys: [${
             options.nodeMetadata.nodeKeys.values
               .mkString(", ")
@@ -161,7 +159,7 @@ class Neo4jWriteMappingStrategy(private val options: Neo4jOptions)
           || consumer.targetNodeMap.get(KEYS).containsValue(Values.NULL)
       )
     ) {
-      logWarning(
+      logTrace(
         s"Skipping row because it contains null value for one of the relationship keys: [${
             options.relationshipMetadata.relationshipKeys.values
               .mkString(", ")

--- a/common/src/main/scala/org/neo4j/spark/service/MappingService.scala
+++ b/common/src/main/scala/org/neo4j/spark/service/MappingService.scala
@@ -65,13 +65,8 @@ class Neo4jWriteMappingStrategy(private val options: Neo4jOptions)
         }
       })
 
-    if (options.skipNullKeys && keys.containsValue(Values.NULL)) {
-      logTrace(
-        s"Skipping row because it contains null value for one of the node keys: [${
-            options.nodeMetadata.nodeKeys.values
-              .mkString(", ")
-          }]"
-      )
+    if (options.nodeMetadata.skipNullKeys && containsNull(keys)) {
+      logSkipping("node keys", options.nodeMetadata.nodeKeys.values)
       None
     } else {
       Some(rowMap)
@@ -152,32 +147,19 @@ class Neo4jWriteMappingStrategy(private val options: Neo4jOptions)
       )
     }
 
-    if (
-      options.skipNullKeys && (
-        consumer.relMap.get(KEYS).containsValue(Values.NULL)
-          || consumer.sourceNodeMap.get(KEYS).containsValue(Values.NULL)
-          || consumer.targetNodeMap.get(KEYS).containsValue(Values.NULL)
-      )
-    ) {
-      logTrace(
-        s"Skipping row because it contains null value for one of the relationship keys: [${
-            options.relationshipMetadata.relationshipKeys.values
-              .mkString(", ")
-          }] or source node keys: [${
-            options.relationshipMetadata.source.nodeKeys.values
-              .mkString(", ")
-          }] or target node keys: [${
-            options.relationshipMetadata.target.nodeKeys.values
-              .mkString(", ")
-          }]"
-      )
+    if (options.relationshipMetadata.skipNullKeys && containsNull(consumer.relMap, KEYS)) {
+      logSkipping("relationship keys", options.relationshipMetadata.relationshipKeys.values)
+      None
+    } else if (options.relationshipMetadata.source.skipNullKeys && containsNull(consumer.sourceNodeMap, KEYS)) {
+      logSkipping("source node keys", options.relationshipMetadata.source.nodeKeys.values)
+      None
+    } else if (options.relationshipMetadata.target.skipNullKeys && containsNull(consumer.targetNodeMap, KEYS)) {
+      logSkipping("target node keys", options.relationshipMetadata.target.nodeKeys.values)
       None
     } else {
-
       rowMap.put(Neo4jUtil.RELATIONSHIP_ALIAS, consumer.relMap)
       rowMap.put(Neo4jUtil.RELATIONSHIP_SOURCE_ALIAS, consumer.sourceNodeMap)
       rowMap.put(Neo4jUtil.RELATIONSHIP_TARGET_ALIAS, consumer.targetNodeMap)
-
       Some(rowMap)
     }
   }
@@ -201,6 +183,20 @@ class Neo4jWriteMappingStrategy(private val options: Neo4jOptions)
         .toMap
         .asJava
     )
+  }
+
+  // Helper methods
+
+  private def containsNull(map: java.util.Map[String, Object]): Boolean = {
+    map.containsValue(Values.NULL)
+  }
+
+  private def containsNull(map: java.util.Map[String, java.util.Map[String, AnyRef]], key: String): Boolean = {
+    map.get(key).containsValue(Values.NULL)
+  }
+
+  private def logSkipping(keyType: String, keys: Iterable[String]): Unit = {
+    logTrace(s"Skipping row because it contains null value for one of the $keyType: [${keys.mkString(", ")}]")
   }
 }
 

--- a/common/src/main/scala/org/neo4j/spark/service/MappingService.scala
+++ b/common/src/main/scala/org/neo4j/spark/service/MappingService.scala
@@ -45,12 +45,12 @@ import scala.collection.JavaConverters._
 import scala.collection.mutable
 
 class Neo4jWriteMappingStrategy(private val options: Neo4jOptions)
-    extends Neo4jMappingStrategy[InternalRow, java.util.Map[String, AnyRef]]
+    extends Neo4jMappingStrategy[InternalRow, Option[java.util.Map[String, AnyRef]]]
     with Logging {
 
   private val dataConverter = SparkToNeo4jDataConverter()
 
-  override def node(row: InternalRow, schema: StructType): java.util.Map[String, AnyRef] = {
+  override def node(row: InternalRow, schema: StructType): Option[java.util.Map[String, AnyRef]] = {
     val rowMap: java.util.Map[String, Object] = new java.util.HashMap[String, Object]
     val keys: java.util.Map[String, Object] = new java.util.HashMap[String, Object]
     val properties: java.util.Map[String, Object] = new java.util.HashMap[String, Object]
@@ -58,6 +58,7 @@ class Neo4jWriteMappingStrategy(private val options: Neo4jOptions)
     rowMap.put(PROPERTIES, properties)
 
     query(row, schema)
+      .get
       .forEach(new BiConsumer[String, AnyRef] {
         override def accept(key: String, value: AnyRef): Unit = if (options.nodeMetadata.nodeKeys.contains(key)) {
           keys.put(options.nodeMetadata.nodeKeys.getOrElse(key, key), value)
@@ -66,7 +67,17 @@ class Neo4jWriteMappingStrategy(private val options: Neo4jOptions)
         }
       })
 
-    rowMap
+    if (options.skipNullKeys && keys.containsValue(Values.NULL)) {
+      logWarning(
+        s"Skipping row because it contains null value for one of the node keys: [${
+            options.nodeMetadata.nodeKeys.values
+              .mkString(", ")
+          }]"
+      )
+      None
+    } else {
+      Some(rowMap)
+    }
   }
 
   private def nativeStrategyConsumer(): MappingBiConsumer = new MappingBiConsumer {
@@ -121,7 +132,7 @@ class Neo4jWriteMappingStrategy(private val options: Neo4jOptions)
     }
   }
 
-  override def relationship(row: InternalRow, schema: StructType): java.util.Map[String, AnyRef] = {
+  override def relationship(row: InternalRow, schema: StructType): Option[java.util.Map[String, AnyRef]] = {
     val rowMap: java.util.Map[String, AnyRef] = new java.util.HashMap[String, AnyRef]
 
     val consumer = options.relationshipMetadata.saveStrategy match {
@@ -129,7 +140,7 @@ class Neo4jWriteMappingStrategy(private val options: Neo4jOptions)
       case RelationshipSaveStrategy.KEYS   => keysStrategyConsumer()
     }
 
-    query(row, schema).forEach(consumer)
+    query(row, schema).get.forEach(consumer)
 
     if (
       options.relationshipMetadata.saveStrategy.equals(RelationshipSaveStrategy.NATIVE)
@@ -143,30 +154,55 @@ class Neo4jWriteMappingStrategy(private val options: Neo4jOptions)
       )
     }
 
-    rowMap.put(Neo4jUtil.RELATIONSHIP_ALIAS, consumer.relMap)
-    rowMap.put(Neo4jUtil.RELATIONSHIP_SOURCE_ALIAS, consumer.sourceNodeMap)
-    rowMap.put(Neo4jUtil.RELATIONSHIP_TARGET_ALIAS, consumer.targetNodeMap)
+    if (
+      options.skipNullKeys && (
+        consumer.relMap.get(KEYS).containsValue(Values.NULL)
+          || consumer.sourceNodeMap.get(KEYS).containsValue(Values.NULL)
+          || consumer.targetNodeMap.get(KEYS).containsValue(Values.NULL)
+      )
+    ) {
+      logWarning(
+        s"Skipping row because it contains null value for one of the relationship keys: [${
+            options.relationshipMetadata.relationshipKeys.values
+              .mkString(", ")
+          }] or source node keys: [${
+            options.relationshipMetadata.source.nodeKeys.values
+              .mkString(", ")
+          }] or target node keys: [${
+            options.relationshipMetadata.target.nodeKeys.values
+              .mkString(", ")
+          }]"
+      )
+      None
+    } else {
 
-    rowMap
+      rowMap.put(Neo4jUtil.RELATIONSHIP_ALIAS, consumer.relMap)
+      rowMap.put(Neo4jUtil.RELATIONSHIP_SOURCE_ALIAS, consumer.sourceNodeMap)
+      rowMap.put(Neo4jUtil.RELATIONSHIP_TARGET_ALIAS, consumer.targetNodeMap)
+
+      Some(rowMap)
+    }
   }
 
-  override def query(row: InternalRow, schema: StructType): java.util.Map[String, AnyRef] = {
+  override def query(row: InternalRow, schema: StructType): Option[java.util.Map[String, AnyRef]] = {
     val seq = row.toSeq(schema)
-    schema.indices
-      .flatMap(i => {
-        val field = schema(i)
-        val neo4jValue = dataConverter.convert(seq(i), field.dataType)
-        neo4jValue match {
-          case map: MapValue =>
-            map.asMap().asScala.toMap
-              .flattenMap(field.name, options.schemaMetadata.mapGroupDuplicateKeys)
-              .mapValues(value => Values.value(value).asInstanceOf[AnyRef])
-              .toSeq
-          case _ => Seq((field.name, neo4jValue))
-        }
-      })
-      .toMap
-      .asJava
+    Some(
+      schema.indices
+        .flatMap(i => {
+          val field = schema(i)
+          val neo4jValue = dataConverter.convert(seq(i), field.dataType)
+          neo4jValue match {
+            case map: MapValue =>
+              map.asMap().asScala.toMap
+                .flattenMap(field.name, options.schemaMetadata.mapGroupDuplicateKeys)
+                .mapValues(value => Values.value(value).asInstanceOf[AnyRef])
+                .toSeq
+            case _ => Seq((field.name, neo4jValue))
+          }
+        })
+        .toMap
+        .asJava
+    )
   }
 }
 

--- a/common/src/main/scala/org/neo4j/spark/util/Neo4jOptions.scala
+++ b/common/src/main/scala/org/neo4j/spark/util/Neo4jOptions.scala
@@ -89,8 +89,6 @@ class Neo4jOptions(private val options: java.util.Map[String, String]) extends S
   val pushdownTopNEnabled: Boolean =
     getParameter(PUSHDOWN_TOPN_ENABLED, DEFAULT_PUSHDOWN_TOPN_ENABLED.toString).toBoolean
 
-  val skipNullKeys: Boolean = getParameter(SKIP_NULL_KEY_PROPS, "false").toBoolean
-
   val schemaMetadata: Neo4jSchemaMetadata = initSchemaMetadata
 
   private def initSchemaMetadata = {
@@ -202,7 +200,8 @@ class Neo4jOptions(private val options: java.util.Map[String, String]) extends S
   private def initNeo4jNodeMetadata(
     nodeKeysString: String = getParameter(NODE_KEYS, ""),
     labelsString: String = query.value,
-    nodePropsString: String = ""
+    nodePropsString: String = "",
+    skipNullKeys: Boolean = getParameter(NODE_KEYS_SKIP_NULLS, "false").toBoolean
   ): Neo4jNodeMetadata = {
 
     val nodeKeys = mapPropsString(nodeKeysString)
@@ -212,7 +211,7 @@ class Neo4jOptions(private val options: java.util.Map[String, String]) extends S
       .split(":")
       .map(_.trim)
       .filter(_.nonEmpty)
-    Neo4jNodeMetadata(labels, nodeKeys, nodeProps)
+    Neo4jNodeMetadata(labels, nodeKeys, nodeProps, skipNullKeys)
   }
 
   val transactionSettings: Neo4jTransactionSettings = initNeo4jTransactionSettings()
@@ -240,13 +239,15 @@ class Neo4jOptions(private val options: java.util.Map[String, String]) extends S
     val source = initNeo4jNodeMetadata(
       getParameter(RELATIONSHIP_SOURCE_NODE_KEYS, ""),
       getParameter(RELATIONSHIP_SOURCE_LABELS, ""),
-      getParameter(RELATIONSHIP_SOURCE_NODE_PROPS, "")
+      getParameter(RELATIONSHIP_SOURCE_NODE_PROPS, ""),
+      getParameter(RELATIONSHIP_SOURCE_NODE_KEYS_SKIP_NULLS, "false").toBoolean
     )
 
     val target = initNeo4jNodeMetadata(
       getParameter(RELATIONSHIP_TARGET_NODE_KEYS, ""),
       getParameter(RELATIONSHIP_TARGET_LABELS, ""),
-      getParameter(RELATIONSHIP_TARGET_NODE_PROPS, "")
+      getParameter(RELATIONSHIP_TARGET_NODE_PROPS, ""),
+      getParameter(RELATIONSHIP_TARGET_NODE_KEYS_SKIP_NULLS, "false").toBoolean
     )
 
     val nodeMap = getParameter(RELATIONSHIP_NODES_MAP, DEFAULT_RELATIONSHIP_NODES_MAP.toString).toBoolean
@@ -277,7 +278,8 @@ class Neo4jOptions(private val options: java.util.Map[String, String]) extends S
       query.value,
       nodeMap,
       writeStrategy,
-      relationshipKeys
+      relationshipKeys,
+      getParameter(RELATIONSHIP_KEYS_SKIP_NULLS, "false").toBoolean
     )
   }
 
@@ -373,7 +375,12 @@ case class Neo4jTransactionSettings(
 
 }
 
-case class Neo4jNodeMetadata(labels: Seq[String], nodeKeys: Map[String, String], properties: Map[String, String]) {
+case class Neo4jNodeMetadata(
+  labels: Seq[String],
+  nodeKeys: Map[String, String],
+  properties: Map[String, String],
+  skipNullKeys: Boolean = false
+) {
   def includesProperty(name: String): Boolean = nodeKeys.contains(name) || properties.contains(name)
 }
 
@@ -386,7 +393,8 @@ case class Neo4jRelationshipMetadata(
   relationshipType: String,
   nodeMap: Boolean,
   saveStrategy: RelationshipSaveStrategy.Value,
-  relationshipKeys: Map[String, String]
+  relationshipKeys: Map[String, String],
+  skipNullKeys: Boolean = false
 )
 
 case class Neo4jQueryMetadata(query: String, queryCount: String)
@@ -558,8 +566,12 @@ object Neo4jOptions {
   // orderBy
   val ORDER_BY = "orderBy"
 
+  // skip.nulls postfix
+  val SKIP_NULLS = "skip.nulls"
+
   // Node Metadata
   val NODE_KEYS = "node.keys"
+  val NODE_KEYS_SKIP_NULLS = s"${NODE_KEYS}.${SKIP_NULLS}"
   val NODE_PROPS = "node.properties"
 
   val BATCH_SIZE = "batch.size"
@@ -569,24 +581,24 @@ object Neo4jOptions {
   val RELATIONSHIP_SOURCE_LABELS =
     s"${QueryType.RELATIONSHIP.toString.toLowerCase}.source.${QueryType.LABELS.toString.toLowerCase}"
   val RELATIONSHIP_SOURCE_NODE_KEYS = s"${QueryType.RELATIONSHIP.toString.toLowerCase}.source.$NODE_KEYS"
+  val RELATIONSHIP_SOURCE_NODE_KEYS_SKIP_NULLS = s"${RELATIONSHIP_SOURCE_NODE_KEYS}.${SKIP_NULLS}"
   val RELATIONSHIP_SOURCE_NODE_PROPS = s"${QueryType.RELATIONSHIP.toString.toLowerCase}.source.$NODE_PROPS"
   val RELATIONSHIP_SOURCE_SAVE_MODE = s"${QueryType.RELATIONSHIP.toString.toLowerCase}.source.$SAVE_MODE"
 
   val RELATIONSHIP_TARGET_LABELS =
     s"${QueryType.RELATIONSHIP.toString.toLowerCase}.target.${QueryType.LABELS.toString.toLowerCase}"
   val RELATIONSHIP_TARGET_NODE_KEYS = s"${QueryType.RELATIONSHIP.toString.toLowerCase}.target.$NODE_KEYS"
+  val RELATIONSHIP_TARGET_NODE_KEYS_SKIP_NULLS = s"${RELATIONSHIP_TARGET_NODE_KEYS}.${SKIP_NULLS}"
   val RELATIONSHIP_TARGET_NODE_PROPS = s"${QueryType.RELATIONSHIP.toString.toLowerCase}.target.$NODE_PROPS"
   val RELATIONSHIP_TARGET_SAVE_MODE = s"${QueryType.RELATIONSHIP.toString.toLowerCase}.target.$SAVE_MODE"
   val RELATIONSHIP_PROPERTIES = s"${QueryType.RELATIONSHIP.toString.toLowerCase}.properties"
   val RELATIONSHIP_NODES_MAP = s"${QueryType.RELATIONSHIP.toString.toLowerCase}.nodes.map"
   val RELATIONSHIP_SAVE_STRATEGY = s"${QueryType.RELATIONSHIP.toString.toLowerCase}.save.strategy"
   val RELATIONSHIP_KEYS = s"${QueryType.RELATIONSHIP.toString.toLowerCase}.keys"
+  val RELATIONSHIP_KEYS_SKIP_NULLS = s"${RELATIONSHIP_KEYS}.${SKIP_NULLS}"
 
   // Query metadata
   val QUERY_COUNT = "query.count"
-
-  // Skip NULL valued key properties when creating nodes/relationships
-  val SKIP_NULL_KEY_PROPS = "skip.null.keys"
 
   // Transaction Metadata
   val TRANSACTION_RETRIES = "transaction.retries"

--- a/common/src/main/scala/org/neo4j/spark/util/Neo4jOptions.scala
+++ b/common/src/main/scala/org/neo4j/spark/util/Neo4jOptions.scala
@@ -89,6 +89,8 @@ class Neo4jOptions(private val options: java.util.Map[String, String]) extends S
   val pushdownTopNEnabled: Boolean =
     getParameter(PUSHDOWN_TOPN_ENABLED, DEFAULT_PUSHDOWN_TOPN_ENABLED.toString).toBoolean
 
+  val skipNullKeys: Boolean = getParameter(SKIP_NULL_KEY_PROPS, "false").toBoolean
+
   val schemaMetadata: Neo4jSchemaMetadata = initSchemaMetadata
 
   private def initSchemaMetadata = {
@@ -582,6 +584,9 @@ object Neo4jOptions {
 
   // Query metadata
   val QUERY_COUNT = "query.count"
+
+  // Skip NULL valued key properties when creating nodes/relationships
+  val SKIP_NULL_KEY_PROPS = "skip.null.keys"
 
   // Transaction Metadata
   val TRANSACTION_RETRIES = "transaction.retries"

--- a/common/src/main/scala/org/neo4j/spark/util/Validations.scala
+++ b/common/src/main/scala/org/neo4j/spark/util/Validations.scala
@@ -123,13 +123,6 @@ case class ValidateSchemaMetadataWrite(neo4jOptions: Neo4jOptions, saveMode: Sav
             s"${Neo4jOptions.NODE_KEYS} is required to define the constraints"
           )
         }
-
-        if (neo4jOptions.skipNullKeys) {
-          ValidationUtil.isTrue(
-            saveMode == SaveMode.Overwrite,
-            s"`${Neo4jOptions.SKIP_NULL_KEY_PROPS}` works only with `mode` `Overwrite`"
-          )
-        }
       }
       case QueryType.RELATIONSHIP => {
         if (hasNodeOptimizations) {

--- a/common/src/main/scala/org/neo4j/spark/util/Validations.scala
+++ b/common/src/main/scala/org/neo4j/spark/util/Validations.scala
@@ -117,10 +117,17 @@ case class ValidateSchemaMetadataWrite(neo4jOptions: Neo4jOptions, saveMode: Sav
       }
       case QueryType.LABELS => {
         if (hasNodeOptimizations) {
-          ValidationUtil.isTrue(saveMode == SaveMode.Overwrite, "This works only with `mode` `SaveMode.Overwrite`")
+          ValidationUtil.isTrue(saveMode == SaveMode.Overwrite, "This works only with `mode` `Overwrite`")
           ValidationUtil.isNotEmpty(
             neo4jOptions.nodeMetadata.nodeKeys,
             s"${Neo4jOptions.NODE_KEYS} is required to define the constraints"
+          )
+        }
+
+        if (neo4jOptions.skipNullKeys) {
+          ValidationUtil.isTrue(
+            saveMode == SaveMode.Overwrite,
+            s"`${Neo4jOptions.SKIP_NULL_KEY_PROPS}` works only with `mode` `Overwrite`"
           )
         }
       }

--- a/common/src/main/scala/org/neo4j/spark/writer/BaseDataWriter.scala
+++ b/common/src/main/scala/org/neo4j/spark/writer/BaseDataWriter.scala
@@ -72,7 +72,7 @@ abstract class BaseDataWriter(
   private val metrics = DataWriterMetrics()
 
   def write(record: InternalRow): Unit = {
-    batch.add(mappingService.convert(record, structType))
+    mappingService.convert(record, structType).foreach(batch.add)
     if (batch.size() == options.transactionSettings.batchSize) {
       writeBatch()
     }

--- a/common/src/main/scala/org/neo4j/spark/writer/BaseDataWriter.scala
+++ b/common/src/main/scala/org/neo4j/spark/writer/BaseDataWriter.scala
@@ -71,8 +71,15 @@ abstract class BaseDataWriter(
 
   private val metrics = DataWriterMetrics()
 
+  private var skipped = 0
+
   def write(record: InternalRow): Unit = {
-    mappingService.convert(record, structType).foreach(batch.add)
+    val mapped = mappingService.convert(record, structType)
+    mapped match {
+      case Some(m) => batch.add(m)
+      case None =>
+        skipped += 1
+    }
     if (batch.size() == options.transactionSettings.batchSize) {
       writeBatch()
     }
@@ -116,6 +123,11 @@ abstract class BaseDataWriter(
         )
       }
       transaction.commit()
+
+      if (skipped > 0) {
+        log.info(s"Skipped $skipped rows that contained null values in one of their key property values.")
+        skipped = 0
+      }
 
       // update metrics
       metrics.applyCounters(batch.size(), counters)

--- a/spark-3/src/test/scala/org/neo4j/spark/DataSourceWriterNeo4jSkipNullKeysTSE.scala
+++ b/spark-3/src/test/scala/org/neo4j/spark/DataSourceWriterNeo4jSkipNullKeysTSE.scala
@@ -1,3 +1,19 @@
+/*
+ * Copyright (c) "Neo4j"
+ * Neo4j Sweden AB [https://neo4j.com]
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.neo4j.spark
 
 import org.apache.spark.SparkException

--- a/spark-3/src/test/scala/org/neo4j/spark/DataSourceWriterNeo4jSkipNullKeysTSE.scala
+++ b/spark-3/src/test/scala/org/neo4j/spark/DataSourceWriterNeo4jSkipNullKeysTSE.scala
@@ -1,0 +1,495 @@
+package org.neo4j.spark
+
+import org.apache.spark.SparkException
+import org.apache.spark.sql.SaveMode
+import org.junit.Test
+import org.neo4j.Closeables.use
+
+class DataSourceWriterNeo4jSkipNullKeysTSE extends SparkConnectorScalaBaseTSE {
+
+  import ss.implicits._
+
+  @Test
+  def `fails to write nodes when mode is not Overwrite`(): Unit = {
+    val cities = Seq(
+      (Some(1), "Cherbourg en Cotentin"),
+      (Some(2), "London"),
+      (Some(3), "Malmö")
+    ).toDF("id", "city")
+
+    val caught = intercept[IllegalArgumentException] {
+      cities.write
+        .format(classOf[DataSource].getName)
+        .mode(SaveMode.Append)
+        .option("url", SparkConnectorScalaSuiteIT.server.getBoltUrl)
+        .option("labels", ":City")
+        .option("node.keys", "id")
+        .option("skip.null.keys", "true")
+        .save()
+    }
+    assert(caught.getMessage contains "`skip.null.keys` works only with `mode` `Overwrite`")
+  }
+
+  @Test
+  def `fails to write nodes when key properties contain null values`(): Unit = {
+    val cities = Seq(
+      (Some(1), "Cherbourg en Cotentin"),
+      (Some(2), "London"),
+      (Some(3), "Malmö"),
+      (None, "Moon")
+    ).toDF("id", "city")
+
+    val caught = intercept[SparkException] {
+      cities.write
+        .format(classOf[DataSource].getName)
+        .mode(SaveMode.Overwrite)
+        .option("url", SparkConnectorScalaSuiteIT.server.getBoltUrl)
+        .option("labels", ":City")
+        .option("node.keys", "id")
+        .option("schema.optimization.node.keys", "KEY")
+        .save()
+    }
+    assert(caught.getMessage contains "Cannot merge the following node because of null property value")
+  }
+
+  @Test
+  def `fails to write relationships when source node key properties contain null values`(): Unit = {
+    val caught = intercept[SparkException] {
+      val cities = Seq(
+        (Some(1), Some(2), "British Airways"),
+        (Some(2), Some(3), "Turkish Airlines"),
+        (None, Some(5), "Another Airline")
+      ).toDF("from", "to", "airline")
+
+      cities.write
+        .format(classOf[DataSource].getName)
+        .mode(SaveMode.Overwrite)
+        .option("url", SparkConnectorScalaSuiteIT.server.getBoltUrl)
+        .option("relationship", "FLIES_TO")
+        .option("relationship.save.strategy", "keys")
+        .option("relationship.source.save.mode", "Overwrite")
+        .option("relationship.source.labels", ":City")
+        .option("relationship.source.node.keys", "from:id")
+        .option("relationship.target.save.mode", "Overwrite")
+        .option("relationship.target.labels", ":City")
+        .option("relationship.target.node.keys", "to:id")
+        .option("relationship.properties", "airline")
+        .option("schema.optimization.node.keys", "KEY")
+        .save()
+    }
+    assert(caught.getMessage contains "Cannot merge the following node because of null property value")
+  }
+
+  @Test
+  def `fails to write relationships when target node key properties contain null values`(): Unit = {
+    val caught = intercept[SparkException] {
+      val cities = Seq(
+        (Some(1), Some(2), "British Airways"),
+        (Some(2), Some(3), "Turkish Airlines"),
+        (Some(3), None, "Another Airline")
+      ).toDF("from", "to", "airline")
+
+      cities.write
+        .format(classOf[DataSource].getName)
+        .mode(SaveMode.Overwrite)
+        .option("url", SparkConnectorScalaSuiteIT.server.getBoltUrl)
+        .option("relationship", "FLIES_TO")
+        .option("relationship.save.strategy", "keys")
+        .option("relationship.source.save.mode", "Overwrite")
+        .option("relationship.source.labels", ":City")
+        .option("relationship.source.node.keys", "from:id")
+        .option("relationship.target.save.mode", "Overwrite")
+        .option("relationship.target.labels", ":City")
+        .option("relationship.target.node.keys", "to:id")
+        .option("relationship.properties", "airline")
+        .option("schema.optimization.node.keys", "KEY")
+        .save()
+    }
+    assert(caught.getMessage contains "Cannot merge the following node because of null property value")
+  }
+
+  @Test
+  def `fails to write relationships when relationship key properties contain null values`(): Unit = {
+    val caught = intercept[SparkException] {
+      val cities = Seq(
+        (Some(1), Some(2), Some("BA721"), "British Airways"),
+        (Some(2), Some(3), Some("TK211"), "Turkish Airlines"),
+        (Some(3), Some(4), None, "Another Airline")
+      ).toDF("from", "to", "flight", "airline")
+
+      cities.write
+        .format(classOf[DataSource].getName)
+        .mode(SaveMode.Overwrite)
+        .option("url", SparkConnectorScalaSuiteIT.server.getBoltUrl)
+        .option("relationship", "FLIES_TO")
+        .option("relationship.save.strategy", "keys")
+        .option("relationship.source.save.mode", "Overwrite")
+        .option("relationship.source.labels", ":City")
+        .option("relationship.source.node.keys", "from:id")
+        .option("relationship.target.save.mode", "Overwrite")
+        .option("relationship.target.labels", ":City")
+        .option("relationship.target.node.keys", "to:id")
+        .option("relationship.keys", "flight")
+        .option("relationship.properties", "airline")
+        .option("schema.optimization.node.keys", "KEY")
+        .option("schema.optimization.relationship.keys", "KEY")
+        .save()
+    }
+    assert(caught.getMessage contains "Cannot merge the following relationship because of null property value")
+  }
+
+  @Test
+  def `skips nodes when key properties contain null values`(): Unit = {
+    val cities = Seq(
+      (Some(1), "Cherbourg en Cotentin"),
+      (Some(2), "London"),
+      (Some(3), "Malmö"),
+      (None, "Moon")
+    ).toDF("id", "city")
+
+    cities.write
+      .format(classOf[DataSource].getName)
+      .mode(SaveMode.Overwrite)
+      .option("url", SparkConnectorScalaSuiteIT.server.getBoltUrl)
+      .option("labels", ":City")
+      .option("node.keys", "id")
+      .option("schema.optimization.node.keys", "KEY")
+      .option("skip.null.keys", "true")
+      .save()
+
+    use(SparkConnectorScalaSuiteIT.driver.session()) { session =>
+      val result = session.run("MATCH (n:City) RETURN count(n) as count")
+        .single()
+        .get("count")
+        .asLong()
+      assert(result == 3)
+    }
+  }
+
+  @Test
+  def `skips relationships when source or target node key properties contain null values`(): Unit = {
+    val cities = Seq(
+      (Some(1), Some(2), "British Airways"),
+      (Some(2), Some(3), "Turkish Airlines"),
+      (None, Some(5), "Another Airline"),
+      (Some(5), None, "Another Airline")
+    ).toDF("from", "to", "airline")
+
+    cities.write
+      .format(classOf[DataSource].getName)
+      .mode(SaveMode.Overwrite)
+      .option("url", SparkConnectorScalaSuiteIT.server.getBoltUrl)
+      .option("relationship", "FLIES_TO")
+      .option("relationship.save.strategy", "keys")
+      .option("relationship.source.save.mode", "Overwrite")
+      .option("relationship.source.labels", ":City")
+      .option("relationship.source.node.keys", "from:id")
+      .option("relationship.target.save.mode", "Overwrite")
+      .option("relationship.target.labels", ":City")
+      .option("relationship.target.node.keys", "to:id")
+      .option("relationship.properties", "airline")
+      .option("schema.optimization.node.keys", "KEY")
+      .option("skip.null.keys", "true")
+      .save()
+
+    use(SparkConnectorScalaSuiteIT.driver.session()) { session =>
+      val cities = session.run("MATCH (n:City) RETURN count(n) as count")
+        .single()
+        .get("count")
+        .asLong()
+      assert(cities == 3)
+
+      val citiesWithId5 = session.run("MATCH (n:City {id: 5}) RETURN count(n) as count")
+        .single()
+        .get("count")
+        .asLong()
+      assert(citiesWithId5 == 0)
+
+      val flies = session.run("MATCH ()-[r:FLIES_TO]->() RETURN count(r) as count")
+        .single()
+        .get("count")
+        .asLong()
+      assert(flies == 2)
+    }
+  }
+
+  @Test
+  def `skips relationships when source or target node key properties contain null values when nodes are matched`()
+    : Unit = {
+    use(SparkConnectorScalaSuiteIT.driver.session()) { session =>
+      session.run("UNWIND [1,2,3,5] AS id CREATE (:City {id: id})").consume()
+    }
+
+    val cities = Seq(
+      (Some(1), Some(2), "British Airways"),
+      (Some(2), Some(3), "Turkish Airlines"),
+      (None, Some(5), "Another Airline"),
+      (Some(5), None, "Another Airline")
+    ).toDF("from", "to", "airline")
+
+    cities.write
+      .format(classOf[DataSource].getName)
+      .mode(SaveMode.Overwrite)
+      .option("url", SparkConnectorScalaSuiteIT.server.getBoltUrl)
+      .option("relationship", "FLIES_TO")
+      .option("relationship.save.strategy", "keys")
+      .option("relationship.source.save.mode", "Match")
+      .option("relationship.source.labels", ":City")
+      .option("relationship.source.node.keys", "from:id")
+      .option("relationship.target.save.mode", "Match")
+      .option("relationship.target.labels", ":City")
+      .option("relationship.target.node.keys", "to:id")
+      .option("relationship.properties", "airline")
+      .option("skip.null.keys", "true")
+      .save()
+
+    use(SparkConnectorScalaSuiteIT.driver.session()) { session =>
+      val cities = session.run("MATCH (n:City) RETURN count(n) as count")
+        .single()
+        .get("count")
+        .asLong()
+      assert(cities == 4)
+
+      val flies = session.run("MATCH ()-[r:FLIES_TO]->() RETURN count(r) as count")
+        .single()
+        .get("count")
+        .asLong()
+      assert(flies == 2)
+    }
+  }
+
+  @Test
+  def `skips relationships when source or target node key properties contain null values when nodes are appended`()
+    : Unit = {
+    val cities = Seq(
+      (Some(1), Some(2), "British Airways"),
+      (Some(3), Some(4), "Turkish Airlines"),
+      (None, Some(5), "Another Airline"),
+      (Some(5), None, "Another Airline")
+    ).toDF("from", "to", "airline")
+
+    cities.write
+      .format(classOf[DataSource].getName)
+      .mode(SaveMode.Overwrite)
+      .option("url", SparkConnectorScalaSuiteIT.server.getBoltUrl)
+      .option("relationship", "FLIES_TO")
+      .option("relationship.save.strategy", "keys")
+      .option("relationship.source.save.mode", "Append")
+      .option("relationship.source.labels", ":City")
+      .option("relationship.source.node.keys", "from:id")
+      .option("relationship.target.save.mode", "Append")
+      .option("relationship.target.labels", ":City")
+      .option("relationship.target.node.keys", "to:id")
+      .option("relationship.properties", "airline")
+      .option("skip.null.keys", "true")
+      .save()
+
+    use(SparkConnectorScalaSuiteIT.driver.session()) { session =>
+      val cities = session.run("MATCH (n:City) RETURN count(n) as count")
+        .single()
+        .get("count")
+        .asLong()
+      assert(cities == 4)
+
+      val citiesWithId5 = session.run("MATCH (n:City {id: 5}) RETURN count(n) as count")
+        .single()
+        .get("count")
+        .asLong()
+      assert(citiesWithId5 == 0)
+
+      val flies = session.run("MATCH ()-[r:FLIES_TO]->() RETURN count(r) as count")
+        .single()
+        .get("count")
+        .asLong()
+      assert(flies == 2)
+    }
+  }
+
+  @Test
+  def `skips relationships when source or target node key properties contain null values with append mode`(): Unit = {
+    val cities = Seq(
+      (Some(1), Some(2), "British Airways"),
+      (Some(3), Some(4), "Turkish Airlines"),
+      (None, Some(5), "Another Airline"),
+      (Some(5), None, "Another Airline")
+    ).toDF("from", "to", "airline")
+
+    cities.write
+      .format(classOf[DataSource].getName)
+      .mode(SaveMode.Append)
+      .option("url", SparkConnectorScalaSuiteIT.server.getBoltUrl)
+      .option("relationship", "FLIES_TO")
+      .option("relationship.save.strategy", "keys")
+      .option("relationship.source.save.mode", "Overwrite")
+      .option("relationship.source.labels", ":City")
+      .option("relationship.source.node.keys", "from:id")
+      .option("relationship.target.save.mode", "Overwrite")
+      .option("relationship.target.labels", ":City")
+      .option("relationship.target.node.keys", "to:id")
+      .option("relationship.properties", "airline")
+      .option("schema.optimization.node.keys", "KEY")
+      .option("skip.null.keys", "true")
+      .save()
+
+    use(SparkConnectorScalaSuiteIT.driver.session()) { session =>
+      val cities = session.run("MATCH (n:City) RETURN count(n) as count")
+        .single()
+        .get("count")
+        .asLong()
+      assert(cities == 4)
+
+      val citiesWithId5 = session.run("MATCH (n:City {id: 5}) RETURN count(n) as count")
+        .single()
+        .get("count")
+        .asLong()
+      assert(citiesWithId5 == 0)
+
+      val flies = session.run("MATCH ()-[r:FLIES_TO]->() RETURN count(r) as count")
+        .single()
+        .get("count")
+        .asLong()
+      assert(flies == 2)
+    }
+  }
+
+  @Test
+  def `skips relationships when source or target node key properties contain null values when nodes are matched with append mode`()
+    : Unit = {
+    use(SparkConnectorScalaSuiteIT.driver.session()) { session =>
+      session.run("UNWIND [1,2,3,5] AS id CREATE (:City {id: id})").consume()
+    }
+
+    val cities = Seq(
+      (Some(1), Some(2), "British Airways"),
+      (Some(2), Some(3), "Turkish Airlines"),
+      (None, Some(5), "Another Airline"),
+      (Some(5), None, "Another Airline")
+    ).toDF("from", "to", "airline")
+
+    cities.write
+      .format(classOf[DataSource].getName)
+      .mode(SaveMode.Append)
+      .option("url", SparkConnectorScalaSuiteIT.server.getBoltUrl)
+      .option("relationship", "FLIES_TO")
+      .option("relationship.save.strategy", "keys")
+      .option("relationship.source.save.mode", "Match")
+      .option("relationship.source.labels", ":City")
+      .option("relationship.source.node.keys", "from:id")
+      .option("relationship.target.save.mode", "Match")
+      .option("relationship.target.labels", ":City")
+      .option("relationship.target.node.keys", "to:id")
+      .option("relationship.properties", "airline")
+      .option("skip.null.keys", "true")
+      .save()
+
+    use(SparkConnectorScalaSuiteIT.driver.session()) { session =>
+      val cities = session.run("MATCH (n:City) RETURN count(n) as count")
+        .single()
+        .get("count")
+        .asLong()
+      assert(cities == 4)
+
+      val flies = session.run("MATCH ()-[r:FLIES_TO]->() RETURN count(r) as count")
+        .single()
+        .get("count")
+        .asLong()
+      assert(flies == 2)
+    }
+  }
+
+  @Test
+  def `skips relationships when source or target node key properties contain null values when nodes are appended with append mode`()
+    : Unit = {
+    val cities = Seq(
+      (Some(1), Some(2), "British Airways"),
+      (Some(3), Some(4), "Turkish Airlines"),
+      (None, Some(5), "Another Airline"),
+      (Some(5), None, "Another Airline")
+    ).toDF("from", "to", "airline")
+
+    cities.write
+      .format(classOf[DataSource].getName)
+      .mode(SaveMode.Append)
+      .option("url", SparkConnectorScalaSuiteIT.server.getBoltUrl)
+      .option("relationship", "FLIES_TO")
+      .option("relationship.save.strategy", "keys")
+      .option("relationship.source.save.mode", "Append")
+      .option("relationship.source.labels", ":City")
+      .option("relationship.source.node.keys", "from:id")
+      .option("relationship.target.save.mode", "Append")
+      .option("relationship.target.labels", ":City")
+      .option("relationship.target.node.keys", "to:id")
+      .option("relationship.properties", "airline")
+      .option("skip.null.keys", "true")
+      .save()
+
+    use(SparkConnectorScalaSuiteIT.driver.session()) { session =>
+      val cities = session.run("MATCH (n:City) RETURN count(n) as count")
+        .single()
+        .get("count")
+        .asLong()
+      assert(cities == 4)
+
+      val citiesWithId5 = session.run("MATCH (n:City {id: 5}) RETURN count(n) as count")
+        .single()
+        .get("count")
+        .asLong()
+      assert(citiesWithId5 == 0)
+
+      val flies = session.run("MATCH ()-[r:FLIES_TO]->() RETURN count(r) as count")
+        .single()
+        .get("count")
+        .asLong()
+      assert(flies == 2)
+    }
+  }
+
+  @Test
+  def `skips relationships when relationship key properties contain null values`(): Unit = {
+    val cities = Seq(
+      (Some(1), Some(2), Some("BA721"), "British Airways"),
+      (Some(2), Some(3), Some("TK211"), "Turkish Airlines"),
+      (Some(3), Some(5), None, "Another Airline")
+    ).toDF("from", "to", "flight", "airline")
+
+    cities.write
+      .format(classOf[DataSource].getName)
+      .mode(SaveMode.Overwrite)
+      .option("url", SparkConnectorScalaSuiteIT.server.getBoltUrl)
+      .option("relationship", "FLIES_TO")
+      .option("relationship.save.strategy", "keys")
+      .option("relationship.source.save.mode", "Overwrite")
+      .option("relationship.source.labels", ":City")
+      .option("relationship.source.node.keys", "from:id")
+      .option("relationship.target.save.mode", "Overwrite")
+      .option("relationship.target.labels", ":City")
+      .option("relationship.target.node.keys", "to:id")
+      .option("relationship.keys", "flight")
+      .option("relationship.properties", "airline")
+      .option("schema.optimization.node.keys", "KEY")
+      .option("schema.optimization.relationship.keys", "KEY")
+      .option("skip.null.keys", "true")
+      .save()
+
+    use(SparkConnectorScalaSuiteIT.driver.session()) { session =>
+      val cities = session.run("MATCH (n:City) RETURN count(n) as count")
+        .single()
+        .get("count")
+        .asLong()
+      assert(cities == 3)
+
+      val citiesWithId5 = session.run("MATCH (n:City {id: 5}) RETURN count(n) as count")
+        .single()
+        .get("count")
+        .asLong()
+      assert(citiesWithId5 == 0)
+
+      val flies = session.run("MATCH ()-[r:FLIES_TO]->() RETURN count(r) as count")
+        .single()
+        .get("count")
+        .asLong()
+      assert(flies == 2)
+    }
+  }
+
+}

--- a/spark-3/src/test/scala/org/neo4j/spark/DataSourceWriterNeo4jSkipNullKeysTSE.scala
+++ b/spark-3/src/test/scala/org/neo4j/spark/DataSourceWriterNeo4jSkipNullKeysTSE.scala
@@ -26,27 +26,6 @@ class DataSourceWriterNeo4jSkipNullKeysTSE extends SparkConnectorScalaBaseTSE {
   import ss.implicits._
 
   @Test
-  def `fails to write nodes when mode is not Overwrite`(): Unit = {
-    val cities = Seq(
-      (Some(1), "Cherbourg en Cotentin"),
-      (Some(2), "London"),
-      (Some(3), "Malmö")
-    ).toDF("id", "city")
-
-    val caught = intercept[IllegalArgumentException] {
-      cities.write
-        .format(classOf[DataSource].getName)
-        .mode(SaveMode.Append)
-        .option("url", SparkConnectorScalaSuiteIT.server.getBoltUrl)
-        .option("labels", ":City")
-        .option("node.keys", "id")
-        .option("skip.null.keys", "true")
-        .save()
-    }
-    assert(caught.getMessage contains "`skip.null.keys` works only with `mode` `Overwrite`")
-  }
-
-  @Test
   def `fails to write nodes when key properties contain null values`(): Unit = {
     val cities = Seq(
       (Some(1), "Cherbourg en Cotentin"),
@@ -155,7 +134,34 @@ class DataSourceWriterNeo4jSkipNullKeysTSE extends SparkConnectorScalaBaseTSE {
   }
 
   @Test
-  def `skips nodes when key properties contain null values`(): Unit = {
+  def `skips nodes when key properties contain null values with APPEND mode`(): Unit = {
+    val cities = Seq(
+      (Some(1), "Cherbourg en Cotentin"),
+      (Some(2), "London"),
+      (Some(3), "Malmö"),
+      (None, "Moon")
+    ).toDF("id", "city")
+
+    cities.write
+      .format(classOf[DataSource].getName)
+      .mode(SaveMode.Append)
+      .option("url", SparkConnectorScalaSuiteIT.server.getBoltUrl)
+      .option("labels", ":City")
+      .option("node.keys", "id")
+      .option("node.keys.skip.nulls", "true")
+      .save()
+
+    use(SparkConnectorScalaSuiteIT.driver.session()) { session =>
+      val result = session.run("MATCH (n:City) RETURN count(n) as count")
+        .single()
+        .get("count")
+        .asLong()
+      assert(result == 3)
+    }
+  }
+
+  @Test
+  def `skips nodes when key properties contain null values with OVERWRITE mode`(): Unit = {
     val cities = Seq(
       (Some(1), "Cherbourg en Cotentin"),
       (Some(2), "London"),
@@ -169,8 +175,8 @@ class DataSourceWriterNeo4jSkipNullKeysTSE extends SparkConnectorScalaBaseTSE {
       .option("url", SparkConnectorScalaSuiteIT.server.getBoltUrl)
       .option("labels", ":City")
       .option("node.keys", "id")
+      .option("node.keys.skip.nulls", "true")
       .option("schema.optimization.node.keys", "KEY")
-      .option("skip.null.keys", "true")
       .save()
 
     use(SparkConnectorScalaSuiteIT.driver.session()) { session =>
@@ -205,7 +211,8 @@ class DataSourceWriterNeo4jSkipNullKeysTSE extends SparkConnectorScalaBaseTSE {
       .option("relationship.target.node.keys", "to:id")
       .option("relationship.properties", "airline")
       .option("schema.optimization.node.keys", "KEY")
-      .option("skip.null.keys", "true")
+      .option("relationship.source.node.keys.skip.nulls", "true")
+      .option("relationship.target.node.keys.skip.nulls", "true")
       .save()
 
     use(SparkConnectorScalaSuiteIT.driver.session()) { session =>
@@ -256,7 +263,8 @@ class DataSourceWriterNeo4jSkipNullKeysTSE extends SparkConnectorScalaBaseTSE {
       .option("relationship.target.labels", ":City")
       .option("relationship.target.node.keys", "to:id")
       .option("relationship.properties", "airline")
-      .option("skip.null.keys", "true")
+      .option("relationship.source.node.keys.skip.nulls", "true")
+      .option("relationship.target.node.keys.skip.nulls", "true")
       .save()
 
     use(SparkConnectorScalaSuiteIT.driver.session()) { session =>
@@ -297,7 +305,8 @@ class DataSourceWriterNeo4jSkipNullKeysTSE extends SparkConnectorScalaBaseTSE {
       .option("relationship.target.labels", ":City")
       .option("relationship.target.node.keys", "to:id")
       .option("relationship.properties", "airline")
-      .option("skip.null.keys", "true")
+      .option("relationship.source.node.keys.skip.nulls", "true")
+      .option("relationship.target.node.keys.skip.nulls", "true")
       .save()
 
     use(SparkConnectorScalaSuiteIT.driver.session()) { session =>
@@ -344,7 +353,8 @@ class DataSourceWriterNeo4jSkipNullKeysTSE extends SparkConnectorScalaBaseTSE {
       .option("relationship.target.node.keys", "to:id")
       .option("relationship.properties", "airline")
       .option("schema.optimization.node.keys", "KEY")
-      .option("skip.null.keys", "true")
+      .option("relationship.source.node.keys.skip.nulls", "true")
+      .option("relationship.target.node.keys.skip.nulls", "true")
       .save()
 
     use(SparkConnectorScalaSuiteIT.driver.session()) { session =>
@@ -395,7 +405,8 @@ class DataSourceWriterNeo4jSkipNullKeysTSE extends SparkConnectorScalaBaseTSE {
       .option("relationship.target.labels", ":City")
       .option("relationship.target.node.keys", "to:id")
       .option("relationship.properties", "airline")
-      .option("skip.null.keys", "true")
+      .option("relationship.source.node.keys.skip.nulls", "true")
+      .option("relationship.target.node.keys.skip.nulls", "true")
       .save()
 
     use(SparkConnectorScalaSuiteIT.driver.session()) { session =>
@@ -436,7 +447,8 @@ class DataSourceWriterNeo4jSkipNullKeysTSE extends SparkConnectorScalaBaseTSE {
       .option("relationship.target.labels", ":City")
       .option("relationship.target.node.keys", "to:id")
       .option("relationship.properties", "airline")
-      .option("skip.null.keys", "true")
+      .option("relationship.source.node.keys.skip.nulls", "true")
+      .option("relationship.target.node.keys.skip.nulls", "true")
       .save()
 
     use(SparkConnectorScalaSuiteIT.driver.session()) { session =>
@@ -484,7 +496,7 @@ class DataSourceWriterNeo4jSkipNullKeysTSE extends SparkConnectorScalaBaseTSE {
       .option("relationship.properties", "airline")
       .option("schema.optimization.node.keys", "KEY")
       .option("schema.optimization.relationship.keys", "KEY")
-      .option("skip.null.keys", "true")
+      .option("relationship.keys.skip.nulls", "true")
       .save()
 
     use(SparkConnectorScalaSuiteIT.driver.session()) { session =>

--- a/spark-3/src/test/scala/org/neo4j/spark/DataSourceWriterNeo4jTSE.scala
+++ b/spark-3/src/test/scala/org/neo4j/spark/DataSourceWriterNeo4jTSE.scala
@@ -17,22 +17,17 @@
 package org.neo4j.spark
 
 import org.apache.commons.lang3.exception.ExceptionUtils
-import org.apache.spark.SparkException
 import org.apache.spark.scheduler.SparkListener
 import org.apache.spark.scheduler.SparkListenerStageCompleted
 import org.apache.spark.scheduler.SparkListenerStageSubmitted
 import org.apache.spark.sql.DataFrame
 import org.apache.spark.sql.SaveMode
-import org.apache.spark.sql.SparkSession
 import org.hamcrest.Matchers
-import org.junit
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertNotNull
-import org.junit.Assert.assertThrows
 import org.junit.Assert.assertTrue
 import org.junit.Test
 import org.neo4j.Closeables.use
-import org.neo4j.driver.Result
 import org.neo4j.driver.Session
 import org.neo4j.driver.SessionConfig
 import org.neo4j.driver.Transaction
@@ -663,225 +658,6 @@ class DataSourceWriterNeo4jTSE extends SparkConnectorScalaBaseTSE {
       if (session != null) {
         session.close()
       }
-    }
-  }
-
-  @Test
-  def `fails to write nodes when key properties contain null values`(): Unit = {
-    val cities = Seq(
-      (Some(1), "Cherbourg en Cotentin"),
-      (Some(2), "London"),
-      (Some(3), "Malmö"),
-      (None, "Moon")
-    ).toDF("id", "city")
-
-    val caught = intercept[SparkException] {
-      cities.write
-        .format(classOf[DataSource].getName)
-        .mode(SaveMode.Overwrite)
-        .option("url", SparkConnectorScalaSuiteIT.server.getBoltUrl)
-        .option("labels", ":City")
-        .option("node.keys", "id")
-        .option("schema.optimization.node.keys", "KEY")
-        .save()
-    }
-    assert(caught.getMessage contains "Cannot merge the following node because of null property value")
-  }
-
-  @Test
-  def `fails to write relationships when source node key properties contain null values`(): Unit = {
-    val caught = intercept[SparkException] {
-      val cities = Seq(
-        (Some(1), Some(2), "British Airways"),
-        (Some(2), Some(3), "Turkish Airlines"),
-        (None, Some(5), "Another Airline")
-      ).toDF("from", "to", "airline")
-
-      cities.write
-        .format(classOf[DataSource].getName)
-        .mode(SaveMode.Overwrite)
-        .option("url", SparkConnectorScalaSuiteIT.server.getBoltUrl)
-        .option("relationship", "FLIES_TO")
-        .option("relationship.save.strategy", "keys")
-        .option("relationship.source.save.mode", "Overwrite")
-        .option("relationship.source.labels", ":City")
-        .option("relationship.source.node.keys", "from:id")
-        .option("relationship.target.save.mode", "Overwrite")
-        .option("relationship.target.labels", ":City")
-        .option("relationship.target.node.keys", "to:id")
-        .option("relationship.properties", "airline")
-        .option("schema.optimization.node.keys", "KEY")
-        .save()
-    }
-    assert(caught.getMessage contains "Cannot merge the following node because of null property value")
-  }
-
-  @Test
-  def `fails to write relationships when target node key properties contain null values`(): Unit = {
-    val caught = intercept[SparkException] {
-      val cities = Seq(
-        (Some(1), Some(2), "British Airways"),
-        (Some(2), Some(3), "Turkish Airlines"),
-        (Some(3), None, "Another Airline")
-      ).toDF("from", "to", "airline")
-
-      cities.write
-        .format(classOf[DataSource].getName)
-        .mode(SaveMode.Overwrite)
-        .option("url", SparkConnectorScalaSuiteIT.server.getBoltUrl)
-        .option("relationship", "FLIES_TO")
-        .option("relationship.save.strategy", "keys")
-        .option("relationship.source.save.mode", "Overwrite")
-        .option("relationship.source.labels", ":City")
-        .option("relationship.source.node.keys", "from:id")
-        .option("relationship.target.save.mode", "Overwrite")
-        .option("relationship.target.labels", ":City")
-        .option("relationship.target.node.keys", "to:id")
-        .option("relationship.properties", "airline")
-        .option("schema.optimization.node.keys", "KEY")
-        .save()
-    }
-    assert(caught.getMessage contains "Cannot merge the following node because of null property value")
-  }
-
-  @Test
-  def `fails to write relationships when relationship key properties contain null values`(): Unit = {
-    val caught = intercept[SparkException] {
-      val cities = Seq(
-        (Some(1), Some(2), Some("BA721"), "British Airways"),
-        (Some(2), Some(3), Some("TK211"), "Turkish Airlines"),
-        (Some(3), Some(4), None, "Another Airline")
-      ).toDF("from", "to", "flight", "airline")
-
-      cities.write
-        .format(classOf[DataSource].getName)
-        .mode(SaveMode.Overwrite)
-        .option("url", SparkConnectorScalaSuiteIT.server.getBoltUrl)
-        .option("relationship", "FLIES_TO")
-        .option("relationship.save.strategy", "keys")
-        .option("relationship.source.save.mode", "Overwrite")
-        .option("relationship.source.labels", ":City")
-        .option("relationship.source.node.keys", "from:id")
-        .option("relationship.target.save.mode", "Overwrite")
-        .option("relationship.target.labels", ":City")
-        .option("relationship.target.node.keys", "to:id")
-        .option("relationship.keys", "flight")
-        .option("relationship.properties", "airline")
-        .option("schema.optimization.node.keys", "KEY")
-        .option("schema.optimization.relationship.keys", "KEY")
-        .save()
-    }
-    assert(caught.getMessage contains "Cannot merge the following relationship because of null property value")
-  }
-
-  @Test
-  def `skips nodes when key properties contain null values`(): Unit = {
-    val cities = Seq(
-      (Some(1), "Cherbourg en Cotentin"),
-      (Some(2), "London"),
-      (Some(3), "Malmö"),
-      (None, "Moon")
-    ).toDF("id", "city")
-
-    cities.write
-      .format(classOf[DataSource].getName)
-      .mode(SaveMode.Overwrite)
-      .option("url", SparkConnectorScalaSuiteIT.server.getBoltUrl)
-      .option("labels", ":City")
-      .option("node.keys", "id")
-      .option("schema.optimization.node.keys", "KEY")
-      .option("skip.null.keys", "true")
-      .save()
-
-    use(SparkConnectorScalaSuiteIT.driver.session()) { session =>
-      val result = session.run("MATCH (n:City) RETURN count(n) as count")
-        .single()
-        .get("count")
-        .asLong()
-      assert(result == 3)
-    }
-  }
-
-  @Test
-  def `skips relationships when source or target node key properties contain null values`(): Unit = {
-    val cities = Seq(
-      (Some(1), Some(2), "British Airways"),
-      (Some(2), Some(3), "Turkish Airlines"),
-      (None, Some(5), "Another Airline"),
-      (Some(5), None, "Another Airline")
-    ).toDF("from", "to", "airline")
-
-    cities.write
-      .format(classOf[DataSource].getName)
-      .mode(SaveMode.Overwrite)
-      .option("url", SparkConnectorScalaSuiteIT.server.getBoltUrl)
-      .option("relationship", "FLIES_TO")
-      .option("relationship.save.strategy", "keys")
-      .option("relationship.source.save.mode", "Overwrite")
-      .option("relationship.source.labels", ":City")
-      .option("relationship.source.node.keys", "from:id")
-      .option("relationship.target.save.mode", "Overwrite")
-      .option("relationship.target.labels", ":City")
-      .option("relationship.target.node.keys", "to:id")
-      .option("relationship.properties", "airline")
-      .option("schema.optimization.node.keys", "KEY")
-      .option("skip.null.keys", "true")
-      .save()
-
-    use(SparkConnectorScalaSuiteIT.driver.session()) { session =>
-      val cities = session.run("MATCH (n:City) RETURN count(n) as count")
-        .single()
-        .get("count")
-        .asLong()
-      assert(cities == 3)
-
-      val flies = session.run("MATCH ()-[r:FLIES_TO]->() RETURN count(r) as count")
-        .single()
-        .get("count")
-        .asLong()
-      assert(flies == 2)
-    }
-  }
-
-  @Test
-  def `skips relationships when relationship key properties contain null values`(): Unit = {
-    val cities = Seq(
-      (Some(1), Some(2), Some("BA721"), "British Airways"),
-      (Some(2), Some(3), Some("TK211"), "Turkish Airlines"),
-      (Some(3), Some(4), None, "Another Airline")
-    ).toDF("from", "to", "flight", "airline")
-
-    cities.write
-      .format(classOf[DataSource].getName)
-      .mode(SaveMode.Overwrite)
-      .option("url", SparkConnectorScalaSuiteIT.server.getBoltUrl)
-      .option("relationship", "FLIES_TO")
-      .option("relationship.save.strategy", "keys")
-      .option("relationship.source.save.mode", "Overwrite")
-      .option("relationship.source.labels", ":City")
-      .option("relationship.source.node.keys", "from:id")
-      .option("relationship.target.save.mode", "Overwrite")
-      .option("relationship.target.labels", ":City")
-      .option("relationship.target.node.keys", "to:id")
-      .option("relationship.keys", "flight")
-      .option("relationship.properties", "airline")
-      .option("schema.optimization.node.keys", "KEY")
-      .option("schema.optimization.relationship.keys", "KEY")
-      .option("skip.null.keys", "true")
-      .save()
-
-    use(SparkConnectorScalaSuiteIT.driver.session()) { session =>
-      val cities = session.run("MATCH (n:City) RETURN count(n) as count")
-        .single()
-        .get("count")
-        .asLong()
-      assert(cities == 3)
-
-      val flies = session.run("MATCH ()-[r:FLIES_TO]->() RETURN count(r) as count")
-        .single()
-        .get("count")
-        .asLong()
-      assert(flies == 2)
     }
   }
 

--- a/spark-3/src/test/scala/org/neo4j/spark/DataSourceWriterNeo4jTSE.scala
+++ b/spark-3/src/test/scala/org/neo4j/spark/DataSourceWriterNeo4jTSE.scala
@@ -17,6 +17,7 @@
 package org.neo4j.spark
 
 import org.apache.commons.lang3.exception.ExceptionUtils
+import org.apache.spark.SparkException
 import org.apache.spark.scheduler.SparkListener
 import org.apache.spark.scheduler.SparkListenerStageCompleted
 import org.apache.spark.scheduler.SparkListenerStageSubmitted
@@ -24,8 +25,10 @@ import org.apache.spark.sql.DataFrame
 import org.apache.spark.sql.SaveMode
 import org.apache.spark.sql.SparkSession
 import org.hamcrest.Matchers
+import org.junit
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertNotNull
+import org.junit.Assert.assertThrows
 import org.junit.Assert.assertTrue
 import org.junit.Test
 import org.neo4j.Closeables.use
@@ -660,6 +663,225 @@ class DataSourceWriterNeo4jTSE extends SparkConnectorScalaBaseTSE {
       if (session != null) {
         session.close()
       }
+    }
+  }
+
+  @Test
+  def `fails to write nodes when key properties contain null values`(): Unit = {
+    val cities = Seq(
+      (Some(1), "Cherbourg en Cotentin"),
+      (Some(2), "London"),
+      (Some(3), "Malmö"),
+      (None, "Moon")
+    ).toDF("id", "city")
+
+    val caught = intercept[SparkException] {
+      cities.write
+        .format(classOf[DataSource].getName)
+        .mode(SaveMode.Overwrite)
+        .option("url", SparkConnectorScalaSuiteIT.server.getBoltUrl)
+        .option("labels", ":City")
+        .option("node.keys", "id")
+        .option("schema.optimization.node.keys", "KEY")
+        .save()
+    }
+    assert(caught.getMessage contains "Cannot merge the following node because of null property value")
+  }
+
+  @Test
+  def `fails to write relationships when source node key properties contain null values`(): Unit = {
+    val caught = intercept[SparkException] {
+      val cities = Seq(
+        (Some(1), Some(2), "British Airways"),
+        (Some(2), Some(3), "Turkish Airlines"),
+        (None, Some(5), "Another Airline")
+      ).toDF("from", "to", "airline")
+
+      cities.write
+        .format(classOf[DataSource].getName)
+        .mode(SaveMode.Overwrite)
+        .option("url", SparkConnectorScalaSuiteIT.server.getBoltUrl)
+        .option("relationship", "FLIES_TO")
+        .option("relationship.save.strategy", "keys")
+        .option("relationship.source.save.mode", "Overwrite")
+        .option("relationship.source.labels", ":City")
+        .option("relationship.source.node.keys", "from:id")
+        .option("relationship.target.save.mode", "Overwrite")
+        .option("relationship.target.labels", ":City")
+        .option("relationship.target.node.keys", "to:id")
+        .option("relationship.properties", "airline")
+        .option("schema.optimization.node.keys", "KEY")
+        .save()
+    }
+    assert(caught.getMessage contains "Cannot merge the following node because of null property value")
+  }
+
+  @Test
+  def `fails to write relationships when target node key properties contain null values`(): Unit = {
+    val caught = intercept[SparkException] {
+      val cities = Seq(
+        (Some(1), Some(2), "British Airways"),
+        (Some(2), Some(3), "Turkish Airlines"),
+        (Some(3), None, "Another Airline")
+      ).toDF("from", "to", "airline")
+
+      cities.write
+        .format(classOf[DataSource].getName)
+        .mode(SaveMode.Overwrite)
+        .option("url", SparkConnectorScalaSuiteIT.server.getBoltUrl)
+        .option("relationship", "FLIES_TO")
+        .option("relationship.save.strategy", "keys")
+        .option("relationship.source.save.mode", "Overwrite")
+        .option("relationship.source.labels", ":City")
+        .option("relationship.source.node.keys", "from:id")
+        .option("relationship.target.save.mode", "Overwrite")
+        .option("relationship.target.labels", ":City")
+        .option("relationship.target.node.keys", "to:id")
+        .option("relationship.properties", "airline")
+        .option("schema.optimization.node.keys", "KEY")
+        .save()
+    }
+    assert(caught.getMessage contains "Cannot merge the following node because of null property value")
+  }
+
+  @Test
+  def `fails to write relationships when relationship key properties contain null values`(): Unit = {
+    val caught = intercept[SparkException] {
+      val cities = Seq(
+        (Some(1), Some(2), Some("BA721"), "British Airways"),
+        (Some(2), Some(3), Some("TK211"), "Turkish Airlines"),
+        (Some(3), Some(4), None, "Another Airline")
+      ).toDF("from", "to", "flight", "airline")
+
+      cities.write
+        .format(classOf[DataSource].getName)
+        .mode(SaveMode.Overwrite)
+        .option("url", SparkConnectorScalaSuiteIT.server.getBoltUrl)
+        .option("relationship", "FLIES_TO")
+        .option("relationship.save.strategy", "keys")
+        .option("relationship.source.save.mode", "Overwrite")
+        .option("relationship.source.labels", ":City")
+        .option("relationship.source.node.keys", "from:id")
+        .option("relationship.target.save.mode", "Overwrite")
+        .option("relationship.target.labels", ":City")
+        .option("relationship.target.node.keys", "to:id")
+        .option("relationship.keys", "flight")
+        .option("relationship.properties", "airline")
+        .option("schema.optimization.node.keys", "KEY")
+        .option("schema.optimization.relationship.keys", "KEY")
+        .save()
+    }
+    assert(caught.getMessage contains "Cannot merge the following relationship because of null property value")
+  }
+
+  @Test
+  def `skips nodes when key properties contain null values`(): Unit = {
+    val cities = Seq(
+      (Some(1), "Cherbourg en Cotentin"),
+      (Some(2), "London"),
+      (Some(3), "Malmö"),
+      (None, "Moon")
+    ).toDF("id", "city")
+
+    cities.write
+      .format(classOf[DataSource].getName)
+      .mode(SaveMode.Overwrite)
+      .option("url", SparkConnectorScalaSuiteIT.server.getBoltUrl)
+      .option("labels", ":City")
+      .option("node.keys", "id")
+      .option("schema.optimization.node.keys", "KEY")
+      .option("skip.null.keys", "true")
+      .save()
+
+    use(SparkConnectorScalaSuiteIT.driver.session()) { session =>
+      val result = session.run("MATCH (n:City) RETURN count(n) as count")
+        .single()
+        .get("count")
+        .asLong()
+      assert(result == 3)
+    }
+  }
+
+  @Test
+  def `skips relationships when source or target node key properties contain null values`(): Unit = {
+    val cities = Seq(
+      (Some(1), Some(2), "British Airways"),
+      (Some(2), Some(3), "Turkish Airlines"),
+      (None, Some(5), "Another Airline"),
+      (Some(5), None, "Another Airline")
+    ).toDF("from", "to", "airline")
+
+    cities.write
+      .format(classOf[DataSource].getName)
+      .mode(SaveMode.Overwrite)
+      .option("url", SparkConnectorScalaSuiteIT.server.getBoltUrl)
+      .option("relationship", "FLIES_TO")
+      .option("relationship.save.strategy", "keys")
+      .option("relationship.source.save.mode", "Overwrite")
+      .option("relationship.source.labels", ":City")
+      .option("relationship.source.node.keys", "from:id")
+      .option("relationship.target.save.mode", "Overwrite")
+      .option("relationship.target.labels", ":City")
+      .option("relationship.target.node.keys", "to:id")
+      .option("relationship.properties", "airline")
+      .option("schema.optimization.node.keys", "KEY")
+      .option("skip.null.keys", "true")
+      .save()
+
+    use(SparkConnectorScalaSuiteIT.driver.session()) { session =>
+      val cities = session.run("MATCH (n:City) RETURN count(n) as count")
+        .single()
+        .get("count")
+        .asLong()
+      assert(cities == 3)
+
+      val flies = session.run("MATCH ()-[r:FLIES_TO]->() RETURN count(r) as count")
+        .single()
+        .get("count")
+        .asLong()
+      assert(flies == 2)
+    }
+  }
+
+  @Test
+  def `skips relationships when relationship key properties contain null values`(): Unit = {
+    val cities = Seq(
+      (Some(1), Some(2), Some("BA721"), "British Airways"),
+      (Some(2), Some(3), Some("TK211"), "Turkish Airlines"),
+      (Some(3), Some(4), None, "Another Airline")
+    ).toDF("from", "to", "flight", "airline")
+
+    cities.write
+      .format(classOf[DataSource].getName)
+      .mode(SaveMode.Overwrite)
+      .option("url", SparkConnectorScalaSuiteIT.server.getBoltUrl)
+      .option("relationship", "FLIES_TO")
+      .option("relationship.save.strategy", "keys")
+      .option("relationship.source.save.mode", "Overwrite")
+      .option("relationship.source.labels", ":City")
+      .option("relationship.source.node.keys", "from:id")
+      .option("relationship.target.save.mode", "Overwrite")
+      .option("relationship.target.labels", ":City")
+      .option("relationship.target.node.keys", "to:id")
+      .option("relationship.keys", "flight")
+      .option("relationship.properties", "airline")
+      .option("schema.optimization.node.keys", "KEY")
+      .option("schema.optimization.relationship.keys", "KEY")
+      .option("skip.null.keys", "true")
+      .save()
+
+    use(SparkConnectorScalaSuiteIT.driver.session()) { session =>
+      val cities = session.run("MATCH (n:City) RETURN count(n) as count")
+        .single()
+        .get("count")
+        .asLong()
+      assert(cities == 3)
+
+      val flies = session.run("MATCH ()-[r:FLIES_TO]->() RETURN count(r) as count")
+        .single()
+        .get("count")
+        .asLong()
+      assert(flies == 2)
     }
   }
 


### PR DESCRIPTION
This PR introduces a new option named `node.keys.skip.null.keys`, `relationship.keys.skip.nulls`, `relationship.source.node.keys.skip.nulls` and `relationship.target.node.keys.skip.nulls` which filters out creation of corresponding entities, whose defined `keys` properties contain a null value. 

These options will silently skip those incoming rows and avoids errors to be thrown due to this data problem.