### PR TITLE
ci: try SEMGREP_BASELINE_COMMIT variable

### DIFF
--- a/.teamcity/builds/SemgrepCheck.kt
+++ b/.teamcity/builds/SemgrepCheck.kt
@@ -24,7 +24,15 @@ class SemgrepCheck(id: String, name: String, scalaVersion: ScalaVersion) :
 
     steps.step(
         ScriptBuildStep {
-          scriptContent = "semgrep ci --no-git-ignore"
+          scriptContent = """
+            #!/bin/bash
+            set -eux
+            
+            unset SEMGREP_BASELINE_REF
+            export SEMGREP_BASELINE_COMMIT=$(git merge-base $DEFAULT_BRANCH %teamcity.build.branch%)
+            
+            semgrep ci --no-git-ignore
+            """.trimIndent()
           dockerImagePlatform = ScriptBuildStep.ImagePlatform.Linux
           dockerImage = SEMGREP_DOCKER_IMAGE
           dockerRunParameters =

--- a/.teamcity/builds/SemgrepCheck.kt
+++ b/.teamcity/builds/SemgrepCheck.kt
@@ -23,7 +23,7 @@ class SemgrepCheck(id: String, name: String, scalaVersion: ScalaVersion) :
 
     steps.step(
         ScriptBuildStep {
-          scriptContent ="semgrep ci --no-git-ignore"
+          scriptContent = "semgrep ci --no-git-ignore"
           dockerImagePlatform = ScriptBuildStep.ImagePlatform.Linux
           dockerImage = SEMGREP_DOCKER_IMAGE
           dockerRunParameters =

--- a/.teamcity/builds/SemgrepCheck.kt
+++ b/.teamcity/builds/SemgrepCheck.kt
@@ -15,7 +15,6 @@ class SemgrepCheck(id: String, name: String, scalaVersion: ScalaVersion) :
   init {
 
     params.password("env.SEMGREP_APP_TOKEN", "%semgrep-app-token%")
-    params.text("env.SEMGREP_BASELINE_REF", DEFAULT_BRANCH)
     params.text("env.SEMGREP_REPO_NAME", FULL_GITHUB_REPOSITORY)
     params.text("env.SEMGREP_REPO_URL", GITHUB_URL)
     params.text("env.SEMGREP_BRANCH", "%teamcity.build.branch%")
@@ -24,15 +23,7 @@ class SemgrepCheck(id: String, name: String, scalaVersion: ScalaVersion) :
 
     steps.step(
         ScriptBuildStep {
-          scriptContent = """
-            #!/bin/bash
-            set -eux
-            
-            unset SEMGREP_BASELINE_REF
-            export SEMGREP_BASELINE_COMMIT=$(git merge-base $DEFAULT_BRANCH %teamcity.build.branch%)
-            
-            semgrep ci --no-git-ignore
-            """.trimIndent()
+          scriptContent ="semgrep ci --no-git-ignore"
           dockerImagePlatform = ScriptBuildStep.ImagePlatform.Linux
           dockerImage = SEMGREP_DOCKER_IMAGE
           dockerRunParameters =


### PR DESCRIPTION
Remove `SEMGREP_BASELINE_REF` to disable diff-aware scans for two reasons: 
* this is a legacy option and should be replaced for `SEMGREP_BASELINE_COMMIT`
* it won't work for main branch, where we need full scan. 

I disabled diff-aware scans, because don't see big value if diff-aware scans and to make scans consistent accorss all branches. 