### PR TITLE
fix: return `null` when no last offset is available

### DIFF
--- a/common/src/main/scala/org/neo4j/spark/service/SchemaService.scala
+++ b/common/src/main/scala/org/neo4j/spark/service/SchemaService.scala
@@ -38,6 +38,7 @@ import org.neo4j.spark.cypher.CypherVersionSelector.selectCypherVersionClause
 import org.neo4j.spark.service.SchemaService.normalizedClassName
 import org.neo4j.spark.service.SchemaService.normalizedClassNameFromGraphEntity
 import org.neo4j.spark.util.Neo4jImplicits.CypherImplicits
+import org.neo4j.spark.util.Neo4jImplicits.ValueImplicits
 import org.neo4j.spark.util.OptimizationType
 import org.neo4j.spark.util._
 
@@ -964,7 +965,13 @@ class SchemaService(
     }
   }
 
-  private def lastOffsetForNode(): Long = {
+  def lastOffset(): Option[Long] = options.query.queryType match {
+    case QueryType.LABELS       => lastOffsetForNode()
+    case QueryType.RELATIONSHIP => lastOffsetForRelationship()
+    case QueryType.QUERY        => lastOffsetForQuery()
+  }
+
+  private def lastOffsetForNode(): Option[Long] = {
     val label = options.nodeMetadata.labels.head
     session.run(
       s"""MATCH (n:$label)
@@ -973,10 +980,10 @@ class SchemaService(
     )
       .single()
       .get(options.streamingOptions.propertyName)
-      .asLong(-1)
+      .asOptionalLong()
   }
 
-  private def lastOffsetForRelationship(): Long = {
+  private def lastOffsetForRelationship(): Option[Long] = {
     val sourceLabel = options.relationshipMetadata.source.labels.head.quote()
     val targetLabel = options.relationshipMetadata.target.labels.head.quote()
     val relType = options.relationshipMetadata.relationshipType.quote()
@@ -988,18 +995,14 @@ class SchemaService(
     )
       .single()
       .get(options.streamingOptions.propertyName)
-      .asLong(-1)
+      .asOptionalLong()
   }
 
-  private def lastOffsetForQuery(): Long = session.run(options.streamingOptions.queryOffset, sessionTransactionConfig)
-    .single()
-    .get(0)
-    .asLong(-1)
-
-  def lastOffset(): Long = options.query.queryType match {
-    case QueryType.LABELS       => lastOffsetForNode()
-    case QueryType.RELATIONSHIP => lastOffsetForRelationship()
-    case QueryType.QUERY        => lastOffsetForQuery()
+  private def lastOffsetForQuery(): Option[Long] = {
+    session.run(options.streamingOptions.queryOffset, sessionTransactionConfig)
+      .single()
+      .get(0)
+      .asOptionalLong()
   }
 
   private def logResolutionChange(message: String, e: ClientException): Unit = {

--- a/common/src/main/scala/org/neo4j/spark/util/Neo4jImplicits.scala
+++ b/common/src/main/scala/org/neo4j/spark/util/Neo4jImplicits.scala
@@ -390,4 +390,14 @@ object Neo4jImplicits {
     def toNestedJavaMap: java.util.Map[String, Any] = nestingMap(map)
   }
 
+  implicit class ValueImplicits(value: Value) {
+
+    def asOptionalLong(): Option[Long] = {
+      if (value.isNull) {
+        Option.empty
+      } else {
+        Option(value.asLong())
+      }
+    }
+  }
 }

--- a/common/src/test/scala/org/neo4j/spark/service/AuthenticationTest.scala
+++ b/common/src/test/scala/org/neo4j/spark/service/AuthenticationTest.scala
@@ -27,7 +27,7 @@ import org.neo4j.driver.GraphDatabase
 import org.neo4j.spark.util.DriverCache
 import org.neo4j.spark.util.Neo4jOptions
 import org.powermock.api.mockito.PowerMockito
-import org.powermock.core.classloader.annotations.PrepareForTest
+import org.powermock.core.classloader.annotations.{PowerMockIgnore, PrepareForTest}
 import org.powermock.modules.junit4.PowerMockRunner
 import org.testcontainers.shaded.com.google.common.io.BaseEncoding
 
@@ -36,6 +36,7 @@ import java.util
 
 @PrepareForTest(Array(classOf[GraphDatabase]))
 @RunWith(classOf[PowerMockRunner])
+@PowerMockIgnore(value = Array("javax.management.*"))
 class AuthenticationTest {
 
   @Test

--- a/common/src/test/scala/org/neo4j/spark/service/AuthenticationTest.scala
+++ b/common/src/test/scala/org/neo4j/spark/service/AuthenticationTest.scala
@@ -27,7 +27,8 @@ import org.neo4j.driver.GraphDatabase
 import org.neo4j.spark.util.DriverCache
 import org.neo4j.spark.util.Neo4jOptions
 import org.powermock.api.mockito.PowerMockito
-import org.powermock.core.classloader.annotations.{PowerMockIgnore, PrepareForTest}
+import org.powermock.core.classloader.annotations.PowerMockIgnore
+import org.powermock.core.classloader.annotations.PrepareForTest
 import org.powermock.modules.junit4.PowerMockRunner
 import org.testcontainers.shaded.com.google.common.io.BaseEncoding
 

--- a/spark-3/src/main/scala/org/neo4j/spark/streaming/Neo4jMicroBatchReader.scala
+++ b/spark-3/src/main/scala/org/neo4j/spark/streaming/Neo4jMicroBatchReader.scala
@@ -83,7 +83,7 @@ class Neo4jMicroBatchReader(
   }
 
   override def latestOffset(): Offset = {
-    val offset = Neo4jOffset(Neo4jUtil.callSchemaService[Long](
+    val offsetValue = Neo4jUtil.callSchemaService[Option[Long]](
       neo4j,
       neo4jOptions,
       jobId,
@@ -93,12 +93,11 @@ class Neo4jMicroBatchReader(
           try {
             schemaService.lastOffset()
           } catch {
-            case _: Throwable => -1L
+            case _: Throwable => null
           }
       }
-    ))
-
-    offset
+    )
+    offsetValue.map(value => Neo4jOffset(value)).orNull
   }
 
   override def initialOffset(): Offset = Neo4jOffset(neo4jOptions.streamingOptions.from.value())

--- a/spark-3/src/test/scala/org/neo4j/spark/DataSourceStreamingReaderTSE.scala
+++ b/spark-3/src/test/scala/org/neo4j/spark/DataSourceStreamingReaderTSE.scala
@@ -21,7 +21,8 @@ import org.apache.spark.sql.streaming.StreamingQuery
 import org.apache.spark.sql.streaming.Trigger
 import org.hamcrest.Matchers
 import org.junit.After
-import org.junit.Assert.{assertEquals, assertTrue}
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
 import org.junit.Rule
 import org.junit.Test
 import org.junit.rules.TemporaryFolder
@@ -30,6 +31,7 @@ import org.neo4j.spark.SparkConnectorScalaSuiteIT.session
 
 import java.util.concurrent.Executors
 import java.util.concurrent.TimeUnit
+
 import scala.annotation.meta.getter
 
 class DataSourceStreamingReaderTSE extends SparkConnectorScalaBaseTSE {

--- a/spark-3/src/test/scala/org/neo4j/spark/DataSourceStreamingReaderTSE.scala
+++ b/spark-3/src/test/scala/org/neo4j/spark/DataSourceStreamingReaderTSE.scala
@@ -21,15 +21,15 @@ import org.apache.spark.sql.streaming.StreamingQuery
 import org.apache.spark.sql.streaming.Trigger
 import org.hamcrest.Matchers
 import org.junit.After
-import org.junit.Assert.assertEquals
+import org.junit.Assert.{assertEquals, assertTrue}
 import org.junit.Rule
 import org.junit.Test
 import org.junit.rules.TemporaryFolder
 import org.neo4j.Closeables.use
+import org.neo4j.spark.SparkConnectorScalaSuiteIT.session
 
 import java.util.concurrent.Executors
 import java.util.concurrent.TimeUnit
-
 import scala.annotation.meta.getter
 
 class DataSourceStreamingReaderTSE extends SparkConnectorScalaBaseTSE {
@@ -586,20 +586,66 @@ class DataSourceStreamingReaderTSE extends SparkConnectorScalaBaseTSE {
     )
   }
 
-  private def createPersonNodes(from: Int, count: Int, delayMs: Int = 0, intervalMs: Int = 0): Unit = {
-    use(SparkConnectorScalaSuiteIT.session()) { session =>
+  @Test
+  def testStreamDoesNotReadAnyDataIfStreamingQueryReturnsNothing(): Unit = {
+    createPersonNodes(0, 50)
+    use(session()) { session =>
+      session.run("MATCH (p:Person) SET p:Human").consume()
+    }
+    val stream = ss.readStream.format(classOf[DataSource].getName)
+      .option("url", SparkConnectorScalaSuiteIT.server.getBoltUrl)
+      .option("streaming.property.name", "timestamp")
+      .option("streaming.from", "ALL")
+      .option(
+        "query",
+        """
+          |MATCH (p:Person)
+          |WHERE p.timestamp > $stream.from AND p.timestamp <= $stream.to
+          |RETURN p.age AS age, p.timestamp AS timestamp
+          |""".stripMargin
+      )
+      .option("streaming.query.offset", "MATCH (p:Human) RETURN max(p.timestamp)")
+      .load()
+
+    val checkpoint = folder.newFolder()
+    // 1st trigger: every node was processed
+    var streamTable = stream.writeStream
+      .trigger(Trigger.AvailableNow())
+      .option("checkpointLocation", checkpoint.getAbsolutePath)
+      .toTable("testStreamDoesNotReadAnyDataIfStreamingQueryReturnsNothing")
+    streamTable.awaitTermination()
+    val firstSource = streamTable.lastProgress.sources.head
+    assertEquals(50, firstSource.numInputRows)
+    val endOffset1 = firstSource.endOffset
+    use(session()) { session =>
+      session.run("MATCH (p:Human) REMOVE p:Human").consume()
+    }
+    // 2nd trigger: nothing was processed again
+    streamTable = stream.writeStream
+      .trigger(Trigger.AvailableNow())
+      .option("checkpointLocation", checkpoint.getAbsolutePath)
+      .toTable("testStreamDoesNotReadAnyDataIfStreamingQueryReturnsNothing")
+    streamTable.awaitTermination()
+    val source = streamTable.lastProgress.sources.head
+    assertEquals(endOffset1, source.startOffset)
+    assertEquals(endOffset1, source.endOffset)
+    assertEquals(0L, source.numInputRows)
+  }
+
+  private def createPersonNodes(minAge: Int, maxAge: Int, delayMs: Int = 0, intervalMs: Int = 0): Unit = {
+    use(session()) { session =>
       Thread.sleep(delayMs)
-      (from until from + count).foreach(index => {
+      (minAge until minAge + maxAge).foreach(age => {
         Thread.sleep(intervalMs)
         session.run(
-          s"CREATE (p:Person {age: '$index', timestamp: timestamp()})"
+          s"CREATE (p:Person {age: '$age', timestamp: timestamp()})"
         ).consume()
       })
     }
   }
 
   private def createMovieNodes(from: Int, count: Int, delayMs: Int = 0, intervalMs: Int = 0): Unit = {
-    use(SparkConnectorScalaSuiteIT.session()) { session =>
+    use(session()) { session =>
       Thread.sleep(delayMs)
       (from until from + count).foreach(index => {
         Thread.sleep(intervalMs)
@@ -611,7 +657,7 @@ class DataSourceStreamingReaderTSE extends SparkConnectorScalaBaseTSE {
   }
 
   private def createLikesRelationships(from: Int, count: Int, delayMs: Int = 0, intervalMs: Int = 0): Unit = {
-    use(SparkConnectorScalaSuiteIT.session()) { session =>
+    use(session()) { session =>
       Thread.sleep(delayMs)
       (from until from + count).foreach(index => {
         Thread.sleep(intervalMs)

--- a/spark-3/src/test/scala/org/neo4j/spark/DataSourceStreamingReaderTSE.scala
+++ b/spark-3/src/test/scala/org/neo4j/spark/DataSourceStreamingReaderTSE.scala
@@ -622,7 +622,7 @@ class DataSourceStreamingReaderTSE extends SparkConnectorScalaBaseTSE {
     use(session()) { session =>
       session.run("MATCH (p:Human) REMOVE p:Human").consume()
     }
-    // 2nd trigger: nothing was processed again
+    // 2nd trigger: previous offset is kept intact
     streamTable = stream.writeStream
       .trigger(Trigger.AvailableNow())
       .option("checkpointLocation", checkpoint.getAbsolutePath)


### PR DESCRIPTION
This means user-defined stream offset queries that return no results will keep the previous offset instead of overwriting with -1.

In some edge scenarios where the user-defined query is ill-defined, this could lead to the whole data being reprocessed again.