### PR TITLE
ci: include 6.0 into dependabot updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -6,9 +6,12 @@ updates:
       interval: "daily"
     cooldown:
       default-days: 3
-  - package-ecosystem: "maven"
+  - &maven
+    package-ecosystem: "maven"
     directory: "/"
     schedule:
       interval: "daily"
     cooldown:
       default-days: 3
+  - <<: *maven
+    target-branch: "6.0"


### PR DESCRIPTION
Add a rule for Maven dependencies for the `6.0` git branch. 