### PR TITLE
ci: add semgrep environment variables

### DIFF
--- a/.teamcity/builds/Common.kt
+++ b/.teamcity/builds/Common.kt
@@ -36,6 +36,9 @@ val MAVEN_DEFAULT_ARGS = buildString {
       "-Dmaven.wagon.http.retryHandler.nonRetryableClasses=java.io.InterruptedIOException,java.net.UnknownHostException,java.net.ConnectException ")
 }
 const val SEMGREP_DOCKER_IMAGE = "semgrep/semgrep:1.146.0"
+const val FULL_GITHUB_REPOSITORY = "$GITHUB_OWNER/$GITHUB_REPOSITORY"
+const val GITHUB_URL = "https://github.com/$FULL_GITHUB_REPOSITORY"
+
 
 val DEFAULT_JAVA_VERSION = JavaVersion.V_11
 

--- a/.teamcity/builds/SemgrepCheck.kt
+++ b/.teamcity/builds/SemgrepCheck.kt
@@ -15,6 +15,12 @@ class SemgrepCheck(id: String, name: String, scalaVersion: ScalaVersion) :
   init {
 
     params.password("env.SEMGREP_APP_TOKEN", "%semgrep-app-token%")
+    params.text("env.SEMGREP_BASELINE_REF", DEFAULT_BRANCH)
+    params.text("env.SEMGREP_REPO_NAME", FULL_GITHUB_REPOSITORY)
+    params.text("env.SEMGREP_REPO_URL", GITHUB_URL)
+    params.text("env.SEMGREP_BRANCH", "%teamcity.build.branch%")
+    params.text("env.SEMGREP_JOB_URL", "%env.BUILD_URL%")
+    params.text("env.SEMGREP_COMMIT", "%env.BUILD_VCS_NUMBER%")
 
     steps.step(
         ScriptBuildStep {


### PR DESCRIPTION
[Linear card](https://linear.app/neo4j/issue/CONN-488/setup-maven-dependency-chain-scans-neo4j-spark-connector)
Add additional environment variable to link scans with semgrep project. 