### PR TITLE
ci: introduce snyk scan step

### DIFF
--- a/.snyk
+++ b/.snyk
@@ -1,0 +1,16 @@
+# Snyk (https://snyk.io) policy file, patches or ignores known vulnerabilities.
+version: v1.25.1
+# ignores vulnerabilities until expiry date; change duration by modifying expiry date
+ignore:
+  'SNYK-JAVA-COMFASTERXMLJACKSONCORE-10500754': &spark-core-exclusions
+    - 'org.apache.spark:spark-core_2.13': &spark-core
+        reason: Spark Core is provided dependency
+        expires: 2050-01-01T00:00:00.000Z
+        created: 2025-09-18T08:33:31.014
+    - 'org.apache.spark:spark-core_2.12':
+        <<: *spark-core
+  'SNYK-JAVA-COMFASTERXMLJACKSONCORE-7569538': *spark-core-exclusions
+  'SNYK-JAVA-COMGOOGLEPROTOBUF-8055227': *spark-core-exclusions
+  'SNYK-JAVA-ORGAPACHEIVY-5847858': *spark-core-exclusions
+  'SNYK-JAVA-ORGAPACHEZOOKEEPER-5961102': *spark-core-exclusions
+patch: {}

--- a/.teamcity/builds/Build.kt
+++ b/.teamcity/builds/Build.kt
@@ -108,6 +108,14 @@ class Build(
                   }
                 }
               }
+
+              SNYK_PROFILES.forEach { snykProfile ->
+                dependentBuildType(
+                    SnykTest(id = "$name-snyk-test-${snykProfile.name}",
+                        name = "$name snyk test ${snykProfile.name}",
+                        snykProfile = snykProfile)
+                )
+              }
             }
 
             dependentBuildType(complete)

--- a/.teamcity/builds/Common.kt
+++ b/.teamcity/builds/Common.kt
@@ -127,6 +127,12 @@ enum class Neo4jVersion(val version: String, val dockerImage: String) {
   ),
 }
 
+data class SnykProfile(val name: String, val mavenArgs: String, val dockerImage: String = "snyk/snyk:maven-3-jdk-17")
+
+val SNYK_PROFILES = setOf(
+    SnykProfile("scala-2-13", "-Pscala-2.13")
+)
+
 fun <S, T, Y> Iterable<S>.cartesianProduct(
     other1: Collection<T>,
     other2: Collection<Y>

--- a/.teamcity/builds/Common.kt
+++ b/.teamcity/builds/Common.kt
@@ -131,7 +131,6 @@ data class SnykProfile(val name: String, val mavenArgs: String, val dockerImage:
 
 val SNYK_PROFILES = setOf(
     SnykProfile("scala-2-13", "-Pscala-2.13"),
-    SnykProfile("neo4j-4-4", "-Pneo4j-4.4"),
 )
 
 fun <S, T, Y> Iterable<S>.cartesianProduct(

--- a/.teamcity/builds/Common.kt
+++ b/.teamcity/builds/Common.kt
@@ -130,7 +130,8 @@ enum class Neo4jVersion(val version: String, val dockerImage: String) {
 data class SnykProfile(val name: String, val mavenArgs: String, val dockerImage: String = "snyk/snyk:maven-3-jdk-17")
 
 val SNYK_PROFILES = setOf(
-    SnykProfile("scala-2-13", "-Pscala-2.13")
+    SnykProfile("scala-2-13", "-Pscala-2.13"),
+    SnykProfile("neo4j-4-4", "-Pneo4j-4.4"),
 )
 
 fun <S, T, Y> Iterable<S>.cartesianProduct(

--- a/.teamcity/builds/SnykTest.kt
+++ b/.teamcity/builds/SnykTest.kt
@@ -1,0 +1,44 @@
+package builds
+
+import jetbrains.buildServer.configs.kotlin.BuildType
+import jetbrains.buildServer.configs.kotlin.ParameterDisplay
+import jetbrains.buildServer.configs.kotlin.buildFeatures.buildCache
+import jetbrains.buildServer.configs.kotlin.buildSteps.ScriptBuildStep
+import jetbrains.buildServer.configs.kotlin.buildSteps.script
+
+class SnykTest(id: String, name: String, snykProfile: SnykProfile) : BuildType(
+    {
+      this.id(id)
+      this.name = name
+
+      params {
+        password("env.SNYK_TOKEN", "%snyk-token%", display = ParameterDisplay.HIDDEN)
+      }
+
+      steps {
+        script {
+          scriptContent = """
+            #!/bin/bash
+            set -eux
+            snyk test --severity-threshold=high --all-projects --policy-path=. -- ${snykProfile.mavenArgs}
+          """.trimIndent()
+
+          dockerImagePlatform = ScriptBuildStep.ImagePlatform.Linux
+          dockerImage = snykProfile.dockerImage
+          dockerRunParameters = "--volume /var/run/docker.sock:/var/run/docker.sock"
+        }
+      }
+
+      features {
+        buildCache {
+          this.name = "neo4j-spark-connector"
+          publish = true
+          use = true
+          publishOnlyChanged = true
+          rules = ".m2/repository"
+        }
+      }
+
+      requirements { runOnLinux(LinuxSize.SMALL) }
+    }
+)

--- a/.teamcity/settings.kts
+++ b/.teamcity/settings.kts
@@ -20,6 +20,7 @@ project {
     password("signing-key-passphrase", "%publish-signing-key-password%")
     password("github-commit-status-token", "%github-token%")
     password("github-pull-request-token", "%github-token%")
+    password("snyk-token", "%snyk-token%")
   }
 
   vcsRoot(Neo4jSparkConnectorVcs)
@@ -69,7 +70,7 @@ project {
         Neo4jVersion.entries.minus(Neo4jVersion.V_NONE).forEach { neo4j ->
           subProject(
               Build(
-                  name = "${neo4j.version}",
+                  name = neo4j.version,
                   javaVersions =
                       setOf(JavaVersion.V_8, JavaVersion.V_11, JavaVersion.V_17, JavaVersion.V_21),
                   scalaVersions = setOf(ScalaVersion.V2_12, ScalaVersion.V2_13),


### PR DESCRIPTION
**Problem**
Some maven profiles change dependencies, and we need to reflect this in our vulnerability scans.

**Solution**
Options viewed:
* Snyk UI - doesn't support custom maven parameters. 
* Snyk maven plugin - despite being a maven plugin, it doesn't respect maven profile properly and is basically a wrapper around Snyk CLI. 
* Snyk CLI - is capable of applying different maven arguments, so was chosen as a right approach 

Snyk CLI is integrated via a custom script TeamCity step. It's parallel to the main build-test flow and fails the result step of failure. 

**Drowbacks**
* This is not synchronised with the Snyk UI. Exclusions are managed via `.snyk` file. So we might need to exclude the same complaint twice in some cases. Because of this reason, I included only non-default maven profiles. 
* Doesn't do periodic scans. This is partially solved by periodical compatibility builds. 