### PR TITLE
ci: sync dependabot conf for 6

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,7 +4,14 @@ updates:
     directory: "/"
     schedule:
       interval: "daily"
-  - package-ecosystem: "maven"
+    cooldown:
+      default-days: 3
+  - &maven
+    package-ecosystem: "maven"
     directory: "/"
     schedule:
       interval: "daily"
+    cooldown:
+      default-days: 3
+  - <<: *maven
+    target-branch: "5.0"


### PR DESCRIPTION
Sync dependabot config with the '6.0' branch. Replaced `6.0` branch in `target-branch` rule, because `&maven` rule will cover default branch. 