### PR TITLE
ci: add semgrep check

### DIFF
--- a/.teamcity/builds/Build.kt
+++ b/.teamcity/builds/Build.kt
@@ -30,7 +30,7 @@ class Build(
 
             parallel {
               scalaVersions.forEach { scala ->
-                SemGrepCheck(
+                SemgrepCheck(
                     "${name}-semgrep-check-${scala.version}",
                     "semgrep check (${scala.version})",
                     scala

--- a/.teamcity/builds/Build.kt
+++ b/.teamcity/builds/Build.kt
@@ -29,6 +29,14 @@ class Build(
             if (forPullRequests) dependentBuildType(PRCheck("${name}-pr-check", "pr check"))
 
             parallel {
+              scalaVersions.forEach { scala ->
+                SemGrepCheck(
+                    "${name}-semgrep-check-${scala.version}",
+                    "semgrep check (${scala.version})",
+                    scala
+                )
+              }
+
               javaVersions.cartesianProduct(scalaVersions, neo4jVersions).forEach {
                   (java, scala, neo4j) ->
                 sequential {

--- a/.teamcity/builds/Build.kt
+++ b/.teamcity/builds/Build.kt
@@ -30,11 +30,11 @@ class Build(
 
             parallel {
               scalaVersions.forEach { scala ->
-                SemgrepCheck(
+                dependentBuildType(SemgrepCheck(
                     "${name}-semgrep-check-${scala.version}",
                     "semgrep check (${scala.version})",
                     scala
-                )
+                ))
               }
 
               javaVersions.cartesianProduct(scalaVersions, neo4jVersions).forEach {

--- a/.teamcity/builds/Common.kt
+++ b/.teamcity/builds/Common.kt
@@ -35,6 +35,7 @@ val MAVEN_DEFAULT_ARGS = buildString {
   append(
       "-Dmaven.wagon.http.retryHandler.nonRetryableClasses=java.io.InterruptedIOException,java.net.UnknownHostException,java.net.ConnectException ")
 }
+const val SEMGREP_DOCKER_IMAGE = "semgrep/semgrep:1.146.0"
 
 val DEFAULT_JAVA_VERSION = JavaVersion.V_11
 

--- a/.teamcity/builds/Maven.kt
+++ b/.teamcity/builds/Maven.kt
@@ -3,7 +3,7 @@ package builds
 import jetbrains.buildServer.configs.kotlin.BuildType
 import jetbrains.buildServer.configs.kotlin.toId
 
-class Maven(
+open class Maven(
     id: String,
     name: String,
     goals: String,

--- a/.teamcity/builds/SemGrepCheck.kt
+++ b/.teamcity/builds/SemGrepCheck.kt
@@ -1,0 +1,32 @@
+package builds
+
+import jetbrains.buildServer.configs.kotlin.buildSteps.ScriptBuildStep
+
+class SemGrepCheck(
+    id: String,
+    name: String,
+    scalaVersion: ScalaVersion
+): Maven(
+    id,
+    name,
+    "dependency:tree",
+    JavaVersion.V_17,
+    scalaVersion,
+    Neo4jVersion.V_NONE,
+    "-DoutputFile=maven_dep_tree.txt"
+) {
+
+  init {
+
+    params.password("env.SEMGREP_APP_TOKEN", "%semgrep-app-token%")
+
+    steps.step(ScriptBuildStep {
+      scriptContent="semgrep ci --no-git-ignore"
+      dockerImagePlatform = ScriptBuildStep.ImagePlatform.Linux
+      dockerImage = "semgrep/semgrep:1.146.0"
+      dockerRunParameters =
+          "--volume /var/run/docker.sock:/var/run/docker.sock --volume %teamcity.build.checkoutDir%/signingkeysandbox:/root/.gnupg"
+    })
+  }
+
+}

--- a/.teamcity/builds/SemgrepCheck.kt
+++ b/.teamcity/builds/SemgrepCheck.kt
@@ -23,7 +23,7 @@ class SemgrepCheck(
     steps.step(ScriptBuildStep {
       scriptContent="semgrep ci --no-git-ignore"
       dockerImagePlatform = ScriptBuildStep.ImagePlatform.Linux
-      dockerImage = "semgrep/semgrep:1.146.0"
+      dockerImage = SEMGREP_DOCKER_IMAGE
       dockerRunParameters =
           "--volume /var/run/docker.sock:/var/run/docker.sock --volume %teamcity.build.checkoutDir%/signingkeysandbox:/root/.gnupg"
     })

--- a/.teamcity/builds/SemgrepCheck.kt
+++ b/.teamcity/builds/SemgrepCheck.kt
@@ -2,7 +2,7 @@ package builds
 
 import jetbrains.buildServer.configs.kotlin.buildSteps.ScriptBuildStep
 
-class SemGrepCheck(
+class SemgrepCheck(
     id: String,
     name: String,
     scalaVersion: ScalaVersion

--- a/.teamcity/settings.kts
+++ b/.teamcity/settings.kts
@@ -22,6 +22,7 @@ project {
     password("signing-key-passphrase", "%publish-signing-key-password%")
     password("github-commit-status-token", "%github-token%")
     password("github-pull-request-token", "%github-token%")
+    password("semgrep-app-token", "%semgrep-token%")
   }
 
   vcsRoot(Neo4jSparkConnectorVcs)


### PR DESCRIPTION
This PR adds a Semgrep check to CI pipeline. [Linear card](https://linear.app/neo4j/issue/CONN-488/setup-maven-dependency-chain-scans-neo4j-spark-connector)

Key changes:

Introduce a separate build to generate maven dependency tree and perform Semgrep scan. Scan results are integrated with Semgrep UI and available in the scan history.
Scans are performed on each pull request, main branch and on periodic compatibility testing.
Note: --no-git-ignore file apparently required to both discover language rules and scan tree files correctly.

The change wasn't tested yet.