### PR TITLE
test: rely on environment variable for tests

### DIFF
--- a/.teamcity/builds/Build.kt
+++ b/.teamcity/builds/Build.kt
@@ -111,10 +111,10 @@ class Build(
 
               SNYK_PROFILES.forEach { snykProfile ->
                 dependentBuildType(
-                    SnykTest(id = "$name-snyk-test-${snykProfile.name}",
+                    SnykTest(
+                        id = "$name-snyk-test-${snykProfile.name}",
                         name = "$name snyk test ${snykProfile.name}",
-                        snykProfile = snykProfile)
-                )
+                        snykProfile = snykProfile))
               }
             }
 

--- a/.teamcity/builds/Common.kt
+++ b/.teamcity/builds/Common.kt
@@ -127,11 +127,16 @@ enum class Neo4jVersion(val version: String, val dockerImage: String) {
   ),
 }
 
-data class SnykProfile(val name: String, val mavenArgs: String, val dockerImage: String = "snyk/snyk:maven-3-jdk-17")
-
-val SNYK_PROFILES = setOf(
-    SnykProfile("scala-2-13", "-Pscala-2.13"),
+data class SnykProfile(
+    val name: String,
+    val mavenArgs: String,
+    val dockerImage: String = "snyk/snyk:maven-3-jdk-17"
 )
+
+val SNYK_PROFILES =
+    setOf(
+        SnykProfile("scala-2-13", "-Pscala-2.13"),
+    )
 
 fun <S, T, Y> Iterable<S>.cartesianProduct(
     other1: Collection<T>,

--- a/.teamcity/builds/JavaIntegrationTests.kt
+++ b/.teamcity/builds/JavaIntegrationTests.kt
@@ -37,7 +37,7 @@ class JavaIntegrationTests(
             maven {
               this.goals = "verify"
               this.runnerArgs =
-                  "$MAVEN_DEFAULT_ARGS -Djava.version=${javaVersion.version} -Dscala-${scalaVersion.version} -Dneo4j-${neo4jVersion.version} -DskipUnitTests"
+                  "$MAVEN_DEFAULT_ARGS -Djava.version=${javaVersion.version} -Dscala-${scalaVersion.version} -DskipUnitTests"
 
               dockerImagePlatform = MavenBuildStep.ImagePlatform.Linux
               dockerImage = javaVersion.dockerImage

--- a/.teamcity/builds/SnykTest.kt
+++ b/.teamcity/builds/SnykTest.kt
@@ -1,28 +1,27 @@
 package builds
 
 import jetbrains.buildServer.configs.kotlin.BuildType
-import jetbrains.buildServer.configs.kotlin.ParameterDisplay
 import jetbrains.buildServer.configs.kotlin.buildFeatures.buildCache
 import jetbrains.buildServer.configs.kotlin.buildSteps.ScriptBuildStep
 import jetbrains.buildServer.configs.kotlin.buildSteps.script
 import jetbrains.buildServer.configs.kotlin.toId
 
-class SnykTest(id: String, name: String, snykProfile: SnykProfile) : BuildType(
-    {
+class SnykTest(id: String, name: String, snykProfile: SnykProfile) :
+    BuildType({
       this.id(id.toId())
       this.name = name
 
-      params {
-        password("env.SNYK_TOKEN", "%snyk-token%")
-      }
+      params { password("env.SNYK_TOKEN", "%snyk-token%") }
 
       steps {
         script {
-          scriptContent = """
+          scriptContent =
+              """
             #!/bin/bash
             set -eux
             snyk test --severity-threshold=high --all-projects --policy-path=. -- ${snykProfile.mavenArgs}
-          """.trimIndent()
+          """
+                  .trimIndent()
 
           dockerImagePlatform = ScriptBuildStep.ImagePlatform.Linux
           dockerImage = snykProfile.dockerImage
@@ -41,5 +40,4 @@ class SnykTest(id: String, name: String, snykProfile: SnykProfile) : BuildType(
       }
 
       requirements { runOnLinux(LinuxSize.SMALL) }
-    }
-)
+    })

--- a/common/pom.xml
+++ b/common/pom.xml
@@ -85,6 +85,12 @@
         </dependency>
     </dependencies>
     <build>
+        <resources>
+            <resource>
+                <filtering>true</filtering>
+                <directory>src/main/resources</directory>
+            </resource>
+        </resources>
         <plugins>
             <plugin>
                 <groupId>net.alchim31.maven</groupId>

--- a/common/src/test/resources/neo4j-spark-connector.properties
+++ b/common/src/test/resources/neo4j-spark-connector.properties
@@ -1,2 +1,0 @@
-neo4j.version=${neo4j.version}
-neo4j.experimental=${neo4j.experimental}

--- a/common/src/test/scala/org/neo4j/spark/service/Neo4jQueryServiceIT.scala
+++ b/common/src/test/scala/org/neo4j/spark/service/Neo4jQueryServiceIT.scala
@@ -21,19 +21,18 @@ import org.apache.spark.sql.connector.expressions.aggregate.Max
 import org.apache.spark.sql.connector.expressions.aggregate.Min
 import org.apache.spark.sql.connector.expressions.aggregate.Sum
 import org.junit.After
-import org.junit.Assert
 import org.junit.FixMethodOrder
 import org.junit.Test
 import org.junit.runners.MethodSorters
-import org.neo4j.caniuse.Neo4j
-import org.neo4j.caniuse.Neo4jDeploymentType
-import org.neo4j.caniuse.Neo4jEdition
-import org.neo4j.caniuse.Neo4jVersion
 import org.neo4j.spark.SparkConnectorScalaSuiteWithGdsBase
 import org.neo4j.spark.SparkConnectorScalaSuiteWithGdsBase.neo4j
 import org.neo4j.spark.util.DriverCache
 import org.neo4j.spark.util.DummyNamedReference
 import org.neo4j.spark.util.Neo4jOptions
+import org.scalatest.matchers.must.Matchers.convertToAnyMustWrapper
+import org.scalatest.matchers.must.Matchers.endWith
+
+import scala.language.postfixOps
 
 @FixMethodOrder(MethodSorters.JVM)
 class Neo4jQueryServiceIT extends SparkConnectorScalaSuiteWithGdsBase {
@@ -81,13 +80,12 @@ class Neo4jQueryServiceIT extends SparkConnectorScalaSuiteWithGdsBase {
       )
     ).createQuery()
 
-    Assert.assertEquals(
+    query must endWith(
       """CALL gds.pageRank.stream($graphName)
         |YIELD nodeId, score
         |RETURN nodeId AS nodeId, max(score) AS `MAX(score)`, min(score) AS `MIN(score)`, count(score) AS `COUNT(score)`, count(DISTINCT score) AS `COUNT(DISTINCT score)`, sum(score) AS `SUM(score)`, sum(DISTINCT score) AS `SUM(DISTINCT score)`"""
         .stripMargin
-        .replaceAll("\n", " "),
-      query
+        .replaceAll("\n", " ")
     )
   }
 

--- a/pom.xml
+++ b/pom.xml
@@ -203,18 +203,6 @@
         </dependencies>
     </dependencyManagement>
     <build>
-        <resources>
-            <resource>
-                <filtering>true</filtering>
-                <directory>src/main/resources</directory>
-            </resource>
-        </resources>
-        <testResources>
-            <testResource>
-                <filtering>true</filtering>
-                <directory>src/test/resources</directory>
-            </testResource>
-        </testResources>
         <pluginManagement>
             <plugins>
                 <plugin>

--- a/pom.xml
+++ b/pom.xml
@@ -569,32 +569,6 @@
         <!-- end scala profiles -->
         <!-- spark profiles -->
         <!-- end spark profiles -->
-        <!-- neo4j profiles -->
-        <profile>
-            <id>neo4j-4.4</id>
-            <activation>
-                <property>
-                    <name>neo4j-4</name>
-                </property>
-            </activation>
-            <properties>
-                <neo4j.experimental>false</neo4j.experimental>
-                <neo4j.version>4.4.34</neo4j.version>
-            </properties>
-        </profile>
-        <profile>
-            <id>neo4j-5</id>
-            <activation>
-                <property>
-                    <name>!neo4j-4</name>
-                </property>
-            </activation>
-            <properties>
-                <neo4j.experimental>false</neo4j.experimental>
-                <neo4j.version>5.20.0</neo4j.version>
-            </properties>
-        </profile>
-        <!-- end neo4j profiles -->
         <profile>
             <id>has-sources</id>
             <activation>

--- a/spark-3/pom.xml
+++ b/spark-3/pom.xml
@@ -65,6 +65,12 @@
         </dependency>
     </dependencies>
     <build>
+        <resources>
+            <resource>
+                <filtering>true</filtering>
+                <directory>src/main/resources</directory>
+            </resource>
+        </resources>
         <plugins>
             <plugin>
                 <groupId>net.alchim31.maven</groupId>

--- a/spark-3/src/test/resources/neo4j-spark-connector.properties
+++ b/spark-3/src/test/resources/neo4j-spark-connector.properties
@@ -1,2 +1,0 @@
-neo4j.version=${neo4j.version}
-neo4j.experimental=${neo4j.experimental}

--- a/spark-3/src/test/scala/org/neo4j/spark/DataSourceSchemaWriterTSE.scala
+++ b/spark-3/src/test/scala/org/neo4j/spark/DataSourceSchemaWriterTSE.scala
@@ -43,7 +43,7 @@ object DataSourceSchemaWriterTSE {
 
   @BeforeClass
   def checkNeo4jVersion() {
-    Assume.assumeTrue(TestUtil.neo4jVersion() >= Versions.NEO4J_5_13)
+    Assume.assumeTrue(TestUtil.neo4jVersion(SparkConnectorScalaSuiteIT.session()) >= Versions.NEO4J_5_13)
   }
 }
 

--- a/spark-3/src/test/scala/org/neo4j/spark/DataSourceWriterNeo4jSkipNullKeysTSE.scala
+++ b/spark-3/src/test/scala/org/neo4j/spark/DataSourceWriterNeo4jSkipNullKeysTSE.scala
@@ -18,8 +18,11 @@ package org.neo4j.spark
 
 import org.apache.spark.SparkException
 import org.apache.spark.sql.SaveMode
+import org.junit.Assume
 import org.junit.Test
 import org.neo4j.Closeables.use
+import org.neo4j.caniuse.CanIUse
+import org.neo4j.caniuse.Schema
 
 class DataSourceWriterNeo4jSkipNullKeysTSE extends SparkConnectorScalaBaseTSE {
 
@@ -105,6 +108,10 @@ class DataSourceWriterNeo4jSkipNullKeysTSE extends SparkConnectorScalaBaseTSE {
 
   @Test
   def `fails to write relationships when relationship key properties contain null values`(): Unit = {
+    Assume.assumeTrue(
+      CanIUse.INSTANCE.canIUse(Schema.INSTANCE.relationshipKeyConstraints()).withNeo4j(SparkConnectorScalaSuiteIT.neo4j)
+    )
+
     val caught = intercept[SparkException] {
       val cities = Seq(
         (Some(1), Some(2), Some("BA721"), "British Airways"),
@@ -474,6 +481,10 @@ class DataSourceWriterNeo4jSkipNullKeysTSE extends SparkConnectorScalaBaseTSE {
 
   @Test
   def `skips relationships when relationship key properties contain null values`(): Unit = {
+    Assume.assumeTrue(
+      CanIUse.INSTANCE.canIUse(Schema.INSTANCE.relationshipKeyConstraints()).withNeo4j(SparkConnectorScalaSuiteIT.neo4j)
+    )
+
     val cities = Seq(
       (Some(1), Some(2), Some("BA721"), "British Airways"),
       (Some(2), Some(3), Some("TK211"), "Turkish Airlines"),

--- a/spark-3/src/test/scala/org/neo4j/spark/DataSourceWriterTSE.scala
+++ b/spark-3/src/test/scala/org/neo4j/spark/DataSourceWriterTSE.scala
@@ -1346,11 +1346,12 @@ class DataSourceWriterTSE extends SparkConnectorScalaBaseTSE {
   }
 
   private def getIndexQueryCount: String = {
-    val (uniqueKey, uniqueCondition) = if (TestUtil.neo4jVersion() >= Versions.NEO4J_5) {
-      ("owningConstraint", "owningConstraint IS NULL")
-    } else {
-      ("uniqueness", "uniqueness = 'NONUNIQUE'")
-    }
+    val (uniqueKey, uniqueCondition) =
+      if (TestUtil.neo4jVersion(SparkConnectorScalaSuiteIT.session()) >= Versions.NEO4J_5) {
+        ("owningConstraint", "owningConstraint IS NULL")
+      } else {
+        ("uniqueness", "uniqueness = 'NONUNIQUE'")
+      }
 
     s"""SHOW INDEXES YIELD labelsOrTypes, properties, $uniqueKey
        |WHERE labelsOrTypes = ['Person'] AND properties = ['surname'] AND $uniqueCondition
@@ -1359,11 +1360,12 @@ class DataSourceWriterTSE extends SparkConnectorScalaBaseTSE {
   }
 
   private def getConstraintQueryCount: String = {
-    val (uniqueKey, uniqueCondition) = if (TestUtil.neo4jVersion() >= Versions.NEO4J_5) {
-      ("owningConstraint", "owningConstraint IS NOT NULL")
-    } else {
-      ("uniqueness", "uniqueness = 'UNIQUE'")
-    }
+    val (uniqueKey, uniqueCondition) =
+      if (TestUtil.neo4jVersion(SparkConnectorScalaSuiteIT.session()) >= Versions.NEO4J_5) {
+        ("owningConstraint", "owningConstraint IS NOT NULL")
+      } else {
+        ("uniqueness", "uniqueness = 'UNIQUE'")
+      }
     s"""SHOW INDEXES YIELD labelsOrTypes, properties, $uniqueKey
        |WHERE labelsOrTypes = ['Person'] AND properties = ['surname'] AND $uniqueCondition
        |RETURN count(*) AS count
@@ -1529,12 +1531,15 @@ class DataSourceWriterTSE extends SparkConnectorScalaBaseTSE {
     val expected = ds.count
     assertEquals(expected, records)
 
-    val uniqueFieldName = if (TestUtil.neo4jVersion() >= Versions.NEO4J_5) "owningConstraint" else "uniqueness"
-    val (indexCondition, uniqueCondition) = if (TestUtil.neo4jVersion() >= Versions.NEO4J_5) {
-      (s"$uniqueFieldName IS NULL", s"$uniqueFieldName IS NOT NULL")
-    } else {
-      (s"$uniqueFieldName = 'NONUNIQUE'", s"$uniqueFieldName = 'UNIQUE'")
-    }
+    val uniqueFieldName = if (TestUtil.neo4jVersion(SparkConnectorScalaSuiteIT.session()) >= Versions.NEO4J_5)
+      "owningConstraint"
+    else "uniqueness"
+    val (indexCondition, uniqueCondition) =
+      if (TestUtil.neo4jVersion(SparkConnectorScalaSuiteIT.session()) >= Versions.NEO4J_5) {
+        (s"$uniqueFieldName IS NULL", s"$uniqueFieldName IS NOT NULL")
+      } else {
+        (s"$uniqueFieldName = 'NONUNIQUE'", s"$uniqueFieldName = 'UNIQUE'")
+      }
     val query =
       s"""SHOW INDEXES YIELD labelsOrTypes, properties, $uniqueFieldName
          |WHERE (labelsOrTypes = ['Person'] AND properties = ['surname'] AND $indexCondition)

--- a/spark-3/src/test/scala/org/neo4j/spark/ReauthenticationIT.scala
+++ b/spark-3/src/test/scala/org/neo4j/spark/ReauthenticationIT.scala
@@ -72,8 +72,8 @@ object ReauthenticationIT {
     .withNetwork(NETWORK)
     .withEnv("NEO4J_ACCEPT_LICENSE_AGREEMENT", "yes")
     .withCopyFileToContainer(MountableFile.forClasspathResource("/neo4j-keycloak.jks"), "/tmp/keycloak.jks")
-    .withNeo4jConfig(
-      "server.jvm.additional",
+    .withEnv(
+      "_JAVA_OPTIONS",
       "-Djavax.net.ssl.keyStore=/tmp/keycloak.jks -Djavax.net.ssl.keyStorePassword=testpwd -Djavax.net.ssl.trustStore=/tmp/keycloak.jks -Djavax.net.ssl.trustStorePassword=testpwd"
     )
     .withNeo4jConfig("dbms.security.authentication_providers", "oidc-keycloak,native")

--- a/test-support/src/main/resources/neo4j-spark-connector.properties
+++ b/test-support/src/main/resources/neo4j-spark-connector.properties
@@ -1,2 +1,0 @@
-neo4j.version=${neo4j.version}
-neo4j.experimental=${neo4j.experimental}

--- a/test-support/src/main/scala/org/neo4j/Neo4jContainerExtension.scala
+++ b/test-support/src/main/scala/org/neo4j/Neo4jContainerExtension.scala
@@ -96,10 +96,9 @@ class DatabasesWaitStrategy(private val auth: AuthToken) extends AbstractWaitStr
 }
 
 // docker pull neo4j/neo4j-experimental:4.0.0-rc01-enterprise
-class Neo4jContainerExtension(imageName: String =
-  s"neo4j${if (TestUtil.experimental()) "/neo4j-experimental" else ""}:${TestUtil.neo4jVersion()}-enterprise")
+class Neo4jContainerExtension
     extends Neo4jContainer[Neo4jContainerExtension](
-      DockerImageName.parse(imageName).asCompatibleSubstituteFor("neo4j")
+      TestUtil.neo4jImage()
     ) {
   private var databases: Seq[String] = Seq.empty
 

--- a/test-support/src/main/scala/org/neo4j/spark/SparkConnectorScalaSuiteWithApocIT.scala
+++ b/test-support/src/main/scala/org/neo4j/spark/SparkConnectorScalaSuiteWithApocIT.scala
@@ -44,7 +44,6 @@ object SparkConnectorScalaSuiteWithApocIT {
 
   @BeforeClass
   def setUpContainer(): Unit = {
-    Assume.assumeFalse("Neo4j Preview versions doesn't have APOC", TestUtil.experimental())
     if (!server.isRunning) {
       try {
         server.start()
@@ -60,6 +59,7 @@ object SparkConnectorScalaSuiteWithApocIT {
       driver = GraphDatabase.driver(server.getBoltUrl, AuthTokens.none())
       neo4j = Neo4jDetector.INSTANCE.detect(driver)
     }
+    Assume.assumeTrue("Neo4j Preview versions doesn't have APOC", TestUtil.hasApoc(session()))
   }
 
   @AfterClass

--- a/test-support/src/main/scala/org/neo4j/spark/TestUtil.scala
+++ b/test-support/src/main/scala/org/neo4j/spark/TestUtil.scala
@@ -54,10 +54,10 @@ object Versions {
 object TestUtil {
 
   def neo4jImage(): DockerImageName = {
-    val image = System.getenv("NEO4J_TEST_IMAGE")
-    if (image == null || image.trim.isBlank) {
-      throw new IllegalArgumentException("NEO4J_TEST_IMAGE environment variable is not defined!")
-    }
+    val image = Option(System.getenv("NEO4J_TEST_IMAGE"))
+      .map(_.trim)
+      .filter(_.nonEmpty) // avoids Java 11-only isBlank
+      .getOrElse(throw new IllegalArgumentException("NEO4J_TEST_IMAGE environment variable is not defined!"))
     DockerImageName.parse(image).asCompatibleSubstituteFor("neo4j")
   }
 

--- a/test-support/src/main/scala/org/neo4j/spark/TestUtil.scala
+++ b/test-support/src/main/scala/org/neo4j/spark/TestUtil.scala
@@ -19,6 +19,7 @@ package org.neo4j.spark
 import org.neo4j.driver.Session
 import org.neo4j.driver.Transaction
 import org.slf4j.Logger
+import org.testcontainers.utility.DockerImageName
 
 import java.util.Properties
 
@@ -52,13 +53,13 @@ object Versions {
 
 object TestUtil {
 
-  private val properties = new Properties()
-
-  properties.load(
-    Thread.currentThread().getContextClassLoader().getResourceAsStream("neo4j-spark-connector.properties")
-  )
-
-  def neo4jVersion(): Version = Version.parse(properties.getProperty("neo4j.version"))
+  def neo4jImage(): DockerImageName = {
+    val image = System.getenv("NEO4J_TEST_IMAGE")
+    if (image == null || image.trim.isBlank) {
+      throw new IllegalArgumentException("NEO4J_TEST_IMAGE environment variable is not defined!")
+    }
+    DockerImageName.parse(image).asCompatibleSubstituteFor("neo4j")
+  }
 
   def gdsVersion(session: Session): Version = {
     Version.parse(session.run(
@@ -72,7 +73,12 @@ object TestUtil {
     ).single().get(0).asString())
   }
 
-  def experimental(): Boolean = properties.getProperty("neo4j.experimental", "false").toBoolean
+  def hasApoc(session: Session): Boolean = {
+    val result = session.run(
+      "SHOW PROCEDURES YIELD name RETURN any(x IN collect(name) WHERE x STARTS WITH 'apoc.') AS hasApoc"
+    )
+    result.single().get("hasApoc").asBoolean()
+  }
 
   def closeSafely(autoCloseable: AutoCloseable, logger: Logger = null): Unit = {
     try {


### PR DESCRIPTION
This PR changes how we lookup neo4j version under test, and completely gets rid of maven profiles and relies on environment variables completely.

fixes CONN-368.