### PR TITLE
build(deps): bump scalatest + scalatestplus from 3.2.19.1 to 3.2.20.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -176,7 +176,7 @@
             <dependency>
                 <groupId>org.scalatest</groupId>
                 <artifactId>scalatest_${scala.binary.version}</artifactId>
-                <version>3.2.19</version>
+                <version>3.2.20</version>
             </dependency>
             <dependency>
                 <groupId>org.scalatestplus</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -181,7 +181,7 @@
             <dependency>
                 <groupId>org.scalatestplus</groupId>
                 <artifactId>junit-4-13_${scala.binary.version}</artifactId>
-                <version>3.2.19.1</version>
+                <version>3.2.20.0</version>
             </dependency>
             <dependency>
                 <groupId>org.slf4j</groupId>


### PR DESCRIPTION
Bumping both versions in one go, this PR cherry-picks changes
from these other PRs:

https://github.com/neo4j/neo4j-spark-connector/pull/874

https://github.com/neo4j/neo4j-spark-connector/pull/875