### PR TITLE
test: handle inconsistencies in SHOW CONSTRAINT between 2025 and 2026 neo4j versions

### DIFF
--- a/spark/src/test/scala/org/neo4j/spark/DataSourceSchemaWriterTSE.scala
+++ b/spark/src/test/scala/org/neo4j/spark/DataSourceSchemaWriterTSE.scala
@@ -50,6 +50,28 @@ object DataSourceSchemaWriterTSE {
 class DataSourceSchemaWriterTSE extends SparkConnectorScalaBaseTSE {
   val sparkSession = SparkSession.builder().getOrCreate()
 
+  final private val SHOW_CONSTRAINTS_QUERY =
+    """|SHOW CONSTRAINTS
+       |YIELD name, type, entityType, labelsOrTypes, properties, ownedIndex""".stripMargin
+
+  final private val NODE_UNIQUENESS_SHOW_CONSTRAINTS_QUERY =
+    """|SHOW CONSTRAINTS
+       |YIELD name, type AS ptype, entityType, labelsOrTypes, properties, ownedIndex
+       |RETURN name, entityType, labelsOrTypes, properties, ownedIndex,
+       |CASE ptype
+       |  WHEN "UNIQUENESS" THEN "NODE_PROPERTY_UNIQUENESS"
+       |  ELSE ptype
+       |END AS type""".stripMargin
+
+  final private val RELATIONSHIP_UNIQUENESS_SHOW_CONSTRAINTS_QUERY =
+    """|SHOW CONSTRAINTS
+       |YIELD name, type AS ptype, entityType, labelsOrTypes, properties, ownedIndex
+       |RETURN name, entityType, labelsOrTypes, properties, ownedIndex,
+       |CASE ptype
+       |  WHEN "RELATIONSHIP_UNIQUENESS" THEN "RELATIONSHIP_PROPERTY_UNIQUENESS"
+       |  ELSE ptype
+       |END AS type""".stripMargin
+
   import sparkSession.implicits._
 
   private def mapData(x: Any): Any = x match {
@@ -777,19 +799,18 @@ class DataSourceSchemaWriterTSE extends SparkConnectorScalaBaseTSE {
       .toSet
     assertEquals(expected, records)
 
-    val actualConstraint = SparkConnectorScalaSuiteIT.session().run("SHOW CONSTRAINTS")
+    val actualConstraint = SparkConnectorScalaSuiteIT.session().run(NODE_UNIQUENESS_SHOW_CONSTRAINTS_QUERY)
       .list()
       .asScala
       .map(_.asMap(v => v.asObject()).asScala.mapValues(mapData).filter(k => k._1 != "id").toMap)
       .head
     val expectedConstraint = Map(
       "name" -> "spark_NODE_UNIQUE-CONSTRAINT_Person_surname",
-      "type" -> "UNIQUENESS",
+      "type" -> "NODE_PROPERTY_UNIQUENESS",
       "entityType" -> "NODE",
       "labelsOrTypes" -> Seq("Person"),
       "properties" -> Seq("surname"),
-      "ownedIndex" -> "spark_NODE_UNIQUE-CONSTRAINT_Person_surname",
-      "propertyType" -> null
+      "ownedIndex" -> "spark_NODE_UNIQUE-CONSTRAINT_Person_surname"
     )
     assertEquals(expectedConstraint, actualConstraint)
 
@@ -823,7 +844,7 @@ class DataSourceSchemaWriterTSE extends SparkConnectorScalaBaseTSE {
       .toSet
     assertEquals(expected, records)
 
-    val actualConstraint = SparkConnectorScalaSuiteIT.session().run("SHOW CONSTRAINTS")
+    val actualConstraint = SparkConnectorScalaSuiteIT.session().run(SHOW_CONSTRAINTS_QUERY)
       .list()
       .asScala
       .map(_.asMap(v => v.asObject()).asScala.mapValues(mapData).filter(k => k._1 != "id").toMap)
@@ -834,8 +855,7 @@ class DataSourceSchemaWriterTSE extends SparkConnectorScalaBaseTSE {
       "entityType" -> "NODE",
       "labelsOrTypes" -> Seq("Person"),
       "properties" -> Seq("surname"),
-      "ownedIndex" -> "spark_NODE_KEY-CONSTRAINT_Person_surname",
-      "propertyType" -> null
+      "ownedIndex" -> "spark_NODE_KEY-CONSTRAINT_Person_surname"
     )
     assertEquals(expectedConstraint, actualConstraint)
 
@@ -867,19 +887,19 @@ class DataSourceSchemaWriterTSE extends SparkConnectorScalaBaseTSE {
       .mapValues(mapData)
       .toMap
     assertEquals(expectedMap, actualMap)
-    val actualConstraint = SparkConnectorScalaSuiteIT.session().run("SHOW CONSTRAINTS")
+
+    val actualConstraint = SparkConnectorScalaSuiteIT.session().run(RELATIONSHIP_UNIQUENESS_SHOW_CONSTRAINTS_QUERY)
       .list()
       .asScala
       .map(_.asMap(v => v.asObject()).asScala.mapValues(mapData).filter(k => k._1 != "id").toMap)
       .head
     val expectedConstraint = Map(
       "name" -> "spark_RELATIONSHIP_UNIQUE-CONSTRAINT_MY_REL_string-int",
-      "type" -> "RELATIONSHIP_UNIQUENESS",
+      "type" -> "RELATIONSHIP_PROPERTY_UNIQUENESS",
       "entityType" -> "RELATIONSHIP",
       "labelsOrTypes" -> Seq("MY_REL"),
       "properties" -> Seq("string", "int"),
-      "ownedIndex" -> "spark_RELATIONSHIP_UNIQUE-CONSTRAINT_MY_REL_string-int",
-      "propertyType" -> null
+      "ownedIndex" -> "spark_RELATIONSHIP_UNIQUE-CONSTRAINT_MY_REL_string-int"
     )
     assertEquals(expectedConstraint, actualConstraint)
   }
@@ -910,7 +930,8 @@ class DataSourceSchemaWriterTSE extends SparkConnectorScalaBaseTSE {
       .mapValues(mapData)
       .toMap
     assertEquals(expectedMap, actualMap)
-    val actualConstraint = SparkConnectorScalaSuiteIT.session().run("SHOW CONSTRAINTS")
+
+    val actualConstraint = SparkConnectorScalaSuiteIT.session().run(SHOW_CONSTRAINTS_QUERY)
       .list()
       .asScala
       .map(_.asMap(v => v.asObject()).asScala.mapValues(mapData).filter(k => k._1 != "id").toMap)
@@ -921,8 +942,7 @@ class DataSourceSchemaWriterTSE extends SparkConnectorScalaBaseTSE {
       "entityType" -> "RELATIONSHIP",
       "labelsOrTypes" -> Seq("MY_REL"),
       "properties" -> Seq("string", "int"),
-      "ownedIndex" -> "spark_RELATIONSHIP_KEY-CONSTRAINT_MY_REL_string-int",
-      "propertyType" -> null
+      "ownedIndex" -> "spark_RELATIONSHIP_KEY-CONSTRAINT_MY_REL_string-int"
     )
     assertEquals(expectedConstraint, actualConstraint)
   }


### PR DESCRIPTION
Fixes https://linear.app/neo4j/issue/CONN-756/inconsistent-show-constraints-parsing-across-neo4j-versions

Adds handling for inconsistencies in SHOW CONSTRAINTS behavior between neo4j:2025-enterprise and neo4j:2026-enterprise docker images.