### PR TITLE
feat: import exactly relationship.properties when specified

### DIFF
--- a/common/src/main/scala/org/neo4j/spark/service/MappingService.scala
+++ b/common/src/main/scala/org/neo4j/spark/service/MappingService.scala
@@ -120,7 +120,12 @@ class Neo4jWriteMappingStrategy(private val options: Neo4jOptions)
       if (options.relationshipMetadata.relationshipKeys.contains(key)) {
         relMap.get(KEYS).put(options.relationshipMetadata.relationshipKeys.getOrElse(key, key), value)
       } else if (!source.includesProperty(key) && !target.includesProperty(key)) {
-        relMap.get(PROPERTIES).put(options.relationshipMetadata.properties.getOrElse(key, key), value)
+        val propertyKey = options.relationshipMetadata.properties match {
+          case Some(relProperties) => relProperties.get(key)
+          case None                => Some(key)
+        }
+
+        propertyKey.foreach(k => relMap.get(PROPERTIES).put(k, value))
       }
     }
   }

--- a/common/src/main/scala/org/neo4j/spark/service/MappingService.scala
+++ b/common/src/main/scala/org/neo4j/spark/service/MappingService.scala
@@ -119,12 +119,16 @@ class Neo4jWriteMappingStrategy(private val options: Neo4jOptions)
 
       if (options.relationshipMetadata.relationshipKeys.contains(key)) {
         relMap.get(KEYS).put(options.relationshipMetadata.relationshipKeys.getOrElse(key, key), value)
-      } else if (!source.includesProperty(key) && !target.includesProperty(key)) {
+      } else {
         val propertyKey = options.relationshipMetadata.properties match {
           case Some(relProperties) => relProperties.get(key)
-          case None                => Some(key)
+          case None =>
+            if (!source.includesProperty(key) && !target.includesProperty(key)) {
+              Some(key)
+            } else {
+              None
+            }
         }
-
         propertyKey.foreach(k => relMap.get(PROPERTIES).put(k, value))
       }
     }

