### PR TITLE
chore: remove alias from dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -6,12 +6,19 @@ updates:
       interval: "daily"
     cooldown:
       default-days: 3
-  - &maven
-    package-ecosystem: "maven"
+
+  - package-ecosystem: "maven"
     directory: "/"
+    target-branch: "5.0"
     schedule:
       interval: "daily"
     cooldown:
       default-days: 3
-  - <<: *maven
+
+  - package-ecosystem: "maven"
+    directory: "/"
     target-branch: "6.0"
+    schedule:
+      interval: "daily"
+    cooldown:
+      default-days: 3


### PR DESCRIPTION
error from github UI:

```
Dependabot couldn't parse the config file. The error raised was:

YAML aliases are not supported
```