### PR TITLE
ci: exclude transient vuln from spark core

### DIFF
--- a/.snyk
+++ b/.snyk
@@ -15,4 +15,5 @@ ignore:
   'SNYK-JAVA-ORGAPACHEZOOKEEPER-5961102': *spark-core-exclusions
   'SNYK-JAVA-ORGGLASSFISHJERSEYCORE-14049172': *spark-core-exclusions
   'SNYK-JAVA-ORGLZ4-14151788': *spark-core-exclusions
+  'SNYK-JAVA-ORGLZ4-14219384': *spark-core-exclusions
 patch: {}


### PR DESCRIPTION
exclude one more vulnerabilities related to spark-core as it's a provided dependency
it is distinct to the previous one: SNYK-JAVA-ORGLZ4-14151788

from snyk:
"distinct from ... CVE-2025-12183, and was discovered during follow-up research."