### PR TITLE
fix: add maven assembly plugin

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -624,6 +624,10 @@
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-resources-plugin</artifactId>
             </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-assembly-plugin</artifactId>
+            </plugin>
         </plugins>
     </build>
     <profiles>


### PR DESCRIPTION
By mistake, I didn't activate assembly plugin for fat jar in the previous structure refactor PR so python integration tests fail in main TeamCity build due to missing classes.