--- a/common/src/main/scala/org/neo4j/spark/service/SchemaService.scala
+++ b/common/src/main/scala/org/neo4j/spark/service/SchemaService.scala
@@ -869,7 +869,7 @@ class SchemaService(
           .map(f => (f.name, f.name))
           .toMap
         val propsFromMeta: Map[String, String] =
-          options.relationshipMetadata.relationshipKeys ++ options.relationshipMetadata.properties
+          options.relationshipMetadata.relationshipKeys ++ options.relationshipMetadata.properties.getOrElse(Map.empty)
         createEntityTypeConstraint(
           "RELATIONSHIP",
           options.relationshipMetadata.relationshipType,

--- a/common/src/main/scala/org/neo4j/spark/util/Neo4jOptions.scala
+++ b/common/src/main/scala/org/neo4j/spark/util/Neo4jOptions.scala
@@ -57,10 +57,12 @@ class Neo4jOptions(private val options: java.util.Map[String, String]) extends S
   }
 
   private def getParameter(parameter: String, defaultValue: String = ""): String =
-    Some(options.getOrDefault(parameter, defaultValue))
+    getParameterOption(parameter).getOrElse(defaultValue)
+
+  private def getParameterOption(parameter: String): Option[String] =
+    Some(options.get(parameter))
       .flatMap(Option(_)) // to turn null into None
       .map(_.trim)
-      .getOrElse(defaultValue)
 
   private def getAuthenticationParameters: Map[String, String] = {
     val authType = getParameter(AUTH_TYPE, DEFAULT_AUTH_TYPE)
@@ -176,26 +178,28 @@ class Neo4jOptions(private val options: java.util.Map[String, String]) extends S
 
   val nodeMetadata: Neo4jNodeMetadata = initNeo4jNodeMetadata()
 
-  private def mapPropsString(str: String): Map[String, String] = str.split(",")
-    .map(_.trim)
-    .filter(_.nonEmpty)
-    .map(s => {
-      val keys = if (s.startsWith("`")) {
-        val pattern = "`[^`]+`".r
-        val groups = pattern findAllIn s
-        groups
-          .map(_.replaceAll("`", ""))
-          .toArray
-      } else {
-        s.split(":")
-      }
-      if (keys.length == 2) {
-        (keys(0), keys(1))
-      } else {
-        (keys(0), keys(0))
-      }
-    })
-    .toMap
+  private def mapPropsString(strOpt: Option[String]): Option[Map[String, String]] = strOpt.map(str =>
+    str.split(",")
+      .map(_.trim)
+      .filter(_.nonEmpty)
+      .map(s => {
+        val keys = if (s.startsWith("`")) {
+          val pattern = "`[^`]+`".r
+          val groups = pattern findAllIn s
+          groups
+            .map(_.replaceAll("`", ""))
+            .toArray
+        } else {
+          s.split(":")
+        }
+        if (keys.length == 2) {
+          (keys(0), keys(1))
+        } else {
+          (keys(0), keys(0))
+        }
+      })
+      .toMap
+  )
 
   private def initNeo4jNodeMetadata(
     nodeKeysString: String = getParameter(NODE_KEYS, ""),
@@ -204,8 +208,8 @@ class Neo4jOptions(private val options: java.util.Map[String, String]) extends S
     skipNullKeys: Boolean = getParameter(NODE_KEYS_SKIP_NULLS, "false").toBoolean
   ): Neo4jNodeMetadata = {
 
-    val nodeKeys = mapPropsString(nodeKeysString)
-    val nodeProps = mapPropsString(nodePropsString)
+    val nodeKeys = mapPropsString(Some(nodeKeysString)).getOrElse(Map.empty[String, String])
+    val nodeProps = mapPropsString(Some(nodePropsString)).getOrElse(Map.empty[String, String])
 
     val labels = labelsString
       .split(":")
@@ -252,7 +256,7 @@ class Neo4jOptions(private val options: java.util.Map[String, String]) extends S
 
     val nodeMap = getParameter(RELATIONSHIP_NODES_MAP, DEFAULT_RELATIONSHIP_NODES_MAP.toString).toBoolean
 
-    val relProps = mapPropsString(getParameter(RELATIONSHIP_PROPERTIES))
+    val relProps = mapPropsString(getParameterOption(RELATIONSHIP_PROPERTIES))
 
     val writeStrategy = RelationshipSaveStrategy.withCaseInsensitiveName(getParameter(
       RELATIONSHIP_SAVE_STRATEGY,
@@ -267,7 +271,7 @@ class Neo4jOptions(private val options: java.util.Map[String, String]) extends S
       DEFAULT_RELATIONSHIP_TARGET_SAVE_MODE.toString
     ))
 
-    val relationshipKeys = mapPropsString(getParameter(RELATIONSHIP_KEYS, ""))
+    val relationshipKeys = mapPropsString(getParameterOption(RELATIONSHIP_KEYS)).getOrElse(Map.empty)
 
     Neo4jRelationshipMetadata(
       source,
@@ -389,7 +393,7 @@ case class Neo4jRelationshipMetadata(
   target: Neo4jNodeMetadata,
   sourceSaveMode: NodeSaveMode.Value,
   targetSaveMode: NodeSaveMode.Value,
-  properties: Map[String, String],
+  properties: Option[Map[String, String]],
   relationshipType: String,
   nodeMap: Boolean,
   saveStrategy: RelationshipSaveStrategy.Value,

--- a/common/src/main/scala/org/neo4j/spark/util/Validations.scala
+++ b/common/src/main/scala/org/neo4j/spark/util/Validations.scala
@@ -48,7 +48,7 @@ case class ValidateSchemaOptions(neo4jOptions: Neo4jOptions, schema: StructType)
       Neo4jOptions.NODE_KEYS -> schema.getMissingFields(neo4jOptions.nodeMetadata.nodeKeys.keySet),
       Neo4jOptions.NODE_PROPS -> schema.getMissingFields(neo4jOptions.nodeMetadata.properties.keySet),
       Neo4jOptions.RELATIONSHIP_PROPERTIES -> schema.getMissingFields(
-        neo4jOptions.relationshipMetadata.properties.keySet
+        neo4jOptions.relationshipMetadata.properties.getOrElse(Map.empty).keySet
       ),
       Neo4jOptions.RELATIONSHIP_SOURCE_NODE_PROPS -> schema.getMissingFields(
         neo4jOptions.relationshipMetadata.source.properties.keySet

--- a/common/src/test/scala/org/neo4j/spark/util/Neo4jOptionsTest.scala
+++ b/common/src/test/scala/org/neo4j/spark/util/Neo4jOptionsTest.scala
@@ -204,7 +204,7 @@ class Neo4jOptionsTest {
 
     val neo4jOptions: Neo4jOptions = new Neo4jOptions(options)
 
-    assertEquals(neo4jOptions.relationshipMetadata.properties, Map.empty)
+    assertEquals(neo4jOptions.relationshipMetadata.properties, None)
   }
 
   @Test

--- a/spark-3/src/test/scala/org/neo4j/spark/DataSourceWriterTSE.scala
+++ b/spark-3/src/test/scala/org/neo4j/spark/DataSourceWriterTSE.scala
@@ -36,6 +36,7 @@ import org.neo4j.driver.internal.types.InternalTypeSystem
 import org.neo4j.driver.summary.ResultSummary
 import org.neo4j.driver.types.IsoDuration
 import org.neo4j.driver.types.Type
+import org.neo4j.spark.RowUtil.getByName
 import org.neo4j.spark.util.Neo4jOptions
 import org.scalatest.matchers.must.Matchers.be
 import org.scalatest.matchers.must.Matchers.include
@@ -995,57 +996,272 @@ class DataSourceWriterTSE extends SparkConnectorScalaBaseTSE {
       .save()
   }
 
-  @Test
-  def `should write relations with KEYS mode with props`(): Unit = {
+  def writeKeyModeRelationshipWriteDataSet(
+    optionModifier: Map[String, String] => Map[String, String] = { m => m }
+  ): DataFrame = {
     val musicDf = Seq(
-      (12, "John Bonham", "Drums"),
-      (19, "John Mayer", "Guitar"),
-      (32, "John Scofield", "Guitar"),
-      (15, "John Butler", "Guitar")
-    ).toDF("experience", "name", "instrument")
+      (12, "John Bonham", "Drums", 2, true),
+      (19, "John Mayer", "Guitar", 1, false),
+      (32, "John Scofield", "Guitar", 3, true),
+      (15, "John Butler", "Guitar", 4, false)
+    ).toDF("experience", "name", "instrument", "rating", "hasDiploma")
+
+    val options = Map(
+      "url" -> SparkConnectorScalaSuiteIT.server.getBoltUrl,
+      "relationship" -> "PLAYS",
+      "relationship.source.save.mode" -> "Overwrite",
+      "relationship.target.save.mode" -> "Overwrite",
+      "relationship.save.strategy" -> "keys",
+      "relationship.source.labels" -> ":Musician",
+      "relationship.source.node.keys" -> "name",
+      "relationship.target.labels" -> ":Instrument",
+      "relationship.target.node.keys" -> "instrument:name"
+    )
+    val modifiedOptions = optionModifier(options)
 
     musicDf.repartition(1).write
       .format(classOf[DataSource].getName)
       .mode(SaveMode.Overwrite)
-      .option("url", SparkConnectorScalaSuiteIT.server.getBoltUrl)
-      .option("relationship", "PLAYS")
-      .option("relationship.properties", "experience")
-      .option("relationship.source.save.mode", "Overwrite")
-      .option("relationship.target.save.mode", "Overwrite")
-      .option("relationship.save.strategy", "keys")
-      .option("relationship.source.labels", ":Musician")
-      .option("relationship.source.node.keys", "name")
-      .option("relationship.target.labels", ":Instrument")
-      .option("relationship.target.node.keys", "instrument:name")
+      .options(modifiedOptions)
       .save()
 
-    val df2 = ss.read.format(classOf[DataSource].getName)
+    ss.read.format(classOf[DataSource].getName)
       .option("url", SparkConnectorScalaSuiteIT.server.getBoltUrl)
       .option("relationship.nodes.map", "false")
       .option("relationship", "PLAYS")
       .option("relationship.source.labels", ":Musician")
       .option("relationship.target.labels", ":Instrument")
       .load()
+  }
 
-    assertEquals(4, df2.count())
+  @Test
+  def `should write relations with KEYS mode with explicitly listed properties`(): Unit = {
+    val resultDf = writeKeyModeRelationshipWriteDataSet({ options =>
+      options + ("relationship.properties" -> "experience, rating:avgRating")
+    })
 
-    val res = df2.orderBy("`source.name`").collectAsList()
+    resultDf.show(false)
+    assertEquals(4, resultDf.count())
 
-    assertEquals("John Bonham", res.get(0).getString(4))
-    assertEquals("Drums", res.get(0).getString(7))
-    assertEquals(12, res.get(0).getLong(8))
+    val res = resultDf.orderBy("`source.name`").collectAsList()
 
-    assertEquals("John Butler", res.get(1).getString(4))
-    assertEquals("Guitar", res.get(1).getString(7))
-    assertEquals(15, res.get(1).getLong(8))
+    assertEquals("John Bonham", getByName[String](res.get(0), "source.name"))
+    assertEquals("Drums", getByName[String](res.get(0), "target.name"))
+    assertEquals(12, getByName[Long](res.get(0), "rel.experience"))
+    assertEquals(2, getByName[Long](res.get(0), "rel.avgRating"))
+    assertThrows[IllegalArgumentException](
+      "relationship should not have hasDiploma field",
+      res.get(0).fieldIndex("rel.hasDiploma")
+    )
+    assertThrows[IllegalArgumentException](
+      "relationship should not have rating field",
+      res.get(0).fieldIndex("rel.rating")
+    )
+    assertThrows[IllegalArgumentException]("relationship should not have name field", res.get(0).fieldIndex("rel.name"))
+    assertThrows[IllegalArgumentException](
+      "relationship should not have instrument field",
+      res.get(0).fieldIndex("rel.instrument")
+    )
 
-    assertEquals("John Mayer", res.get(2).getString(4))
-    assertEquals("Guitar", res.get(2).getString(7))
-    assertEquals(19, res.get(2).getLong(8))
+    assertEquals("John Butler", getByName[String](res.get(1), "source.name"))
+    assertEquals("Guitar", getByName[String](res.get(1), "target.name"))
+    assertEquals(15, getByName[Long](res.get(1), "rel.experience"))
+    assertEquals(4, getByName[Long](res.get(1), "rel.avgRating"))
+    assertThrows[IllegalArgumentException](
+      "relationship should not have hasDiploma field",
+      res.get(1).fieldIndex("rel.hasDiploma")
+    )
+    assertThrows[IllegalArgumentException](
+      "relationship should not have rating field",
+      res.get(1).fieldIndex("rel.rating")
+    )
+    assertThrows[IllegalArgumentException]("relationship should not have name field", res.get(1).fieldIndex("rel.name"))
+    assertThrows[IllegalArgumentException](
+      "relationship should not have instrument field",
+      res.get(1).fieldIndex("rel.instrument")
+    )
 
-    assertEquals("John Scofield", res.get(3).getString(4))
-    assertEquals("Guitar", res.get(3).getString(7))
-    assertEquals(32, res.get(3).getLong(8))
+    assertEquals("John Mayer", getByName[String](res.get(2), "source.name"))
+    assertEquals("Guitar", getByName[String](res.get(2), "target.name"))
+    assertEquals(19, getByName[Long](res.get(2), "rel.experience"))
+    assertEquals(1, getByName[Long](res.get(2), "rel.avgRating"))
+    assertThrows[IllegalArgumentException](
+      "relationship should not have hasDiploma field",
+      res.get(2).fieldIndex("rel.hasDiploma")
+    )
+    assertThrows[IllegalArgumentException](
+      "relationship should not have rating field",
+      res.get(2).fieldIndex("rel.rating")
+    )
+    assertThrows[IllegalArgumentException]("relationship should not have name field", res.get(2).fieldIndex("rel.name"))
+    assertThrows[IllegalArgumentException](
+      "relationship should not have instrument field",
+      res.get(2).fieldIndex("rel.instrument")
+    )
+
+    assertEquals("John Scofield", getByName[String](res.get(3), "source.name"))
+    assertEquals("Guitar", getByName[String](res.get(3), "target.name"))
+    assertEquals(32, getByName[Long](res.get(3), "rel.experience"))
+    assertEquals(3, getByName[Long](res.get(3), "rel.avgRating"))
+    assertThrows[IllegalArgumentException](
+      "relationship should not have hasDiploma field",
+      res.get(3).fieldIndex("rel.hasDiploma")
+    )
+    assertThrows[IllegalArgumentException](
+      "relationship should not have rating field",
+      res.get(3).fieldIndex("rel.rating")
+    )
+    assertThrows[IllegalArgumentException]("relationship should not have name field", res.get(3).fieldIndex("rel.name"))
+    assertThrows[IllegalArgumentException](
+      "relationship should not have instrument field",
+      res.get(3).fieldIndex("rel.instrument")
+    )
+  }
+
+  @Test
+  def `should write relations with KEYS mode with explicitly listed empty properties`(): Unit = {
+    val resultDf = writeKeyModeRelationshipWriteDataSet({ options =>
+      options + ("relationship.properties" -> "")
+    })
+
+    resultDf.show(false)
+    assertEquals(4, resultDf.count())
+
+    val res = resultDf.orderBy("`source.name`").collectAsList()
+
+    assertEquals("John Bonham", getByName[String](res.get(0), "source.name"))
+    assertEquals("Drums", getByName[String](res.get(0), "target.name"))
+    assertThrows[IllegalArgumentException](
+      "relationship should not have experience field",
+      res.get(0).fieldIndex("rel.experience")
+    )
+    assertThrows[IllegalArgumentException](
+      "relationship should not have hasDiploma field",
+      res.get(0).fieldIndex("rel.hasDiploma")
+    )
+    assertThrows[IllegalArgumentException](
+      "relationship should not have rating field",
+      res.get(0).fieldIndex("rel.rating")
+    )
+    assertThrows[IllegalArgumentException]("relationship should not have name field", res.get(0).fieldIndex("rel.name"))
+    assertThrows[IllegalArgumentException](
+      "relationship should not have instrument field",
+      res.get(0).fieldIndex("rel.instrument")
+    )
+
+    assertEquals("John Butler", getByName[String](res.get(1), "source.name"))
+    assertEquals("Guitar", getByName[String](res.get(1), "target.name"))
+    assertThrows[IllegalArgumentException](
+      "relationship should not have experience field",
+      res.get(1).fieldIndex("rel.experience")
+    )
+    assertThrows[IllegalArgumentException](
+      "relationship should not have hasDiploma field",
+      res.get(1).fieldIndex("rel.hasDiploma")
+    )
+    assertThrows[IllegalArgumentException](
+      "relationship should not have rating field",
+      res.get(1).fieldIndex("rel.rating")
+    )
+    assertThrows[IllegalArgumentException]("relationship should not have name field", res.get(1).fieldIndex("rel.name"))
+    assertThrows[IllegalArgumentException](
+      "relationship should not have instrument field",
+      res.get(1).fieldIndex("rel.instrument")
+    )
+
+    assertEquals("John Mayer", getByName[String](res.get(2), "source.name"))
+    assertEquals("Guitar", getByName[String](res.get(2), "target.name"))
+    assertThrows[IllegalArgumentException](
+      "relationship should not have experience field",
+      res.get(2).fieldIndex("rel.experience")
+    )
+    assertThrows[IllegalArgumentException](
+      "relationship should not have hasDiploma field",
+      res.get(2).fieldIndex("rel.hasDiploma")
+    )
+    assertThrows[IllegalArgumentException](
+      "relationship should not have rating field",
+      res.get(2).fieldIndex("rel.rating")
+    )
+    assertThrows[IllegalArgumentException]("relationship should not have name field", res.get(2).fieldIndex("rel.name"))
+    assertThrows[IllegalArgumentException](
+      "relationship should not have instrument field",
+      res.get(2).fieldIndex("rel.instrument")
+    )
+
+    assertEquals("John Scofield", getByName[String](res.get(3), "source.name"))
+    assertEquals("Guitar", getByName[String](res.get(3), "target.name"))
+    assertThrows[IllegalArgumentException](
+      "relationship should not have experience field",
+      res.get(3).fieldIndex("rel.experience")
+    )
+    assertThrows[IllegalArgumentException](
+      "relationship should not have hasDiploma field",
+      res.get(3).fieldIndex("rel.hasDiploma")
+    )
+    assertThrows[IllegalArgumentException](
+      "relationship should not have rating field",
+      res.get(3).fieldIndex("rel.rating")
+    )
+    assertThrows[IllegalArgumentException]("relationship should not have name field", res.get(3).fieldIndex("rel.name"))
+    assertThrows[IllegalArgumentException](
+      "relationship should not have instrument field",
+      res.get(3).fieldIndex("rel.instrument")
+    )
+  }
+
+  @Test
+  def `should write relations with KEYS mode with default properties`(): Unit = {
+    val resultDf = writeKeyModeRelationshipWriteDataSet()
+
+    resultDf.show(false)
+    assertEquals(4, resultDf.count())
+
+    val res = resultDf.orderBy("`source.name`").collectAsList()
+
+    assertEquals("John Bonham", getByName[String](res.get(0), "source.name"))
+    assertEquals("Drums", getByName[String](res.get(0), "target.name"))
+    assertEquals(12, getByName[Long](res.get(0), "rel.experience"))
+    assertEquals(true, getByName[Boolean](res.get(0), "rel.hasDiploma"))
+    assertEquals(2, getByName[Long](res.get(0), "rel.rating"))
+    assertThrows[IllegalArgumentException]("relationship should not have name field", res.get(0).fieldIndex("rel.name"))
+    assertThrows[IllegalArgumentException](
+      "relationship should not have instrument field",
+      res.get(0).fieldIndex("rel.instrument")
+    )
+
+    assertEquals("John Butler", getByName[String](res.get(1), "source.name"))
+    assertEquals("Guitar", getByName[String](res.get(1), "target.name"))
+    assertEquals(15, getByName[Long](res.get(1), "rel.experience"))
+    assertEquals(false, getByName[Boolean](res.get(1), "rel.hasDiploma"))
+    assertEquals(4, getByName[Long](res.get(1), "rel.rating"))
+    assertThrows[IllegalArgumentException]("relationship should not have name field", res.get(1).fieldIndex("rel.name"))
+    assertThrows[IllegalArgumentException](
+      "relationship should not have instrument field",
+      res.get(1).fieldIndex("rel.instrument")
+    )
+
+    assertEquals("John Mayer", getByName[String](res.get(2), "source.name"))
+    assertEquals("Guitar", getByName[String](res.get(2), "target.name"))
+    assertEquals(19, getByName[Long](res.get(2), "rel.experience"))
+    assertEquals(false, getByName[Boolean](res.get(2), "rel.hasDiploma"))
+    assertEquals(1, getByName[Long](res.get(2), "rel.rating"))
+    assertThrows[IllegalArgumentException]("relationship should not have name field", res.get(2).fieldIndex("rel.name"))
+    assertThrows[IllegalArgumentException](
+      "relationship should not have instrument field",
+      res.get(2).fieldIndex("rel.instrument")
+    )
+
+    assertEquals("John Scofield", getByName[String](res.get(3), "source.name"))
+    assertEquals("Guitar", getByName[String](res.get(3), "target.name"))
+    assertEquals(32, getByName[Long](res.get(3), "rel.experience"))
+    assertEquals(true, getByName[Boolean](res.get(3), "rel.hasDiploma"))
+    assertEquals(3, getByName[Long](res.get(3), "rel.rating"))
+    assertThrows[IllegalArgumentException]("relationship should not have name field", res.get(3).fieldIndex("rel.name"))
+    assertThrows[IllegalArgumentException](
+      "relationship should not have instrument field",
+      res.get(3).fieldIndex("rel.instrument")
+    )
   }
 
   @Test

--- a/spark-3/src/test/scala/org/neo4j/spark/DataSourceWriterTSE.scala
+++ b/spark-3/src/test/scala/org/neo4j/spark/DataSourceWriterTSE.scala
@@ -1037,7 +1037,7 @@ class DataSourceWriterTSE extends SparkConnectorScalaBaseTSE {
   @Test
   def `should write relations with KEYS mode with explicitly listed properties`(): Unit = {
     val resultDf = writeKeyModeRelationshipWriteDataSet({ options =>
-      options + ("relationship.properties" -> "experience, rating:avgRating")
+      options + ("relationship.properties" -> "experience, rating:avgRating, instrument")
     })
 
     resultDf.show(false)
@@ -1047,6 +1047,7 @@ class DataSourceWriterTSE extends SparkConnectorScalaBaseTSE {
 
     assertEquals("John Bonham", getByName[String](res.get(0), "source.name"))
     assertEquals("Drums", getByName[String](res.get(0), "target.name"))
+    assertEquals("Drums", getByName[String](res.get(0), "rel.instrument"))
     assertEquals(12, getByName[Long](res.get(0), "rel.experience"))
     assertEquals(2, getByName[Long](res.get(0), "rel.avgRating"))
     assertThrows[IllegalArgumentException](
@@ -1058,13 +1059,10 @@ class DataSourceWriterTSE extends SparkConnectorScalaBaseTSE {
       res.get(0).fieldIndex("rel.rating")
     )
     assertThrows[IllegalArgumentException]("relationship should not have name field", res.get(0).fieldIndex("rel.name"))
-    assertThrows[IllegalArgumentException](
-      "relationship should not have instrument field",
-      res.get(0).fieldIndex("rel.instrument")
-    )
 
     assertEquals("John Butler", getByName[String](res.get(1), "source.name"))
     assertEquals("Guitar", getByName[String](res.get(1), "target.name"))
+    assertEquals("Guitar", getByName[String](res.get(1), "rel.instrument"))
     assertEquals(15, getByName[Long](res.get(1), "rel.experience"))
     assertEquals(4, getByName[Long](res.get(1), "rel.avgRating"))
     assertThrows[IllegalArgumentException](
@@ -1076,13 +1074,10 @@ class DataSourceWriterTSE extends SparkConnectorScalaBaseTSE {
       res.get(1).fieldIndex("rel.rating")
     )
     assertThrows[IllegalArgumentException]("relationship should not have name field", res.get(1).fieldIndex("rel.name"))
-    assertThrows[IllegalArgumentException](
-      "relationship should not have instrument field",
-      res.get(1).fieldIndex("rel.instrument")
-    )
 
     assertEquals("John Mayer", getByName[String](res.get(2), "source.name"))
     assertEquals("Guitar", getByName[String](res.get(2), "target.name"))
+    assertEquals("Guitar", getByName[String](res.get(2), "rel.instrument"))
     assertEquals(19, getByName[Long](res.get(2), "rel.experience"))
     assertEquals(1, getByName[Long](res.get(2), "rel.avgRating"))
     assertThrows[IllegalArgumentException](
@@ -1094,13 +1089,10 @@ class DataSourceWriterTSE extends SparkConnectorScalaBaseTSE {
       res.get(2).fieldIndex("rel.rating")
     )
     assertThrows[IllegalArgumentException]("relationship should not have name field", res.get(2).fieldIndex("rel.name"))
-    assertThrows[IllegalArgumentException](
-      "relationship should not have instrument field",
-      res.get(2).fieldIndex("rel.instrument")
-    )
 
     assertEquals("John Scofield", getByName[String](res.get(3), "source.name"))
     assertEquals("Guitar", getByName[String](res.get(3), "target.name"))
+    assertEquals("Guitar", getByName[String](res.get(3), "rel.instrument"))
     assertEquals(32, getByName[Long](res.get(3), "rel.experience"))
     assertEquals(3, getByName[Long](res.get(3), "rel.avgRating"))
     assertThrows[IllegalArgumentException](
@@ -1112,10 +1104,6 @@ class DataSourceWriterTSE extends SparkConnectorScalaBaseTSE {
       res.get(3).fieldIndex("rel.rating")
     )
     assertThrows[IllegalArgumentException]("relationship should not have name field", res.get(3).fieldIndex("rel.name"))
-    assertThrows[IllegalArgumentException](
-      "relationship should not have instrument field",
-      res.get(3).fieldIndex("rel.instrument")
-    )
   }
 
   @Test

--- a/test-support/src/main/scala/org/neo4j/spark/RowUtil.scala
+++ b/test-support/src/main/scala/org/neo4j/spark/RowUtil.scala
@@ -1,3 +1,19 @@
+/*
+ * Copyright (c) "Neo4j"
+ * Neo4j Sweden AB [https://neo4j.com]
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.neo4j.spark
 
 import org.apache.spark.sql.Row

--- a/test-support/src/main/scala/org/neo4j/spark/RowUtil.scala
+++ b/test-support/src/main/scala/org/neo4j/spark/RowUtil.scala
@@ -1,0 +1,7 @@
+package org.neo4j.spark
+
+import org.apache.spark.sql.Row
+
+object RowUtil {
+  def getByName[T](row: Row, name: String): T = row.getAs[T](row.fieldIndex(name))
+}


### PR DESCRIPTION
Changes the behaviour of `relationship.properties` the following way:
* if set explicitly, imports listed fields as properties (of set to empty string, imports none fields)
* if omitted, preserves old behaviour, which is importing all possible fields except used for node keys