### PR TITLE
ci: fix version parsing for calver

### DIFF
--- a/test-support/src/main/scala/org/neo4j/spark/TestUtil.scala
+++ b/test-support/src/main/scala/org/neo4j/spark/TestUtil.scala
@@ -33,6 +33,11 @@ object Version {
 
   def parse(version: String): Version = {
     val fields = version.split("\\.")
+      .map(field => {
+        val additionalInfoIndex = field.indexOf('-')
+        if (additionalInfoIndex.equals(-1)) field
+        else field.substring(0, additionalInfoIndex)
+      })
       .map(_.toInt)
       .toList
 

--- a/test-support/src/test/scala/org/neo4j/spark/VersionTest.scala
+++ b/test-support/src/test/scala/org/neo4j/spark/VersionTest.scala
@@ -1,3 +1,19 @@
+/*
+ * Copyright (c) "Neo4j"
+ * Neo4j Sweden AB [https://neo4j.com]
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.neo4j.spark
 
 import org.junit.Assert.assertEquals

--- a/test-support/src/test/scala/org/neo4j/spark/VersionTest.scala
+++ b/test-support/src/test/scala/org/neo4j/spark/VersionTest.scala
@@ -1,0 +1,13 @@
+package org.neo4j.spark
+
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+class VersionTest {
+
+  @Test
+  def parses_versions(): Unit = {
+    assertEquals(Version(5, 26, 399), Version.parse("5.26.399"))
+    assertEquals(Version(2025, 11, 0), Version.parse("2025.11.0-41865"))
+  }
+}


### PR DESCRIPTION
Now that the CI config is fixed and runs against calver, we need to update the version parsing logic accordingly.