### PR TITLE
feat: upgrade junit version to 6

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -43,7 +43,7 @@
         <!-- 3.4.3.Final is the latest jboss-logging version compatible with java 8 -->
         <jboss-logging.version>3.6.3.Final</jboss-logging.version>
         <junit.version>6.0.3</junit.version>
-        <license-maven-plugin.version>4.6</license-maven-plugin.version>
+        <license-maven-plugin.version>5.0.0</license-maven-plugin.version>
         <licensing-maven-plugin.version>1.7.12</licensing-maven-plugin.version>
         <licensing.prepend.text>/license/neo4j_apache_v2/notice.txt</licensing.prepend.text>
         <maven-clean-plugin.version>3.5.0</maven-clean-plugin.version>

--- a/pom.xml
+++ b/pom.xml
@@ -42,7 +42,7 @@
         <java.version>17</java.version>
         <!-- 3.4.3.Final is the latest jboss-logging version compatible with java 8 -->
         <jboss-logging.version>3.6.3.Final</jboss-logging.version>
-        <junit.version>4.13.2</junit.version>
+        <junit.version>6.0.3</junit.version>
         <license-maven-plugin.version>4.6</license-maven-plugin.version>
         <licensing-maven-plugin.version>1.7.12</licensing-maven-plugin.version>
         <licensing.prepend.text>/license/neo4j_apache_v2/notice.txt</licensing.prepend.text>
@@ -58,6 +58,7 @@
         <maven-site-plugin.version>3.21.0</maven-site-plugin.version>
         <maven-source-plugin.version>3.3.1</maven-source-plugin.version>
         <maven-surefire-plugin.version>3.5.5</maven-surefire-plugin.version>
+        <mockito.version>3.12.4</mockito.version>
         <neo4j.experimental>false</neo4j.experimental>
         <neo4j.version>4.4.20</neo4j.version>
         <netty-bom.version>4.1.128.Final</netty-bom.version>
@@ -79,6 +80,13 @@
                 <groupId>io.netty</groupId>
                 <artifactId>netty-bom</artifactId>
                 <version>${netty-bom.version}</version>
+                <type>pom</type>
+                <scope>import</scope>
+            </dependency>
+            <dependency>
+                <groupId>org.junit</groupId>
+                <artifactId>junit-bom</artifactId>
+                <version>${junit.version}</version>
                 <type>pom</type>
                 <scope>import</scope>
             </dependency>
@@ -194,15 +202,41 @@
             <scope>runtime</scope>
         </dependency>
         <dependency>
-            <groupId>junit</groupId>
-            <artifactId>junit</artifactId>
-            <version>${junit.version}</version>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
             <groupId>org.hamcrest</groupId>
             <artifactId>hamcrest</artifactId>
             <version>3.0</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter-params</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.junit.platform</groupId>
+            <artifactId>junit-platform-suite</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.junit.vintage</groupId>
+            <artifactId>junit-vintage-engine</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.mockito</groupId>
+            <artifactId>mockito-core</artifactId>
+            <version>${mockito.version}</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.mockito</groupId>
+            <artifactId>mockito-inline</artifactId>
+            <version>${mockito.version}</version>
             <scope>test</scope>
         </dependency>
         <dependency>
@@ -227,18 +261,6 @@
             <groupId>org.powermock</groupId>
             <artifactId>powermock-module-junit4</artifactId>
             <version>${powermock.version}</version>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
-            <groupId>org.scalatest</groupId>
-            <artifactId>scalatest_${scala.binary.version}</artifactId>
-            <version>3.2.19</version>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
-            <groupId>org.scalatestplus</groupId>
-            <artifactId>junit-4-13_${scala.binary.version}</artifactId>
-            <version>3.2.19.0</version>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -202,12 +202,6 @@
             <scope>runtime</scope>
         </dependency>
         <dependency>
-            <groupId>org.hamcrest</groupId>
-            <artifactId>hamcrest</artifactId>
-            <version>3.0</version>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
             <groupId>org.junit.jupiter</groupId>
             <artifactId>junit-jupiter</artifactId>
             <scope>test</scope>
@@ -220,11 +214,6 @@
         <dependency>
             <groupId>org.junit.platform</groupId>
             <artifactId>junit-platform-suite</artifactId>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
-            <groupId>org.junit.vintage</groupId>
-            <artifactId>junit-vintage-engine</artifactId>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -42,7 +42,7 @@
         <java.version>17</java.version>
         <!-- 3.4.3.Final is the latest jboss-logging version compatible with java 8 -->
         <jboss-logging.version>3.6.3.Final</jboss-logging.version>
-        <junit.version>4.13.2</junit.version>
+        <junit.version>6.0.3</junit.version>
         <license-maven-plugin.version>5.0.0</license-maven-plugin.version>
         <licensing-maven-plugin.version>1.7.12</licensing-maven-plugin.version>
         <licensing.prepend.text>/license/neo4j_apache_v2/notice.txt</licensing.prepend.text>
@@ -58,6 +58,7 @@
         <maven-site-plugin.version>3.21.0</maven-site-plugin.version>
         <maven-source-plugin.version>3.4.0</maven-source-plugin.version>
         <maven-surefire-plugin.version>3.5.5</maven-surefire-plugin.version>
+        <mockito.version>3.12.4</mockito.version>
         <neo4j.experimental>false</neo4j.experimental>
         <neo4j.version>4.4.20</neo4j.version>
         <netty-bom.version>4.1.128.Final</netty-bom.version>
@@ -79,6 +80,13 @@
                 <groupId>io.netty</groupId>
                 <artifactId>netty-bom</artifactId>
                 <version>${netty-bom.version}</version>
+                <type>pom</type>
+                <scope>import</scope>
+            </dependency>
+            <dependency>
+                <groupId>org.junit</groupId>
+                <artifactId>junit-bom</artifactId>
+                <version>${junit.version}</version>
                 <type>pom</type>
                 <scope>import</scope>
             </dependency>
@@ -194,15 +202,41 @@
             <scope>runtime</scope>
         </dependency>
         <dependency>
-            <groupId>junit</groupId>
-            <artifactId>junit</artifactId>
-            <version>${junit.version}</version>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
             <groupId>org.hamcrest</groupId>
             <artifactId>hamcrest</artifactId>
             <version>3.0</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter-params</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.junit.platform</groupId>
+            <artifactId>junit-platform-suite</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.junit.vintage</groupId>
+            <artifactId>junit-vintage-engine</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.mockito</groupId>
+            <artifactId>mockito-core</artifactId>
+            <version>${mockito.version}</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.mockito</groupId>
+            <artifactId>mockito-inline</artifactId>
+            <version>${mockito.version}</version>
             <scope>test</scope>
         </dependency>
         <dependency>
@@ -227,18 +261,6 @@
             <groupId>org.powermock</groupId>
             <artifactId>powermock-module-junit4</artifactId>
             <version>${powermock.version}</version>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
-            <groupId>org.scalatest</groupId>
-            <artifactId>scalatest_${scala.binary.version}</artifactId>
-            <version>3.2.19</version>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
-            <groupId>org.scalatestplus</groupId>
-            <artifactId>junit-4-13_${scala.binary.version}</artifactId>
-            <version>3.2.20.0</version>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/src/main/scala/org/neo4j/spark/util/DriverCache.scala
+++ b/src/main/scala/org/neo4j/spark/util/DriverCache.scala
@@ -39,11 +39,17 @@ class DriverCache(private val options: Neo4jDriverOptions) extends Serializable
   }
 
   def close(): Unit = {
-    Option(cache.get(options)).foreach { case (driver, counter) =>
+    Option(cache.get(options)).map { case (driver, counter) =>
       if (counter.decrementAndGet() == 0) {
         cache.remove(options)
         Neo4jUtil.closeSafely(driver)
       }
-    }
+    }.orElse(None)
+//    Option(cache.get(options)).foreach { case (driver, counter) =>
+//      if (counter.decrementAndGet() == 0) {
+//        cache.remove(options)
+//        Neo4jUtil.closeSafely(driver)
+//      }
+//    }
   }
 }

--- a/src/main/scala/org/neo4j/spark/util/DriverCache.scala
+++ b/src/main/scala/org/neo4j/spark/util/DriverCache.scala
@@ -45,11 +45,5 @@ class DriverCache(private val options: Neo4jDriverOptions) extends Serializable
         Neo4jUtil.closeSafely(driver)
       }
     }.orElse(None)
-//    Option(cache.get(options)).foreach { case (driver, counter) =>
-//      if (counter.decrementAndGet() == 0) {
-//        cache.remove(options)
-//        Neo4jUtil.closeSafely(driver)
-//      }
-//    }
   }
 }

--- a/src/main/scala/org/neo4j/spark/util/DriverCache.scala
+++ b/src/main/scala/org/neo4j/spark/util/DriverCache.scala
@@ -39,10 +39,11 @@ class DriverCache(private val options: Neo4jDriverOptions) extends Serializable
   }
 
   def close(): Unit = {
-    val (driver, counter) = cache.get(options)
-    if (counter.decrementAndGet() == 0) {
-      cache.remove(options)
-      Neo4jUtil.closeSafely(driver)
+    Option(cache.get(options)).foreach { case (driver, counter) =>
+      if (counter.decrementAndGet() == 0) {
+        cache.remove(options)
+        Neo4jUtil.closeSafely(driver)
+      }
     }
   }
 }

--- a/src/test/java/org/neo4j/spark/DataSourceReaderTypesTSE.java
+++ b/src/test/java/org/neo4j/spark/DataSourceReaderTypesTSE.java
@@ -19,7 +19,7 @@ package org.neo4j.spark;
 import org.apache.spark.sql.Dataset;
 import org.apache.spark.sql.Row;
 import org.apache.spark.sql.catalyst.expressions.GenericRowWithSchema;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.neo4j.driver.Session;
 import org.neo4j.spark.testsupport.SparkConnectorScalaBaseTSE;
 import org.neo4j.spark.testsupport.SparkConnectorScalaSuiteIT;

--- a/src/test/java/org/neo4j/spark/SparkConnectorSuiteIT.java
+++ b/src/test/java/org/neo4j/spark/SparkConnectorSuiteIT.java
@@ -16,12 +16,12 @@
  */
 package org.neo4j.spark;
 
-import org.junit.runner.RunWith;
-import org.junit.runners.Suite;
+import org.junit.platform.suite.api.SelectClasses;
+import org.junit.platform.suite.api.Suite;
 import org.neo4j.spark.testsupport.SparkConnectorScalaSuiteIT;
 
-@RunWith(Suite.class)
-@Suite.SuiteClasses({
+@Suite
+@SelectClasses({
     DataSourceReaderTypesTSE.class
 })
 public class SparkConnectorSuiteIT extends SparkConnectorScalaSuiteIT {

--- a/src/test/java/org/neo4j/spark/testsupport/Assert.java
+++ b/src/test/java/org/neo4j/spark/testsupport/Assert.java
@@ -19,16 +19,15 @@ package org.neo4j.spark.testsupport;//
 // (powered by Fernflower decompiler)
 //
 
+import org.junit.jupiter.api.Assertions;
+
 import java.util.Arrays;
+import java.util.Objects;
 import java.util.concurrent.TimeUnit;
 import java.util.function.Function;
 import java.util.function.Supplier;
 
-import org.hamcrest.Description;
-import org.hamcrest.Matcher;
-import org.hamcrest.MatcherAssert;
-import org.hamcrest.StringDescription;
-import org.hamcrest.core.StringContains;
+import static org.junit.jupiter.api.Assertions.fail;
 
 public final class Assert {
     private Assert() {
@@ -66,44 +65,37 @@ public final class Assert {
     public static <E extends Exception> void assertException(ThrowingAction<E> f, Class<?> typeOfException, String partOfErrorMessage) {
         try {
             f.apply();
-            org.junit.Assert.fail("Expected exception of type " + typeOfException + ", but no exception was thrown");
+            fail("Expected exception of type " + typeOfException + ", but no exception was thrown");
         } catch (Exception var4) {
             if (typeOfException.isInstance(var4)) {
                 if (partOfErrorMessage != null) {
-                    MatcherAssert.assertThat(var4.getMessage(), StringContains.containsString(partOfErrorMessage));
+                    Assertions.assertTrue(var4.getMessage() != null  && var4.getMessage().contains(partOfErrorMessage), "Expected exception message to be present");
                 }
             } else {
-                org.junit.Assert.fail("Got unexpected exception " + var4.getClass() + "\nExpected: " + typeOfException);
+                fail("Got unexpected exception " + var4.getClass() + "\nExpected: " + typeOfException);
             }
         }
 
     }
 
-    public static <T, E extends Exception> void assertEventually(ThrowingSupplier<T, E> actual, Matcher<? super T> matcher, long timeout, TimeUnit timeUnit) throws E, InterruptedException {
-        assertEventually((ignored) -> {
-            return "";
-        }, actual, matcher, timeout, timeUnit);
+    public static <T, E extends Exception> void assertEventually(T expected, ThrowingSupplier<T, E> actual, long timeout, TimeUnit timeUnit) throws E, InterruptedException {
+        assertEventually((ignored) -> "", actual, expected, timeout, timeUnit);
     }
 
-    public static <T, E extends Exception> void assertEventually(String reason, ThrowingSupplier<T, E> actual, Matcher<? super T> matcher, long timeout, TimeUnit timeUnit) throws E, InterruptedException {
-        assertEventually((ignored) -> {
-            return reason;
-        }, actual, matcher, timeout, timeUnit);
-    }
-
-    public static <T, E extends Exception> void assertEventually(Function<T, String> reason, ThrowingSupplier<T, E> actual, Matcher<? super T> matcher, long timeout, TimeUnit timeUnit) throws E, InterruptedException {
+    public static <T, E extends Exception> void assertEventually(Function<T, String> reason, ThrowingSupplier<T, E> actual, T expected, long timeout, TimeUnit timeUnit) throws E, InterruptedException {
         long endTimeMillis = System.currentTimeMillis() + timeUnit.toMillis(timeout);
 
         while (true) {
             long sampleTime = System.currentTimeMillis();
             T last = actual.get();
-            boolean matched = matcher.matches(last);
+            boolean matched = Objects.equals(expected, last);
             if (matched || sampleTime > endTimeMillis) {
                 if (!matched) {
-                    Description description = new StringDescription();
-                    description.appendText((String) reason.apply(last)).appendText("\nExpected: ").appendDescriptionOf(matcher).appendText("\n     but: ");
-                    matcher.describeMismatch(last, description);
-                    throw new AssertionError("Timeout hit (" + timeout + " " + timeUnit.toString().toLowerCase() + ") while waiting for condition to match: " + description.toString());
+                    throw new AssertionError(
+                        "Timeout hit (" + timeout + " " + timeUnit.toString().toLowerCase()
+                            + ") while waiting for condition to match: " + reason.apply(last)
+                            + "\nExpected: " + prettyPrint(expected)
+                            + "\n     but: " + prettyPrint(last));
                 } else {
                     return;
                 }
@@ -111,10 +103,6 @@ public final class Assert {
 
             Thread.sleep(100L);
         }
-    }
-
-    private static AssertionError newAssertionError(String message, Object expected, Object actual) {
-        return new AssertionError((message != null && !message.isEmpty() ? message + "\n" : "") + "Expected: " + prettyPrint(expected) + ", actual: " + prettyPrint(actual));
     }
 
     private static String prettyPrint(Object o) {

--- a/src/test/scala/org/neo4j/spark/CommonTestSuiteIT.scala
+++ b/src/test/scala/org/neo4j/spark/CommonTestSuiteIT.scala
@@ -16,13 +16,13 @@
  */
 package org.neo4j.spark
 
-import org.junit.runner.RunWith
-import org.junit.runners.Suite
+import org.junit.platform.suite.api.SelectClasses
+import org.junit.platform.suite.api.Suite
 import org.neo4j.spark.service.SchemaServiceTSE
 import org.neo4j.spark.testsupport.SparkConnectorScalaSuiteIT
 
-@RunWith(classOf[Suite])
-@Suite.SuiteClasses(Array(
+@Suite
+@SelectClasses(Array(
   classOf[SchemaServiceTSE]
 ))
 class CommonTestSuiteIT extends SparkConnectorScalaSuiteIT {}

--- a/src/test/scala/org/neo4j/spark/CommonTestSuiteWithApocIT.scala
+++ b/src/test/scala/org/neo4j/spark/CommonTestSuiteWithApocIT.scala
@@ -16,13 +16,13 @@
  */
 package org.neo4j.spark
 
-import org.junit.runner.RunWith
-import org.junit.runners.Suite
+import org.junit.platform.suite.api.SelectClasses
+import org.junit.platform.suite.api.Suite
 import org.neo4j.spark.service.SchemaServiceWithApocTSE
 import org.neo4j.spark.testsupport.SparkConnectorScalaSuiteWithApocIT
 
-@RunWith(classOf[Suite])
-@Suite.SuiteClasses(Array(
+@Suite
+@SelectClasses(Array(
   classOf[SchemaServiceWithApocTSE]
 ))
 class CommonTestSuiteWithApocIT extends SparkConnectorScalaSuiteWithApocIT {}

--- a/src/test/scala/org/neo4j/spark/DataSourceAggregationTSE.scala
+++ b/src/test/scala/org/neo4j/spark/DataSourceAggregationTSE.scala
@@ -17,7 +17,7 @@
 package org.neo4j.spark
 
 import org.junit.Assert.assertEquals
-import org.junit.Test
+import org.junit.jupiter.api.Test
 import org.neo4j.driver.TransactionContext
 import org.neo4j.spark.testsupport.SparkConnectorScalaBaseTSE
 import org.neo4j.spark.testsupport.SparkConnectorScalaSuiteIT

--- a/src/test/scala/org/neo4j/spark/DataSourceReaderNeo4jTSE.scala
+++ b/src/test/scala/org/neo4j/spark/DataSourceReaderNeo4jTSE.scala
@@ -18,9 +18,10 @@ package org.neo4j.spark
 
 import org.apache.spark.SparkException
 import org.apache.spark.sql.DataFrame
-import org.junit.Assert.assertEquals
-import org.junit.Assert.assertTrue
-import org.junit.Test
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.Assertions.fail
+import org.junit.jupiter.api.Test
 import org.neo4j.driver.SessionConfig
 import org.neo4j.driver.TransactionContext
 import org.neo4j.driver.exceptions.ClientException

--- a/src/test/scala/org/neo4j/spark/DataSourceReaderNeo4jWithApocTSE.scala
+++ b/src/test/scala/org/neo4j/spark/DataSourceReaderNeo4jWithApocTSE.scala
@@ -17,7 +17,7 @@
 package org.neo4j.spark
 
 import org.junit.Assert.assertEquals
-import org.junit.Test
+import org.junit.jupiter.api.Test
 import org.neo4j.driver.SessionConfig
 import org.neo4j.driver.TransactionContext
 import org.neo4j.spark.testsupport.SparkConnectorScalaBaseWithApocTSE

--- a/src/test/scala/org/neo4j/spark/DataSourceReaderTSE.scala
+++ b/src/test/scala/org/neo4j/spark/DataSourceReaderTSE.scala
@@ -23,8 +23,8 @@ import org.apache.spark.sql.functions.col
 import org.apache.spark.sql.types.DataTypes
 import org.apache.spark.sql.types.StructField
 import org.apache.spark.sql.types.StructType
-import org.junit.Assert._
-import org.junit.Test
+import org.junit.jupiter.api.Assertions._
+import org.junit.jupiter.api.Test
 import org.neo4j.driver.TransactionContext
 import org.neo4j.spark.testsupport.SparkConnectorScalaBaseTSE
 import org.neo4j.spark.testsupport.SparkConnectorScalaSuiteIT

--- a/src/test/scala/org/neo4j/spark/DataSourceReaderWithApocTSE.scala
+++ b/src/test/scala/org/neo4j/spark/DataSourceReaderWithApocTSE.scala
@@ -18,8 +18,8 @@ package org.neo4j.spark
 
 import org.apache.spark.sql.DataFrame
 import org.apache.spark.sql.catalyst.expressions.GenericRowWithSchema
-import org.junit.Assert._
-import org.junit.Test
+import org.junit.jupiter.api.Assertions._
+import org.junit.jupiter.api.Test
 import org.neo4j.driver.TransactionContext
 import org.neo4j.spark.testsupport.SparkConnectorScalaBaseWithApocTSE
 import org.neo4j.spark.testsupport.SparkConnectorScalaSuiteWithApocIT

--- a/src/test/scala/org/neo4j/spark/DataSourceSchemaWriterTSE.scala
+++ b/src/test/scala/org/neo4j/spark/DataSourceSchemaWriterTSE.scala
@@ -23,9 +23,10 @@ import org.apache.spark.sql.types.DataTypes
 import org.apache.spark.sql.types.StructField
 import org.apache.spark.sql.types.StructType
 import org.junit.Assert.assertEquals
-import org.junit.Assume
-import org.junit.BeforeClass
-import org.junit.Test
+import org.junit.jupiter.api.Assumptions.assumeTrue
+import org.junit.jupiter.api.BeforeAll
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
 import org.neo4j.spark.testsupport.SparkConnectorScalaBaseTSE
 import org.neo4j.spark.testsupport.SparkConnectorScalaSuiteIT
 import org.neo4j.spark.testsupport.TestUtil
@@ -45,9 +46,9 @@ import scala.math.Ordering.Implicits.infixOrderingOps
 
 object DataSourceSchemaWriterTSE {
 
-  @BeforeClass
+  @BeforeAll
   def checkNeo4jVersion() {
-    Assume.assumeTrue(TestUtil.neo4jVersion(SparkConnectorScalaSuiteIT.session()) >= Versions.NEO4J_5_13)
+    assumeTrue(TestUtil.neo4jVersion(SparkConnectorScalaSuiteIT.session()) >= Versions.NEO4J_5_13)
   }
 }
 

--- a/src/test/scala/org/neo4j/spark/DataSourceStreamingReaderTSE.scala
+++ b/src/test/scala/org/neo4j/spark/DataSourceStreamingReaderTSE.scala
@@ -36,9 +36,6 @@ import java.util.concurrent.TimeUnit
 
 class DataSourceStreamingReaderTSE extends SparkConnectorScalaBaseTSE {
 
-//  @(Rule @getter)
-//  val folder: TemporaryFolder = new TemporaryFolder()
-
   @TempDir
   var folder: Path = _
 

--- a/src/test/scala/org/neo4j/spark/DataSourceStreamingReaderTSE.scala
+++ b/src/test/scala/org/neo4j/spark/DataSourceStreamingReaderTSE.scala
@@ -152,11 +152,11 @@ class DataSourceStreamingReaderTSE extends SparkConnectorScalaBaseTSE {
       )
     )
 
-    val checkpoint = Files.createTempDirectory(folder, "checkpoint")
+    val checkpoint = Files.createTempDirectory(folder, "checkpoint").toAbsolutePath.toString
 
     stream.writeStream
       .trigger(Trigger.AvailableNow())
-      .option("checkpointLocation", checkpoint.toAbsolutePath.toString)
+      .option("checkpointLocation", checkpoint)
       .toTable("readStreamWithLabelsCheckpoint")
       .awaitTermination()
 
@@ -167,7 +167,7 @@ class DataSourceStreamingReaderTSE extends SparkConnectorScalaBaseTSE {
     // fetch whatever is available
     stream.writeStream
       .trigger(Trigger.AvailableNow())
-      .option("checkpointLocation", checkpoint.toAbsolutePath.toString)
+      .option("checkpointLocation", checkpoint)
       .toTable("readStreamWithLabelsCheckpoint")
       .awaitTermination()
 
@@ -177,7 +177,7 @@ class DataSourceStreamingReaderTSE extends SparkConnectorScalaBaseTSE {
     // fetch rest of the items from where we left off
     stream.writeStream
       .trigger(Trigger.AvailableNow())
-      .option("checkpointLocation", checkpoint.toAbsolutePath.toString)
+      .option("checkpointLocation", checkpoint)
       .toTable("readStreamWithLabelsCheckpoint")
       .awaitTermination()
 

--- a/src/test/scala/org/neo4j/spark/DataSourceStreamingReaderTSE.scala
+++ b/src/test/scala/org/neo4j/spark/DataSourceStreamingReaderTSE.scala
@@ -20,29 +20,31 @@ import org.apache.spark.sql.Row
 import org.apache.spark.sql.streaming.StreamingQuery
 import org.apache.spark.sql.streaming.Trigger
 import org.hamcrest.Matchers
-import org.junit.After
-import org.junit.Assert.assertEquals
-import org.junit.Rule
-import org.junit.Test
-import org.junit.rules.TemporaryFolder
+import org.junit.jupiter.api.AfterEach
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.io.TempDir
 import org.neo4j.spark.testsupport.Assert
 import org.neo4j.spark.testsupport.Closeables.use
 import org.neo4j.spark.testsupport.SparkConnectorScalaBaseTSE
 import org.neo4j.spark.testsupport.SparkConnectorScalaSuiteIT
 
+import java.nio.file.Files
+import java.nio.file.Path
 import java.util.concurrent.Executors
 import java.util.concurrent.TimeUnit
 
-import scala.annotation.meta.getter
-
 class DataSourceStreamingReaderTSE extends SparkConnectorScalaBaseTSE {
 
-  @(Rule @getter)
-  val folder: TemporaryFolder = new TemporaryFolder()
+//  @(Rule @getter)
+//  val folder: TemporaryFolder = new TemporaryFolder()
+
+  @TempDir
+  var folder: Path = _
 
   private var query: StreamingQuery = _
 
-  @After
+  @AfterEach
   def close(): Unit = {
     if (query != null) {
       query.stop()
@@ -153,11 +155,11 @@ class DataSourceStreamingReaderTSE extends SparkConnectorScalaBaseTSE {
       )
     )
 
-    val checkpoint = folder.newFolder()
+    val checkpoint = Files.createTempDirectory(folder, "checkpoint")
 
     stream.writeStream
       .trigger(Trigger.AvailableNow())
-      .option("checkpointLocation", checkpoint.getAbsolutePath)
+      .option("checkpointLocation", checkpoint.toAbsolutePath.toString)
       .toTable("readStreamWithLabelsCheckpoint")
       .awaitTermination()
 
@@ -168,7 +170,7 @@ class DataSourceStreamingReaderTSE extends SparkConnectorScalaBaseTSE {
     // fetch whatever is available
     stream.writeStream
       .trigger(Trigger.AvailableNow())
-      .option("checkpointLocation", checkpoint.getAbsolutePath)
+      .option("checkpointLocation", checkpoint.toAbsolutePath.toString)
       .toTable("readStreamWithLabelsCheckpoint")
       .awaitTermination()
 
@@ -178,7 +180,7 @@ class DataSourceStreamingReaderTSE extends SparkConnectorScalaBaseTSE {
     // fetch rest of the items from where we left off
     stream.writeStream
       .trigger(Trigger.AvailableNow())
-      .option("checkpointLocation", checkpoint.getAbsolutePath)
+      .option("checkpointLocation", checkpoint.toAbsolutePath.toString)
       .toTable("readStreamWithLabelsCheckpoint")
       .awaitTermination()
 
@@ -310,11 +312,11 @@ class DataSourceStreamingReaderTSE extends SparkConnectorScalaBaseTSE {
       )
     )
 
-    val checkpoint = folder.newFolder()
+    val checkpoint = Files.createTempDirectory(folder, "checkpoint")
 
     stream.writeStream
       .trigger(Trigger.AvailableNow())
-      .option("checkpointLocation", checkpoint.getAbsolutePath)
+      .option("checkpointLocation", checkpoint.toAbsolutePath.toString)
       .toTable("readStreamWithRelationshipCheckpoint")
       .awaitTermination()
 
@@ -325,7 +327,7 @@ class DataSourceStreamingReaderTSE extends SparkConnectorScalaBaseTSE {
     // fetch whatever is available
     stream.writeStream
       .trigger(Trigger.AvailableNow())
-      .option("checkpointLocation", checkpoint.getAbsolutePath)
+      .option("checkpointLocation", checkpoint.toAbsolutePath.toString)
       .toTable("readStreamWithRelationshipCheckpoint")
       .awaitTermination()
 
@@ -335,7 +337,7 @@ class DataSourceStreamingReaderTSE extends SparkConnectorScalaBaseTSE {
     // fetch rest of the items from where we left off
     stream.writeStream
       .trigger(Trigger.AvailableNow())
-      .option("checkpointLocation", checkpoint.getAbsolutePath)
+      .option("checkpointLocation", checkpoint.toAbsolutePath.toString)
       .toTable("readStreamWithRelationshipCheckpoint")
       .awaitTermination()
 
@@ -487,11 +489,11 @@ class DataSourceStreamingReaderTSE extends SparkConnectorScalaBaseTSE {
       )
     ).toList
 
-    val checkpoint = folder.newFolder()
+    val checkpoint = Files.createTempDirectory(folder, "checkpoint")
 
     stream.writeStream
       .trigger(Trigger.AvailableNow())
-      .option("checkpointLocation", checkpoint.getAbsolutePath)
+      .option("checkpointLocation", checkpoint.toAbsolutePath.toString)
       .toTable("readStreamWithQueryCheckpoint")
       .awaitTermination()
 
@@ -502,7 +504,7 @@ class DataSourceStreamingReaderTSE extends SparkConnectorScalaBaseTSE {
     // fetch whatever is available
     stream.writeStream
       .trigger(Trigger.AvailableNow())
-      .option("checkpointLocation", checkpoint.getAbsolutePath)
+      .option("checkpointLocation", checkpoint.toAbsolutePath.toString)
       .toTable("readStreamWithQueryCheckpoint")
       .awaitTermination()
 
@@ -512,7 +514,7 @@ class DataSourceStreamingReaderTSE extends SparkConnectorScalaBaseTSE {
     // fetch rest of the items from where we left off
     stream.writeStream
       .trigger(Trigger.AvailableNow())
-      .option("checkpointLocation", checkpoint.getAbsolutePath)
+      .option("checkpointLocation", checkpoint.toAbsolutePath.toString)
       .toTable("readStreamWithQueryCheckpoint")
       .awaitTermination()
 
@@ -554,11 +556,11 @@ class DataSourceStreamingReaderTSE extends SparkConnectorScalaBaseTSE {
       )
     ).toList
 
-    val checkpoint = folder.newFolder()
+    val checkpoint = Files.createTempDirectory(folder, "checkpoint")
 
     stream.writeStream
       .trigger(Trigger.AvailableNow())
-      .option("checkpointLocation", checkpoint.getAbsolutePath)
+      .option("checkpointLocation", checkpoint.toAbsolutePath.toString)
       .toTable("readStreamWithQueryCheckpointNewParams")
       .awaitTermination()
 
@@ -569,7 +571,7 @@ class DataSourceStreamingReaderTSE extends SparkConnectorScalaBaseTSE {
     // fetch whatever is available
     stream.writeStream
       .trigger(Trigger.AvailableNow())
-      .option("checkpointLocation", checkpoint.getAbsolutePath)
+      .option("checkpointLocation", checkpoint.toAbsolutePath.toString)
       .toTable("readStreamWithQueryCheckpointNewParams")
       .awaitTermination()
 
@@ -579,7 +581,7 @@ class DataSourceStreamingReaderTSE extends SparkConnectorScalaBaseTSE {
     // fetch rest of the items from where we left off
     stream.writeStream
       .trigger(Trigger.AvailableNow())
-      .option("checkpointLocation", checkpoint.getAbsolutePath)
+      .option("checkpointLocation", checkpoint.toAbsolutePath.toString)
       .toTable("readStreamWithQueryCheckpointNewParams")
       .awaitTermination()
 

--- a/src/test/scala/org/neo4j/spark/DataSourceStreamingReaderTSE.scala
+++ b/src/test/scala/org/neo4j/spark/DataSourceStreamingReaderTSE.scala
@@ -19,7 +19,6 @@ package org.neo4j.spark
 import org.apache.spark.sql.Row
 import org.apache.spark.sql.streaming.StreamingQuery
 import org.apache.spark.sql.streaming.Trigger
-import org.hamcrest.Matchers
 import org.junit.jupiter.api.AfterEach
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Test
@@ -80,12 +79,10 @@ class DataSourceStreamingReaderTSE extends SparkConnectorScalaBaseTSE {
     })
 
     Assert.assertEventually(
-      new Assert.ThrowingSupplier[Seq[Map[String, Any]], Exception] {
-        override def get(): Seq[Map[String, Any]] = {
-          selectRowsFromTable("select * from readStreamWithLabels order by timestamp", mapMovie)
-        }
+      expected,
+      () => {
+        selectRowsFromTable("select * from readStreamWithLabels order by timestamp", mapMovie)
       },
-      Matchers.equalTo(expected),
       30L,
       TimeUnit.SECONDS
     )
@@ -122,12 +119,10 @@ class DataSourceStreamingReaderTSE extends SparkConnectorScalaBaseTSE {
     )
 
     Assert.assertEventually(
-      new Assert.ThrowingSupplier[Seq[Map[String, Any]], Exception] {
-        override def get(): Seq[Map[String, Any]] = {
-          selectRowsFromTable("select * from readStreamWithLabelsAll order by timestamp", mapMovie)
-        }
+      expected,
+      () => {
+        selectRowsFromTable("select * from readStreamWithLabelsAll order by timestamp", mapMovie)
       },
-      Matchers.equalTo(expected),
       30L,
       TimeUnit.SECONDS
     )
@@ -225,12 +220,10 @@ class DataSourceStreamingReaderTSE extends SparkConnectorScalaBaseTSE {
     })
 
     Assert.assertEventually(
-      new Assert.ThrowingSupplier[Seq[Map[String, Any]], Exception] {
-        override def get(): Seq[Map[String, Any]] = {
-          selectRowsFromTable("select * from readStreamWithRelationship order by `rel.timestamp`", mapLikes)
-        }
+      expected,
+      () => {
+        selectRowsFromTable("select * from readStreamWithRelationship order by `rel.timestamp`", mapLikes)
       },
-      Matchers.equalTo(expected),
       30L,
       TimeUnit.SECONDS
     )
@@ -273,12 +266,10 @@ class DataSourceStreamingReaderTSE extends SparkConnectorScalaBaseTSE {
     })
 
     Assert.assertEventually(
-      new Assert.ThrowingSupplier[Seq[Map[String, Any]], Exception] {
-        override def get(): Seq[Map[String, Any]] = {
-          selectRowsFromTable("select * from readStreamWithRelationshipAll order by `rel.timestamp`", mapLikes)
-        }
+      expected,
+      () => {
+        selectRowsFromTable("select * from readStreamWithRelationshipAll order by `rel.timestamp`", mapLikes)
       },
-      Matchers.equalTo(expected),
       30L,
       TimeUnit.SECONDS
     )
@@ -388,12 +379,10 @@ class DataSourceStreamingReaderTSE extends SparkConnectorScalaBaseTSE {
     })
 
     Assert.assertEventually(
-      new Assert.ThrowingSupplier[Seq[Map[String, Any]], Exception] {
-        override def get(): Seq[Map[String, Any]] = {
-          selectRowsFromTable("select * from readStreamWithQuery order by timestamp", mapPerson)
-        }
+      expected,
+      () => {
+        selectRowsFromTable("select * from readStreamWithQuery order by timestamp", mapPerson)
       },
-      Matchers.equalTo(expected),
       30L,
       TimeUnit.SECONDS
     )
@@ -443,12 +432,10 @@ class DataSourceStreamingReaderTSE extends SparkConnectorScalaBaseTSE {
     })
 
     Assert.assertEventually(
-      new Assert.ThrowingSupplier[Seq[Map[String, Any]], Exception] {
-        override def get(): Seq[Map[String, Any]] = {
-          selectRowsFromTable("select * from readStreamWithQueryAll order by timestamp", mapPerson)
-        }
+      expected,
+      () => {
+        selectRowsFromTable("select * from readStreamWithQueryAll order by timestamp", mapPerson)
       },
-      Matchers.equalTo(expected),
       30L,
       TimeUnit.SECONDS
     )

--- a/src/test/scala/org/neo4j/spark/DataSourceStreamingWriterTSE.scala
+++ b/src/test/scala/org/neo4j/spark/DataSourceStreamingWriterTSE.scala
@@ -18,11 +18,9 @@ package org.neo4j.spark
 
 import org.apache.spark.sql.execution.streaming.MemoryStream
 import org.apache.spark.sql.streaming.StreamingQuery
-import org.hamcrest.Matchers
 import org.junit.jupiter.api.AfterEach
 import org.junit.jupiter.api.Test
 import org.neo4j.spark.testsupport.Assert
-import org.neo4j.spark.testsupport.Assert.ThrowingSupplier
 import org.neo4j.spark.testsupport.SparkConnectorScalaBaseTSE
 import org.neo4j.spark.testsupport.SparkConnectorScalaSuiteIT
 
@@ -65,25 +63,23 @@ class DataSourceStreamingWriterTSE extends SparkConnectorScalaBaseTSE {
     })
 
     Assert.assertEventually(
-      new ThrowingSupplier[Boolean, Exception] {
-        override def get(): Boolean = {
-          val dataFrame = ss.read.format(classOf[DataSource].getName)
-            .option("url", SparkConnectorScalaSuiteIT.server.getBoltUrl)
-            .option("labels", "Timestamp")
-            .load()
+      true,
+      () => {
+        val dataFrame = ss.read.format(classOf[DataSource].getName)
+          .option("url", SparkConnectorScalaSuiteIT.server.getBoltUrl)
+          .option("labels", "Timestamp")
+          .load()
 
-          val collect = dataFrame.collect()
-          val data = if (dataFrame.columns.contains("value")) {
-            collect
-              .map(row => row.getAs[Long]("value").toInt)
-              .sorted
-          } else {
-            Array.empty[Int]
-          }
-          data.toList == (1 to (recordSize * partition)).toList
+        val collect = dataFrame.collect()
+        val data = if (dataFrame.columns.contains("value")) {
+          collect
+            .map(row => row.getAs[Long]("value").toInt)
+            .sorted
+        } else {
+          Array.empty[Int]
         }
+        data.toList == (1 to (recordSize * partition)).toList
       },
-      Matchers.equalTo(true),
       30L,
       TimeUnit.SECONDS
     )
@@ -121,30 +117,28 @@ class DataSourceStreamingWriterTSE extends SparkConnectorScalaBaseTSE {
     })
 
     Assert.assertEventually(
-      new ThrowingSupplier[Boolean, Exception] {
-        override def get(): Boolean =
-          try {
-            val dataFrame = ss.read.format(classOf[DataSource].getName)
-              .option("url", SparkConnectorScalaSuiteIT.server.getBoltUrl)
-              .option("relationship", "PAIRS")
-              .option("relationship.source.labels", ":From")
-              .option("relationship.target.labels", ":To")
-              .load()
+      true,
+      () =>
+        try {
+          val dataFrame = ss.read.format(classOf[DataSource].getName)
+            .option("url", SparkConnectorScalaSuiteIT.server.getBoltUrl)
+            .option("relationship", "PAIRS")
+            .option("relationship.source.labels", ":From")
+            .option("relationship.target.labels", ":To")
+            .load()
 
-            val collect = dataFrame.collect()
-            val data = if (dataFrame.columns.contains("source.value") && dataFrame.columns.contains("target.value")) {
-              collect
-                .map(row => (row.getAs[Long]("source.value").toInt, row.getAs[Long]("target.value").toInt))
-                .sorted
-            } else {
-              Array.empty[(Int, Int)]
-            }
-            data.toList == (1 to (recordSize * partition)).map(v => (v, v)).toList
-          } catch {
-            case _: Throwable => false
+          val collect = dataFrame.collect()
+          val data = if (dataFrame.columns.contains("source.value") && dataFrame.columns.contains("target.value")) {
+            collect
+              .map(row => (row.getAs[Long]("source.value").toInt, row.getAs[Long]("target.value").toInt))
+              .sorted
+          } else {
+            Array.empty[(Int, Int)]
           }
-      },
-      Matchers.equalTo(true),
+          data.toList == (1 to (recordSize * partition)).map(v => (v, v)).toList
+        } catch {
+          case _: Throwable => false
+        },
       30L,
       TimeUnit.SECONDS
     )
@@ -174,30 +168,28 @@ class DataSourceStreamingWriterTSE extends SparkConnectorScalaBaseTSE {
     })
 
     Assert.assertEventually(
-      new ThrowingSupplier[Boolean, Exception] {
-        override def get(): Boolean =
-          try {
-            val dataFrame = ss.read.format(classOf[DataSource].getName)
-              .option("url", SparkConnectorScalaSuiteIT.server.getBoltUrl)
-              .option("labels", "MyNewNode")
-              .load()
+      true,
+      () =>
+        try {
+          val dataFrame = ss.read.format(classOf[DataSource].getName)
+            .option("url", SparkConnectorScalaSuiteIT.server.getBoltUrl)
+            .option("labels", "MyNewNode")
+            .load()
 
-            val collect = dataFrame.collect()
-            val data = if (dataFrame.columns.contains("the_value")) {
-              collect
-                .map(row => row.getAs[Long]("the_value").toInt)
-                .sorted
-            } else {
-              Array.empty[Int]
-            }
-            val l1 = data.toList
-            val l2 = (1 to (recordSize * partition)).map(v => v).toList
-            l1 == l2
-          } catch {
-            case _: Throwable => false
+          val collect = dataFrame.collect()
+          val data = if (dataFrame.columns.contains("the_value")) {
+            collect
+              .map(row => row.getAs[Long]("the_value").toInt)
+              .sorted
+          } else {
+            Array.empty[Int]
           }
-      },
-      Matchers.equalTo(true),
+          val l1 = data.toList
+          val l2 = (1 to (recordSize * partition)).map(v => v).toList
+          l1 == l2
+        } catch {
+          case _: Throwable => false
+        },
       30L,
       TimeUnit.SECONDS
     )
@@ -228,25 +220,23 @@ class DataSourceStreamingWriterTSE extends SparkConnectorScalaBaseTSE {
     })
 
     Assert.assertEventually(
-      new ThrowingSupplier[Boolean, Exception] {
-        override def get(): Boolean = {
-          val dataFrame = ss.read.format(classOf[DataSource].getName)
-            .option("url", SparkConnectorScalaSuiteIT.server.getBoltUrl)
-            .option("labels", "Timestamp")
-            .load()
+      true,
+      () => {
+        val dataFrame = ss.read.format(classOf[DataSource].getName)
+          .option("url", SparkConnectorScalaSuiteIT.server.getBoltUrl)
+          .option("labels", "Timestamp")
+          .load()
 
-          val collect = dataFrame.collect()
-          val data = if (dataFrame.columns.contains("value")) {
-            collect
-              .map(row => row.getAs[Long]("value").toInt)
-              .sorted
-          } else {
-            Array.empty[Int]
-          }
-          data.toList == (1 to 500).toList
+        val collect = dataFrame.collect()
+        val data = if (dataFrame.columns.contains("value")) {
+          collect
+            .map(row => row.getAs[Long]("value").toInt)
+            .sorted
+        } else {
+          Array.empty[Int]
         }
+        data.toList == (1 to 500).toList
       },
-      Matchers.equalTo(true),
       30L,
       TimeUnit.SECONDS
     )
@@ -288,30 +278,28 @@ class DataSourceStreamingWriterTSE extends SparkConnectorScalaBaseTSE {
     })
 
     Assert.assertEventually(
-      new ThrowingSupplier[Boolean, Exception] {
-        override def get(): Boolean =
-          try {
-            val dataFrame = ss.read.format(classOf[DataSource].getName)
-              .option("url", SparkConnectorScalaSuiteIT.server.getBoltUrl)
-              .option("relationship", "PAIRS")
-              .option("relationship.source.labels", ":From")
-              .option("relationship.target.labels", ":To")
-              .load()
+      true,
+      () =>
+        try {
+          val dataFrame = ss.read.format(classOf[DataSource].getName)
+            .option("url", SparkConnectorScalaSuiteIT.server.getBoltUrl)
+            .option("relationship", "PAIRS")
+            .option("relationship.source.labels", ":From")
+            .option("relationship.target.labels", ":To")
+            .load()
 
-            val collect = dataFrame.collect()
-            val data = if (dataFrame.columns.contains("source.value") && dataFrame.columns.contains("target.value")) {
-              collect
-                .map(row => (row.getAs[Long]("source.value").toInt, row.getAs[Long]("target.value").toInt))
-                .sorted
-            } else {
-              Array.empty[(Int, Int)]
-            }
-            data.toList == (1 to 500).flatMap(v => (1 to 5).map(_ => (v, v)))
-          } catch {
-            case _: Throwable => false
+          val collect = dataFrame.collect()
+          val data = if (dataFrame.columns.contains("source.value") && dataFrame.columns.contains("target.value")) {
+            collect
+              .map(row => (row.getAs[Long]("source.value").toInt, row.getAs[Long]("target.value").toInt))
+              .sorted
+          } else {
+            Array.empty[(Int, Int)]
           }
-      },
-      Matchers.equalTo(true),
+          data.toList == (1 to 500).flatMap(v => (1 to 5).map(_ => (v, v)))
+        } catch {
+          case _: Throwable => false
+        },
       30L,
       TimeUnit.SECONDS
     )

--- a/src/test/scala/org/neo4j/spark/DataSourceStreamingWriterTSE.scala
+++ b/src/test/scala/org/neo4j/spark/DataSourceStreamingWriterTSE.scala
@@ -19,8 +19,8 @@ package org.neo4j.spark
 import org.apache.spark.sql.execution.streaming.MemoryStream
 import org.apache.spark.sql.streaming.StreamingQuery
 import org.hamcrest.Matchers
-import org.junit.After
-import org.junit.Test
+import org.junit.jupiter.api.AfterEach
+import org.junit.jupiter.api.Test
 import org.neo4j.spark.testsupport.Assert
 import org.neo4j.spark.testsupport.Assert.ThrowingSupplier
 import org.neo4j.spark.testsupport.SparkConnectorScalaBaseTSE
@@ -33,7 +33,7 @@ class DataSourceStreamingWriterTSE extends SparkConnectorScalaBaseTSE {
 
   private var query: StreamingQuery = null
 
-  @After
+  @AfterEach
   def close(): Unit = {
     if (query != null) {
       query.stop()

--- a/src/test/scala/org/neo4j/spark/DataSourceWriterNeo4jSkipNullKeysTSE.scala
+++ b/src/test/scala/org/neo4j/spark/DataSourceWriterNeo4jSkipNullKeysTSE.scala
@@ -18,6 +18,7 @@ package org.neo4j.spark
 
 import org.apache.spark.SparkException
 import org.apache.spark.sql.SaveMode
+import org.junit.Assert.assertThrows
 import org.junit.Assume
 import org.junit.Test
 import org.neo4j.caniuse.CanIUse
@@ -39,72 +40,81 @@ class DataSourceWriterNeo4jSkipNullKeysTSE extends SparkConnectorScalaBaseTSE {
       (None, "Moon")
     ).toDF("id", "city")
 
-    val caught = intercept[SparkException] {
-      cities.write
-        .format(classOf[DataSource].getName)
-        .mode(SaveMode.Overwrite)
-        .option("url", SparkConnectorScalaSuiteIT.server.getBoltUrl)
-        .option("labels", ":City")
-        .option("node.keys", "id")
-        .option("schema.optimization.node.keys", "KEY")
-        .save()
-    }
+    val caught = org.junit.Assert.assertThrows(
+      classOf[SparkException],
+      () => {
+        cities.write
+          .format(classOf[DataSource].getName)
+          .mode(SaveMode.Overwrite)
+          .option("url", SparkConnectorScalaSuiteIT.server.getBoltUrl)
+          .option("labels", ":City")
+          .option("node.keys", "id")
+          .option("schema.optimization.node.keys", "KEY")
+          .save()
+      }
+    )
     assert(caught.getMessage contains "Cannot merge the following node because of null property value")
   }
 
   @Test
   def `fails to write relationships when source node key properties contain null values`(): Unit = {
-    val caught = intercept[SparkException] {
-      val cities = Seq(
-        (Some(1), Some(2), "British Airways"),
-        (Some(2), Some(3), "Turkish Airlines"),
-        (None, Some(5), "Another Airline")
-      ).toDF("from", "to", "airline")
+    val caught = org.junit.Assert.assertThrows(
+      classOf[SparkException],
+      () => {
+        val cities = Seq(
+          (Some(1), Some(2), "British Airways"),
+          (Some(2), Some(3), "Turkish Airlines"),
+          (None, Some(5), "Another Airline")
+        ).toDF("from", "to", "airline")
 
-      cities.write
-        .format(classOf[DataSource].getName)
-        .mode(SaveMode.Overwrite)
-        .option("url", SparkConnectorScalaSuiteIT.server.getBoltUrl)
-        .option("relationship", "FLIES_TO")
-        .option("relationship.save.strategy", "keys")
-        .option("relationship.source.save.mode", "Overwrite")
-        .option("relationship.source.labels", ":City")
-        .option("relationship.source.node.keys", "from:id")
-        .option("relationship.target.save.mode", "Overwrite")
-        .option("relationship.target.labels", ":City")
-        .option("relationship.target.node.keys", "to:id")
-        .option("relationship.properties", "airline")
-        .option("schema.optimization.node.keys", "KEY")
-        .save()
-    }
+        cities.write
+          .format(classOf[DataSource].getName)
+          .mode(SaveMode.Overwrite)
+          .option("url", SparkConnectorScalaSuiteIT.server.getBoltUrl)
+          .option("relationship", "FLIES_TO")
+          .option("relationship.save.strategy", "keys")
+          .option("relationship.source.save.mode", "Overwrite")
+          .option("relationship.source.labels", ":City")
+          .option("relationship.source.node.keys", "from:id")
+          .option("relationship.target.save.mode", "Overwrite")
+          .option("relationship.target.labels", ":City")
+          .option("relationship.target.node.keys", "to:id")
+          .option("relationship.properties", "airline")
+          .option("schema.optimization.node.keys", "KEY")
+          .save()
+      }
+    )
     assert(caught.getMessage contains "Cannot merge the following node because of null property value")
   }
 
   @Test
   def `fails to write relationships when target node key properties contain null values`(): Unit = {
-    val caught = intercept[SparkException] {
-      val cities = Seq(
-        (Some(1), Some(2), "British Airways"),
-        (Some(2), Some(3), "Turkish Airlines"),
-        (Some(3), None, "Another Airline")
-      ).toDF("from", "to", "airline")
+    val caught = org.junit.Assert.assertThrows(
+      classOf[SparkException],
+      () => {
+        val cities = Seq(
+          (Some(1), Some(2), "British Airways"),
+          (Some(2), Some(3), "Turkish Airlines"),
+          (Some(3), None, "Another Airline")
+        ).toDF("from", "to", "airline")
 
-      cities.write
-        .format(classOf[DataSource].getName)
-        .mode(SaveMode.Overwrite)
-        .option("url", SparkConnectorScalaSuiteIT.server.getBoltUrl)
-        .option("relationship", "FLIES_TO")
-        .option("relationship.save.strategy", "keys")
-        .option("relationship.source.save.mode", "Overwrite")
-        .option("relationship.source.labels", ":City")
-        .option("relationship.source.node.keys", "from:id")
-        .option("relationship.target.save.mode", "Overwrite")
-        .option("relationship.target.labels", ":City")
-        .option("relationship.target.node.keys", "to:id")
-        .option("relationship.properties", "airline")
-        .option("schema.optimization.node.keys", "KEY")
-        .save()
-    }
+        cities.write
+          .format(classOf[DataSource].getName)
+          .mode(SaveMode.Overwrite)
+          .option("url", SparkConnectorScalaSuiteIT.server.getBoltUrl)
+          .option("relationship", "FLIES_TO")
+          .option("relationship.save.strategy", "keys")
+          .option("relationship.source.save.mode", "Overwrite")
+          .option("relationship.source.labels", ":City")
+          .option("relationship.source.node.keys", "from:id")
+          .option("relationship.target.save.mode", "Overwrite")
+          .option("relationship.target.labels", ":City")
+          .option("relationship.target.node.keys", "to:id")
+          .option("relationship.properties", "airline")
+          .option("schema.optimization.node.keys", "KEY")
+          .save()
+      }
+    )
     assert(caught.getMessage contains "Cannot merge the following node because of null property value")
   }
 
@@ -114,31 +124,34 @@ class DataSourceWriterNeo4jSkipNullKeysTSE extends SparkConnectorScalaBaseTSE {
       CanIUse.INSTANCE.canIUse(Schema.INSTANCE.relationshipKeyConstraints()).withNeo4j(SparkConnectorScalaSuiteIT.neo4j)
     )
 
-    val caught = intercept[SparkException] {
-      val cities = Seq(
-        (Some(1), Some(2), Some("BA721"), "British Airways"),
-        (Some(2), Some(3), Some("TK211"), "Turkish Airlines"),
-        (Some(3), Some(4), None, "Another Airline")
-      ).toDF("from", "to", "flight", "airline")
+    val caught = org.junit.Assert.assertThrows(
+      classOf[SparkException],
+      () => {
+        val cities = Seq(
+          (Some(1), Some(2), Some("BA721"), "British Airways"),
+          (Some(2), Some(3), Some("TK211"), "Turkish Airlines"),
+          (Some(3), Some(4), None, "Another Airline")
+        ).toDF("from", "to", "flight", "airline")
 
-      cities.write
-        .format(classOf[DataSource].getName)
-        .mode(SaveMode.Overwrite)
-        .option("url", SparkConnectorScalaSuiteIT.server.getBoltUrl)
-        .option("relationship", "FLIES_TO")
-        .option("relationship.save.strategy", "keys")
-        .option("relationship.source.save.mode", "Overwrite")
-        .option("relationship.source.labels", ":City")
-        .option("relationship.source.node.keys", "from:id")
-        .option("relationship.target.save.mode", "Overwrite")
-        .option("relationship.target.labels", ":City")
-        .option("relationship.target.node.keys", "to:id")
-        .option("relationship.keys", "flight")
-        .option("relationship.properties", "airline")
-        .option("schema.optimization.node.keys", "KEY")
-        .option("schema.optimization.relationship.keys", "KEY")
-        .save()
-    }
+        cities.write
+          .format(classOf[DataSource].getName)
+          .mode(SaveMode.Overwrite)
+          .option("url", SparkConnectorScalaSuiteIT.server.getBoltUrl)
+          .option("relationship", "FLIES_TO")
+          .option("relationship.save.strategy", "keys")
+          .option("relationship.source.save.mode", "Overwrite")
+          .option("relationship.source.labels", ":City")
+          .option("relationship.source.node.keys", "from:id")
+          .option("relationship.target.save.mode", "Overwrite")
+          .option("relationship.target.labels", ":City")
+          .option("relationship.target.node.keys", "to:id")
+          .option("relationship.keys", "flight")
+          .option("relationship.properties", "airline")
+          .option("schema.optimization.node.keys", "KEY")
+          .option("schema.optimization.relationship.keys", "KEY")
+          .save()
+      }
+    )
     assert(caught.getMessage contains "Cannot merge the following relationship because of null property value")
   }
 

--- a/src/test/scala/org/neo4j/spark/DataSourceWriterNeo4jSkipNullKeysTSE.scala
+++ b/src/test/scala/org/neo4j/spark/DataSourceWriterNeo4jSkipNullKeysTSE.scala
@@ -18,9 +18,9 @@ package org.neo4j.spark
 
 import org.apache.spark.SparkException
 import org.apache.spark.sql.SaveMode
+import org.junit.jupiter.api.Assertions.assertThrows
 import org.junit.jupiter.api.Assumptions.assumeTrue
 import org.junit.jupiter.api.Test
-import org.junit.jupiter.api.Assertions.assertThrows
 import org.neo4j.caniuse.CanIUse
 import org.neo4j.caniuse.Schema
 import org.neo4j.spark.testsupport.Closeables.use

--- a/src/test/scala/org/neo4j/spark/DataSourceWriterNeo4jSkipNullKeysTSE.scala
+++ b/src/test/scala/org/neo4j/spark/DataSourceWriterNeo4jSkipNullKeysTSE.scala
@@ -18,9 +18,9 @@ package org.neo4j.spark
 
 import org.apache.spark.SparkException
 import org.apache.spark.sql.SaveMode
-import org.junit.Assert.assertThrows
-import org.junit.Assume
-import org.junit.Test
+import org.junit.jupiter.api.Assumptions.assumeTrue
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.Assertions.assertThrows
 import org.neo4j.caniuse.CanIUse
 import org.neo4j.caniuse.Schema
 import org.neo4j.spark.testsupport.Closeables.use
@@ -40,7 +40,7 @@ class DataSourceWriterNeo4jSkipNullKeysTSE extends SparkConnectorScalaBaseTSE {
       (None, "Moon")
     ).toDF("id", "city")
 
-    val caught = org.junit.Assert.assertThrows(
+    val caught = assertThrows(
       classOf[SparkException],
       () => {
         cities.write
@@ -120,7 +120,7 @@ class DataSourceWriterNeo4jSkipNullKeysTSE extends SparkConnectorScalaBaseTSE {
 
   @Test
   def `fails to write relationships when relationship key properties contain null values`(): Unit = {
-    Assume.assumeTrue(
+    assumeTrue(
       CanIUse.INSTANCE.canIUse(Schema.INSTANCE.relationshipKeyConstraints()).withNeo4j(SparkConnectorScalaSuiteIT.neo4j)
     )
 
@@ -496,7 +496,7 @@ class DataSourceWriterNeo4jSkipNullKeysTSE extends SparkConnectorScalaBaseTSE {
 
   @Test
   def `skips relationships when relationship key properties contain null values`(): Unit = {
-    Assume.assumeTrue(
+    assumeTrue(
       CanIUse.INSTANCE.canIUse(Schema.INSTANCE.relationshipKeyConstraints()).withNeo4j(SparkConnectorScalaSuiteIT.neo4j)
     )
 

--- a/src/test/scala/org/neo4j/spark/DataSourceWriterNeo4jSkipNullKeysTSE.scala
+++ b/src/test/scala/org/neo4j/spark/DataSourceWriterNeo4jSkipNullKeysTSE.scala
@@ -58,7 +58,7 @@ class DataSourceWriterNeo4jSkipNullKeysTSE extends SparkConnectorScalaBaseTSE {
 
   @Test
   def `fails to write relationships when source node key properties contain null values`(): Unit = {
-    val caught = org.junit.Assert.assertThrows(
+    val caught = assertThrows(
       classOf[SparkException],
       () => {
         val cities = Seq(
@@ -89,7 +89,7 @@ class DataSourceWriterNeo4jSkipNullKeysTSE extends SparkConnectorScalaBaseTSE {
 
   @Test
   def `fails to write relationships when target node key properties contain null values`(): Unit = {
-    val caught = org.junit.Assert.assertThrows(
+    val caught = assertThrows(
       classOf[SparkException],
       () => {
         val cities = Seq(
@@ -124,7 +124,7 @@ class DataSourceWriterNeo4jSkipNullKeysTSE extends SparkConnectorScalaBaseTSE {
       CanIUse.INSTANCE.canIUse(Schema.INSTANCE.relationshipKeyConstraints()).withNeo4j(SparkConnectorScalaSuiteIT.neo4j)
     )
 
-    val caught = org.junit.Assert.assertThrows(
+    val caught = assertThrows(
       classOf[SparkException],
       () => {
         val cities = Seq(

--- a/src/test/scala/org/neo4j/spark/DataSourceWriterNeo4jTSE.scala
+++ b/src/test/scala/org/neo4j/spark/DataSourceWriterNeo4jTSE.scala
@@ -22,7 +22,6 @@ import org.apache.spark.scheduler.SparkListenerStageCompleted
 import org.apache.spark.scheduler.SparkListenerStageSubmitted
 import org.apache.spark.sql.DataFrame
 import org.apache.spark.sql.SaveMode
-import org.hamcrest.Matchers
 import org.junit.jupiter.api.Assertions._
 import org.junit.jupiter.api.Test
 import org.neo4j.driver.Session
@@ -586,12 +585,12 @@ class DataSourceWriterNeo4jTSE extends SparkConnectorScalaBaseTSE {
 
       val db1Session = SparkConnectorScalaSuiteIT.driver.session(SessionConfig.forDatabase("db1"))
       Assert.assertEventually(
+        4L,
         () => {
           db1Session.run(
             "MATCH (:Name)-[r:STARTS_WITH]->(:Letter) RETURN count(r) as cnt"
           ).single().get("cnt").asLong()
         },
-        Matchers.equalTo(4L),
         30L,
         TimeUnit.SECONDS
       )

--- a/src/test/scala/org/neo4j/spark/DataSourceWriterNeo4jTSE.scala
+++ b/src/test/scala/org/neo4j/spark/DataSourceWriterNeo4jTSE.scala
@@ -23,10 +23,8 @@ import org.apache.spark.scheduler.SparkListenerStageSubmitted
 import org.apache.spark.sql.DataFrame
 import org.apache.spark.sql.SaveMode
 import org.hamcrest.Matchers
-import org.junit.Assert.assertEquals
-import org.junit.Assert.assertNotNull
-import org.junit.Assert.assertTrue
-import org.junit.Test
+import org.junit.jupiter.api.Assertions._
+import org.junit.jupiter.api.Test
 import org.neo4j.driver.Session
 import org.neo4j.driver.SessionConfig
 import org.neo4j.driver.TransactionContext

--- a/src/test/scala/org/neo4j/spark/DataSourceWriterTSE.scala
+++ b/src/test/scala/org/neo4j/spark/DataSourceWriterTSE.scala
@@ -585,7 +585,7 @@ class DataSourceWriterTSE extends SparkConnectorScalaBaseTSE {
     val ds = Seq(SimplePerson("Andrea", "Santurbano")).toDS()
 
     try {
-      val thrown = org.junit.Assert.assertThrows(
+      val thrown = assertThrows(
         classOf[SparkException],
         () => {
           ds.write

--- a/src/test/scala/org/neo4j/spark/DataSourceWriterTSE.scala
+++ b/src/test/scala/org/neo4j/spark/DataSourceWriterTSE.scala
@@ -21,10 +21,10 @@ import org.apache.spark.SparkException
 import org.apache.spark.sql.DataFrame
 import org.apache.spark.sql.SaveMode
 import org.apache.spark.sql.SparkSession
-import org.junit
-import org.junit.Assert._
-import org.junit.Ignore
-import org.junit.Test
+import org.junit.jupiter.api.Assertions._
+import org.junit.jupiter.api.Disabled
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.function.Executable
 import org.neo4j.driver.TransactionContext
 import org.neo4j.driver.Value
 import org.neo4j.driver.exceptions.ClientException
@@ -39,10 +39,6 @@ import org.neo4j.spark.testsupport.SparkConnectorScalaSuiteIT
 import org.neo4j.spark.testsupport.TestUtil
 import org.neo4j.spark.testsupport.Versions
 import org.neo4j.spark.util.Neo4jOptions
-import org.scalatest.matchers.must.Matchers.be
-import org.scalatest.matchers.must.Matchers.include
-import org.scalatest.matchers.must.Matchers.the
-import org.scalatest.matchers.should.Matchers.convertToAnyShouldWrapper
 
 import java.time.LocalTime
 import java.time.OffsetTime
@@ -589,21 +585,24 @@ class DataSourceWriterTSE extends SparkConnectorScalaBaseTSE {
     val ds = Seq(SimplePerson("Andrea", "Santurbano")).toDS()
 
     try {
-      val thrown = the[SparkException] thrownBy {
-        ds.write
-          .format(classOf[DataSource].getName)
-          .mode(SaveMode.Append)
-          .option("url", SparkConnectorScalaSuiteIT.server.getBoltUrl)
-          .option("labels", "Person")
-          .save() // we need the action to be able to trigger the exception because of the changes in Spark 3
-      }
+      val thrown = org.junit.Assert.assertThrows(
+        classOf[SparkException],
+        () => {
+          ds.write
+            .format(classOf[DataSource].getName)
+            .mode(SaveMode.Append)
+            .option("url", SparkConnectorScalaSuiteIT.server.getBoltUrl)
+            .option("labels", "Person")
+            .save() // we need the action to be able to trigger the exception because of the changes in Spark 3
+        }
+      )
 
-      thrown.getMessage should include("org.neo4j.driver.exceptions.ClientException")
+      assertTrue(thrown.getMessage.contains("org.neo4j.driver.exceptions.ClientException"))
       val rootCause = ExceptionUtils.getRootCause(thrown)
       // root cause is not always returned as a ClientException so we pass it through pattern matching to remove flakiness
       rootCause match {
         case c: ClientException =>
-          c.code() should be("Neo.ClientError.Schema.ConstraintValidationFailed")
+          assertEquals("Neo.ClientError.Schema.ConstraintValidationFailed", c.code())
         case _ =>
       }
     } finally {
@@ -667,7 +666,10 @@ class DataSourceWriterTSE extends SparkConnectorScalaBaseTSE {
       .asScala
     assertEquals(1, nodeList.size)
     val node = nodeList.head.get("n").asNode()
-    assertFalse("surname should not exist", node.asMap().containsKey("surname"))
+    assertFalse(
+      node.asMap().containsKey("surname"),
+      "surname should not exist"
+    )
   }
 
   @Test
@@ -726,7 +728,7 @@ class DataSourceWriterTSE extends SparkConnectorScalaBaseTSE {
   }
 
   @Test
-  @Ignore("This won't work right now because we can't know if we are in a Write or Read context")
+  @Disabled("This won't work right now because we can't know if we are in a Write or Read context")
   def `should throw an exception for a read only query`(): Unit = {
     val ds = (1 to 100).map(i => Person("Andrea " + i, "Santurbano " + i, 36, null)).toDS()
 
@@ -833,38 +835,43 @@ class DataSourceWriterTSE extends SparkConnectorScalaBaseTSE {
     assertEquals("Guitar", res.get(3).getString(8))
   }
 
-  @Test(expected = classOf[SparkException])
+  @Test
   def `should give error if native mode doesn't find a valid schema`(): Unit = {
-    val musicDf = Seq(
-      (12, "John Bonham", "Drums"),
-      (19, "John Mayer", "Guitar"),
-      (32, "John Scofield", "Guitar"),
-      (15, "John Butler", "Guitar")
-    ).toDF("experience", "name", "instrument")
+    assertThrows(
+      classOf[SparkException],
+      () => {
+        val musicDf = Seq(
+          (12, "John Bonham", "Drums"),
+          (19, "John Mayer", "Guitar"),
+          (32, "John Scofield", "Guitar"),
+          (15, "John Butler", "Guitar")
+        ).toDF("experience", "name", "instrument")
 
-    try {
-      musicDf.write
-        .format(classOf[DataSource].getName)
-        .mode(SaveMode.Append)
-        .option("url", SparkConnectorScalaSuiteIT.server.getBoltUrl)
-        .option("relationship", "PLAYS")
-        .option("relationship.save.strategy", "NATIVE")
-        .option("relationship.source.labels", ":Person")
-        .option("relationship.source.save.mode", "Overwrite")
-        .option("relationship.target.labels", ":Instrument")
-        .option("relationship.target.save.mode", "Overwrite")
-        .save() // we need the action to be able to trigger the exception because of the changes in Spark 3
-    } catch {
-      case sparkException: SparkException => {
-        val clientException = ExceptionUtils.getRootCause(sparkException)
-        assertTrue(clientException.getMessage.equals(
-          "NATIVE write strategy requires a schema like: rel.[props], source.[props], target.[props]. " +
-            "All of these columns are empty in the current schema."
-        ))
-        throw sparkException
+        try {
+          musicDf.write
+            .format(classOf[DataSource].getName)
+            .mode(SaveMode.Append)
+            .option("url", SparkConnectorScalaSuiteIT.server.getBoltUrl)
+            .option("relationship", "PLAYS")
+            .option("relationship.save.strategy", "NATIVE")
+            .option("relationship.source.labels", ":Person")
+            .option("relationship.source.save.mode", "Overwrite")
+            .option("relationship.target.labels", ":Instrument")
+            .option("relationship.target.save.mode", "Overwrite")
+            .save() // we need the action to be able to trigger the exception because of the changes in Spark 3
+        } catch {
+          case sparkException: SparkException => {
+            val clientException = ExceptionUtils.getRootCause(sparkException)
+            assertTrue(clientException.getMessage.equals(
+              "NATIVE write strategy requires a schema like: rel.[props], source.[props], target.[props]. " +
+                "All of these columns are empty in the current schema."
+            ))
+            throw sparkException
+          }
+          case _: Throwable => fail(s"should be thrown a ${classOf[SparkException].getName}")
+        }
       }
-      case _: Throwable => fail(s"should be thrown a ${classOf[SparkException].getName}")
-    }
+    )
   }
 
   @Test
@@ -947,7 +954,7 @@ class DataSourceWriterTSE extends SparkConnectorScalaBaseTSE {
   }
 
   @Test
-  @Ignore("trying to recreate the deadlock issue")
+  @Disabled("trying to recreate the deadlock issue")
   def `should give better errors if transaction fails`(): Unit = {
     val df = List.fill(200)(("John Bonham", "Drums")).toDF("name", "instrument")
 
@@ -1036,60 +1043,82 @@ class DataSourceWriterTSE extends SparkConnectorScalaBaseTSE {
     assertEquals("Drums", getByName[String](res.get(0), "rel.instrument"))
     assertEquals(12, getByName[Long](res.get(0), "rel.experience"))
     assertEquals(2, getByName[Long](res.get(0), "rel.avgRating"))
-    assertThrows[IllegalArgumentException](
-      "relationship should not have hasDiploma field",
-      res.get(0).fieldIndex("rel.hasDiploma")
+    assertThrows(
+      classOf[IllegalArgumentException],
+      (() => res.get(0).fieldIndex("rel.hasDiploma")): Executable,
+      "relationship should not have hasDiploma field"
     )
-    assertThrows[IllegalArgumentException](
-      "relationship should not have rating field",
-      res.get(0).fieldIndex("rel.rating")
+    assertThrows(
+      classOf[IllegalArgumentException],
+      (() => res.get(0).fieldIndex("rel.rating")): Executable,
+      "relationship should not have rating field"
     )
-    assertThrows[IllegalArgumentException]("relationship should not have name field", res.get(0).fieldIndex("rel.name"))
-
+    assertThrows(
+      classOf[IllegalArgumentException],
+      (() => res.get(0).fieldIndex("rel.name")): Executable,
+      "relationship should not have name field"
+    )
     assertEquals("John Butler", getByName[String](res.get(1), "source.name"))
     assertEquals("Guitar", getByName[String](res.get(1), "target.name"))
     assertEquals("Guitar", getByName[String](res.get(1), "rel.instrument"))
     assertEquals(15, getByName[Long](res.get(1), "rel.experience"))
     assertEquals(4, getByName[Long](res.get(1), "rel.avgRating"))
-    assertThrows[IllegalArgumentException](
-      "relationship should not have hasDiploma field",
-      res.get(1).fieldIndex("rel.hasDiploma")
+    assertThrows(
+      classOf[IllegalArgumentException],
+      (() => res.get(1).fieldIndex("rel.hasDiploma")): Executable,
+      "relationship should not have hasDiploma field"
     )
-    assertThrows[IllegalArgumentException](
-      "relationship should not have rating field",
-      res.get(1).fieldIndex("rel.rating")
+    assertThrows(
+      classOf[IllegalArgumentException],
+      (() => res.get(1).fieldIndex("rel.rating")): Executable,
+      "relationship should not have rating field"
     )
-    assertThrows[IllegalArgumentException]("relationship should not have name field", res.get(1).fieldIndex("rel.name"))
-
+    assertThrows(
+      classOf[IllegalArgumentException],
+      (() => res.get(1).fieldIndex("rel.name")): Executable,
+      "relationship should not have name field"
+    )
     assertEquals("John Mayer", getByName[String](res.get(2), "source.name"))
     assertEquals("Guitar", getByName[String](res.get(2), "target.name"))
     assertEquals("Guitar", getByName[String](res.get(2), "rel.instrument"))
     assertEquals(19, getByName[Long](res.get(2), "rel.experience"))
     assertEquals(1, getByName[Long](res.get(2), "rel.avgRating"))
-    assertThrows[IllegalArgumentException](
-      "relationship should not have hasDiploma field",
-      res.get(2).fieldIndex("rel.hasDiploma")
+    assertThrows(
+      classOf[IllegalArgumentException],
+      (() => res.get(2).fieldIndex("rel.hasDiploma")): Executable,
+      "relationship should not have hasDiploma field"
     )
-    assertThrows[IllegalArgumentException](
-      "relationship should not have rating field",
-      res.get(2).fieldIndex("rel.rating")
+    assertThrows(
+      classOf[IllegalArgumentException],
+      (() => res.get(2).fieldIndex("rel.rating")): Executable,
+      "relationship should not have rating field"
     )
-    assertThrows[IllegalArgumentException]("relationship should not have name field", res.get(2).fieldIndex("rel.name"))
+    assertThrows(
+      classOf[IllegalArgumentException],
+      (() => res.get(2).fieldIndex("rel.name")): Executable,
+      "relationship should not have name field"
+    )
 
     assertEquals("John Scofield", getByName[String](res.get(3), "source.name"))
     assertEquals("Guitar", getByName[String](res.get(3), "target.name"))
     assertEquals("Guitar", getByName[String](res.get(3), "rel.instrument"))
     assertEquals(32, getByName[Long](res.get(3), "rel.experience"))
     assertEquals(3, getByName[Long](res.get(3), "rel.avgRating"))
-    assertThrows[IllegalArgumentException](
-      "relationship should not have hasDiploma field",
-      res.get(3).fieldIndex("rel.hasDiploma")
+    assertThrows(
+      classOf[IllegalArgumentException],
+      (() => res.get(3).fieldIndex("rel.hasDiploma")): Executable,
+      "relationship should not have hasDiploma field"
     )
-    assertThrows[IllegalArgumentException](
-      "relationship should not have rating field",
-      res.get(3).fieldIndex("rel.rating")
+    assertThrows(
+      classOf[IllegalArgumentException],
+      (() => res.get(3).fieldIndex("rel.rating")): Executable,
+      "relationship should not have rating field"
     )
-    assertThrows[IllegalArgumentException]("relationship should not have name field", res.get(3).fieldIndex("rel.name"))
+    assertThrows(
+      classOf[IllegalArgumentException],
+      (() => res.get(3).fieldIndex("rel.name")): Executable,
+      "relationship should not have name field"
+    )
   }
 
   @Test
@@ -1105,82 +1134,114 @@ class DataSourceWriterTSE extends SparkConnectorScalaBaseTSE {
 
     assertEquals("John Bonham", getByName[String](res.get(0), "source.name"))
     assertEquals("Drums", getByName[String](res.get(0), "target.name"))
-    assertThrows[IllegalArgumentException](
-      "relationship should not have experience field",
-      res.get(0).fieldIndex("rel.experience")
+    assertThrows(
+      classOf[IllegalArgumentException],
+      (() => res.get(0).fieldIndex("rel.experience")): Executable,
+      "relationship should not have experience field"
     )
-    assertThrows[IllegalArgumentException](
-      "relationship should not have hasDiploma field",
-      res.get(0).fieldIndex("rel.hasDiploma")
+    assertThrows(
+      classOf[IllegalArgumentException],
+      (() => res.get(0).fieldIndex("rel.hasDiploma")): Executable,
+      "relationship should not have hasDiploma field"
     )
-    assertThrows[IllegalArgumentException](
-      "relationship should not have rating field",
-      res.get(0).fieldIndex("rel.rating")
+    assertThrows(
+      classOf[IllegalArgumentException],
+      (() => res.get(0).fieldIndex("rel.rating")): Executable,
+      "relationship should not have rating field"
     )
-    assertThrows[IllegalArgumentException]("relationship should not have name field", res.get(0).fieldIndex("rel.name"))
-    assertThrows[IllegalArgumentException](
-      "relationship should not have instrument field",
-      res.get(0).fieldIndex("rel.instrument")
+    assertThrows(
+      classOf[IllegalArgumentException],
+      (() => res.get(0).fieldIndex("rel.name")): Executable,
+      "relationship should not have name field"
+    )
+    assertThrows(
+      classOf[IllegalArgumentException],
+      (() => res.get(0).fieldIndex("rel.instrument")): Executable,
+      "relationship should not have instrument field"
     )
 
     assertEquals("John Butler", getByName[String](res.get(1), "source.name"))
     assertEquals("Guitar", getByName[String](res.get(1), "target.name"))
-    assertThrows[IllegalArgumentException](
-      "relationship should not have experience field",
-      res.get(1).fieldIndex("rel.experience")
+    assertThrows(
+      classOf[IllegalArgumentException],
+      (() => res.get(1).fieldIndex("rel.experience")): Executable,
+      "relationship should not have experience field"
     )
-    assertThrows[IllegalArgumentException](
-      "relationship should not have hasDiploma field",
-      res.get(1).fieldIndex("rel.hasDiploma")
+    assertThrows(
+      classOf[IllegalArgumentException],
+      (() => res.get(1).fieldIndex("rel.hasDiploma")): Executable,
+      "relationship should not have hasDiploma field"
     )
-    assertThrows[IllegalArgumentException](
-      "relationship should not have rating field",
-      res.get(1).fieldIndex("rel.rating")
+    assertThrows(
+      classOf[IllegalArgumentException],
+      (() => res.get(1).fieldIndex("rel.rating")): Executable,
+      "relationship should not have rating field"
     )
-    assertThrows[IllegalArgumentException]("relationship should not have name field", res.get(1).fieldIndex("rel.name"))
-    assertThrows[IllegalArgumentException](
-      "relationship should not have instrument field",
-      res.get(1).fieldIndex("rel.instrument")
+    assertThrows(
+      classOf[IllegalArgumentException],
+      (() => res.get(1).fieldIndex("rel.name")): Executable,
+      "relationship should not have name field"
+    )
+    assertThrows(
+      classOf[IllegalArgumentException],
+      (() => res.get(1).fieldIndex("rel.instrument")): Executable,
+      "relationship should not have instrument field"
     )
 
     assertEquals("John Mayer", getByName[String](res.get(2), "source.name"))
     assertEquals("Guitar", getByName[String](res.get(2), "target.name"))
-    assertThrows[IllegalArgumentException](
-      "relationship should not have experience field",
-      res.get(2).fieldIndex("rel.experience")
+    assertThrows(
+      classOf[IllegalArgumentException],
+      (() => res.get(2).fieldIndex("rel.experience")): Executable,
+      "relationship should not have experience field"
     )
-    assertThrows[IllegalArgumentException](
-      "relationship should not have hasDiploma field",
-      res.get(2).fieldIndex("rel.hasDiploma")
+    assertThrows(
+      classOf[IllegalArgumentException],
+      (() => res.get(2).fieldIndex("rel.hasDiploma")): Executable,
+      "relationship should not have hasDiploma field"
     )
-    assertThrows[IllegalArgumentException](
-      "relationship should not have rating field",
-      res.get(2).fieldIndex("rel.rating")
+    assertThrows(
+      classOf[IllegalArgumentException],
+      (() => res.get(2).fieldIndex("rel.rating")): Executable,
+      "relationship should not have rating field"
     )
-    assertThrows[IllegalArgumentException]("relationship should not have name field", res.get(2).fieldIndex("rel.name"))
-    assertThrows[IllegalArgumentException](
-      "relationship should not have instrument field",
-      res.get(2).fieldIndex("rel.instrument")
+    assertThrows(
+      classOf[IllegalArgumentException],
+      (() => res.get(2).fieldIndex("rel.name")): Executable,
+      "relationship should not have name field"
+    )
+    assertThrows(
+      classOf[IllegalArgumentException],
+      (() => res.get(2).fieldIndex("rel.instrument")): Executable,
+      "relationship should not have instrument field"
     )
 
     assertEquals("John Scofield", getByName[String](res.get(3), "source.name"))
     assertEquals("Guitar", getByName[String](res.get(3), "target.name"))
-    assertThrows[IllegalArgumentException](
-      "relationship should not have experience field",
-      res.get(3).fieldIndex("rel.experience")
+    assertThrows(
+      classOf[IllegalArgumentException],
+      (() => res.get(3).fieldIndex("rel.experience")): Executable,
+      "relationship should not have experience field"
     )
-    assertThrows[IllegalArgumentException](
-      "relationship should not have hasDiploma field",
-      res.get(3).fieldIndex("rel.hasDiploma")
+    assertThrows(
+      classOf[IllegalArgumentException],
+      (() => res.get(3).fieldIndex("rel.hasDiploma")): Executable,
+      "relationship should not have hasDiploma field"
     )
-    assertThrows[IllegalArgumentException](
-      "relationship should not have rating field",
-      res.get(3).fieldIndex("rel.rating")
+    assertThrows(
+      classOf[IllegalArgumentException],
+      (() => res.get(3).fieldIndex("rel.rating")): Executable,
+      "relationship should not have rating field"
     )
-    assertThrows[IllegalArgumentException]("relationship should not have name field", res.get(3).fieldIndex("rel.name"))
-    assertThrows[IllegalArgumentException](
-      "relationship should not have instrument field",
-      res.get(3).fieldIndex("rel.instrument")
+    assertThrows(
+      classOf[IllegalArgumentException],
+      (() => res.get(3).fieldIndex("rel.name")): Executable,
+      "relationship should not have name field"
+    )
+    assertThrows(
+      classOf[IllegalArgumentException],
+      (() => res.get(3).fieldIndex("rel.instrument")): Executable,
+      "relationship should not have instrument field"
     )
   }
 
@@ -1198,10 +1259,15 @@ class DataSourceWriterTSE extends SparkConnectorScalaBaseTSE {
     assertEquals(12, getByName[Long](res.get(0), "rel.experience"))
     assertEquals(true, getByName[Boolean](res.get(0), "rel.hasDiploma"))
     assertEquals(2, getByName[Long](res.get(0), "rel.rating"))
-    assertThrows[IllegalArgumentException]("relationship should not have name field", res.get(0).fieldIndex("rel.name"))
-    assertThrows[IllegalArgumentException](
-      "relationship should not have instrument field",
-      res.get(0).fieldIndex("rel.instrument")
+    assertThrows(
+      classOf[IllegalArgumentException],
+      (() => res.get(0).fieldIndex("rel.name")): Executable,
+      "relationship should not have name field"
+    )
+    assertThrows(
+      classOf[IllegalArgumentException],
+      (() => res.get(0).fieldIndex("rel.instrument")): Executable,
+      "relationship should not have instrument field"
     )
 
     assertEquals("John Butler", getByName[String](res.get(1), "source.name"))
@@ -1209,10 +1275,15 @@ class DataSourceWriterTSE extends SparkConnectorScalaBaseTSE {
     assertEquals(15, getByName[Long](res.get(1), "rel.experience"))
     assertEquals(false, getByName[Boolean](res.get(1), "rel.hasDiploma"))
     assertEquals(4, getByName[Long](res.get(1), "rel.rating"))
-    assertThrows[IllegalArgumentException]("relationship should not have name field", res.get(1).fieldIndex("rel.name"))
-    assertThrows[IllegalArgumentException](
-      "relationship should not have instrument field",
-      res.get(1).fieldIndex("rel.instrument")
+    assertThrows(
+      classOf[IllegalArgumentException],
+      (() => res.get(1).fieldIndex("rel.name")): Executable,
+      "relationship should not have name field"
+    )
+    assertThrows(
+      classOf[IllegalArgumentException],
+      (() => res.get(1).fieldIndex("rel.instrument")): Executable,
+      "relationship should not have instrument field"
     )
 
     assertEquals("John Mayer", getByName[String](res.get(2), "source.name"))
@@ -1220,10 +1291,15 @@ class DataSourceWriterTSE extends SparkConnectorScalaBaseTSE {
     assertEquals(19, getByName[Long](res.get(2), "rel.experience"))
     assertEquals(false, getByName[Boolean](res.get(2), "rel.hasDiploma"))
     assertEquals(1, getByName[Long](res.get(2), "rel.rating"))
-    assertThrows[IllegalArgumentException]("relationship should not have name field", res.get(2).fieldIndex("rel.name"))
-    assertThrows[IllegalArgumentException](
-      "relationship should not have instrument field",
-      res.get(2).fieldIndex("rel.instrument")
+    assertThrows(
+      classOf[IllegalArgumentException],
+      (() => res.get(2).fieldIndex("rel.name")): Executable,
+      "relationship should not have name field"
+    )
+    assertThrows(
+      classOf[IllegalArgumentException],
+      (() => res.get(2).fieldIndex("rel.instrument")): Executable,
+      "relationship should not have instrument field"
     )
 
     assertEquals("John Scofield", getByName[String](res.get(3), "source.name"))
@@ -1231,10 +1307,15 @@ class DataSourceWriterTSE extends SparkConnectorScalaBaseTSE {
     assertEquals(32, getByName[Long](res.get(3), "rel.experience"))
     assertEquals(true, getByName[Boolean](res.get(3), "rel.hasDiploma"))
     assertEquals(3, getByName[Long](res.get(3), "rel.rating"))
-    assertThrows[IllegalArgumentException]("relationship should not have name field", res.get(3).fieldIndex("rel.name"))
-    assertThrows[IllegalArgumentException](
-      "relationship should not have instrument field",
-      res.get(3).fieldIndex("rel.instrument")
+    assertThrows(
+      classOf[IllegalArgumentException],
+      (() => res.get(3).fieldIndex("rel.name")): Executable,
+      "relationship should not have name field"
+    )
+    assertThrows(
+      classOf[IllegalArgumentException],
+      (() => res.get(3).fieldIndex("rel.instrument")): Executable,
+      "relationship should not have instrument field"
     )
   }
 
@@ -1751,7 +1832,7 @@ class DataSourceWriterTSE extends SparkConnectorScalaBaseTSE {
       .single()
       .get(0)
       .asLong()
-    junit.Assert.assertEquals(2L, count)
+    assertEquals(2L, count)
   }
 
   @Test
@@ -1779,7 +1860,7 @@ class DataSourceWriterTSE extends SparkConnectorScalaBaseTSE {
       .single()
       .get(0)
       .asLong()
-    junit.Assert.assertEquals(2L, count)
+    assertEquals(2L, count)
   }
 
   @Test
@@ -1808,7 +1889,7 @@ class DataSourceWriterTSE extends SparkConnectorScalaBaseTSE {
       .single()
       .get(0)
       .asLong()
-    junit.Assert.assertEquals(2L, count)
+    assertEquals(2L, count)
   }
 
   @Test
@@ -1843,7 +1924,7 @@ class DataSourceWriterTSE extends SparkConnectorScalaBaseTSE {
       .get(0)
       .asList((value: Value) => value.asMap().asScala)
       .asScala
-    junit.Assert.assertEquals(
+    assertEquals(
       List(
         Map("watch_time" -> "today"),
         Map("watch_time" -> "two days ago"),

--- a/src/test/scala/org/neo4j/spark/DefaultConfigTSE.scala
+++ b/src/test/scala/org/neo4j/spark/DefaultConfigTSE.scala
@@ -17,7 +17,7 @@
 package org.neo4j.spark
 
 import org.junit.Assert.assertEquals
-import org.junit.Test
+import org.junit.jupiter.api.Test
 import org.neo4j.spark.testsupport.SparkConnectorScalaBaseTSE
 import org.neo4j.spark.testsupport.SparkConnectorScalaSuiteIT
 

--- a/src/test/scala/org/neo4j/spark/GraphDataScienceIT.scala
+++ b/src/test/scala/org/neo4j/spark/GraphDataScienceIT.scala
@@ -17,12 +17,12 @@
 package org.neo4j.spark
 
 import org.apache.spark.sql.types._
-import org.junit.After
-import org.junit.Assert.assertEquals
-import org.junit.Assert.assertTrue
-import org.junit.Assert.fail
-import org.junit.Assume
-import org.junit.Test
+import org.junit.jupiter.api.AfterEach
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.Assertions.fail
+import org.junit.jupiter.api.Assumptions.assumeTrue
+import org.junit.jupiter.api.Test
 import org.neo4j.spark.testsupport.Closeables.use
 import org.neo4j.spark.testsupport.SparkConnectorScalaSuiteWithGdsBase
 import org.neo4j.spark.testsupport.TestUtil
@@ -32,7 +32,7 @@ import scala.math.Ordering.Implicits.infixOrderingOps
 
 class GraphDataScienceIT extends SparkConnectorScalaSuiteWithGdsBase {
 
-  @After
+  @AfterEach
   def cleanData(): Unit = {
     use(SparkConnectorScalaSuiteWithGdsBase.session("system")) { session =>
       session.run("CREATE OR REPLACE DATABASE neo4j WAIT 30 seconds").consume()
@@ -401,7 +401,7 @@ class GraphDataScienceIT extends SparkConnectorScalaSuiteWithGdsBase {
   }
 
   private def initForHits(): Unit = {
-    Assume.assumeTrue(TestUtil.neo4jVersion(SparkConnectorScalaSuiteWithGdsBase.session()) >= Versions.NEO4J_5)
+    assumeTrue(TestUtil.neo4jVersion(SparkConnectorScalaSuiteWithGdsBase.session()) >= Versions.NEO4J_5)
     SparkConnectorScalaSuiteWithGdsBase.session()
       .executeWrite(tx =>
         tx.run(

--- a/src/test/scala/org/neo4j/spark/ReauthenticationIT.scala
+++ b/src/test/scala/org/neo4j/spark/ReauthenticationIT.scala
@@ -16,10 +16,10 @@
  */
 package org.neo4j.spark
 
-import org.junit.AfterClass
-import org.junit.Assert.assertEquals
-import org.junit.BeforeClass
-import org.junit.Test
+import org.junit.jupiter.api.AfterAll
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.BeforeAll
+import org.junit.jupiter.api.Test
 import org.neo4j.driver.AuthTokens
 import org.neo4j.driver.Driver
 import org.neo4j.driver.GraphDatabase
@@ -112,13 +112,13 @@ object ReauthenticationIT {
     .withNeo4jConfig("dbms.security.oidc.keycloak.claims.groups", "groups")
     .withNeo4jConfig("dbms.security.auth_cache_ttl", "1s")
 
-  @BeforeClass
+  @BeforeAll
   def setUp(): Unit = {
     KEYCLOAK.start()
     NEO4J.start()
   }
 
-  @AfterClass
+  @AfterAll
   def tearDown() = {
     TestUtil.closeSafely(NEO4J)
     TestUtil.closeSafely(KEYCLOAK)

--- a/src/test/scala/org/neo4j/spark/SparkConnector30ScalaSuiteIT.scala
+++ b/src/test/scala/org/neo4j/spark/SparkConnector30ScalaSuiteIT.scala
@@ -16,12 +16,12 @@
  */
 package org.neo4j.spark
 
-import org.junit.runner.RunWith
-import org.junit.runners.Suite
+import org.junit.platform.suite.api.SelectClasses
+import org.junit.platform.suite.api.Suite
 import org.neo4j.spark.testsupport.SparkConnectorScalaSuiteIT
 
-@RunWith(classOf[Suite])
-@Suite.SuiteClasses(Array(
+@Suite
+@SelectClasses(Array(
   classOf[DataSourceReaderTSE],
   classOf[DataSourceReaderNeo4jTSE],
   classOf[DataSourceWriterNeo4jTSE],

--- a/src/test/scala/org/neo4j/spark/SparkConnector30ScalaSuiteWithApocIT.scala
+++ b/src/test/scala/org/neo4j/spark/SparkConnector30ScalaSuiteWithApocIT.scala
@@ -16,12 +16,12 @@
  */
 package org.neo4j.spark
 
-import org.junit.runner.RunWith
-import org.junit.runners.Suite
+import org.junit.platform.suite.api.SelectClasses
+import org.junit.platform.suite.api.Suite
 import org.neo4j.spark.testsupport.SparkConnectorScalaSuiteWithApocIT
 
-@RunWith(classOf[Suite])
-@Suite.SuiteClasses(Array(
+@Suite
+@SelectClasses(Array(
   classOf[DataSourceReaderWithApocTSE],
   classOf[DataSourceReaderNeo4jWithApocTSE],
   classOf[DataSourceReaderAggregationTSE]

--- a/src/test/scala/org/neo4j/spark/SparkConnectorAuraTest.scala
+++ b/src/test/scala/org/neo4j/spark/SparkConnectorAuraTest.scala
@@ -18,12 +18,12 @@ package org.neo4j.spark
 
 import org.apache.spark.SparkConf
 import org.apache.spark.sql.SparkSession
-import org.junit.AfterClass
-import org.junit.Assert._
-import org.junit.Assume.assumeTrue
-import org.junit.Before
-import org.junit.BeforeClass
-import org.junit.Test
+import org.junit.jupiter.api.AfterAll
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assumptions.assumeTrue
+import org.junit.jupiter.api.BeforeAll
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
 import org.neo4j.driver._
 import org.neo4j.spark.SparkConnectorAuraTest._
 import org.neo4j.spark.testsupport.Closeables.use
@@ -37,7 +37,7 @@ object SparkConnectorAuraTest {
 
   var sparkSession: SparkSession = _
 
-  @BeforeClass
+  @BeforeAll
   def setUpClass(): Unit = {
     assumeTrue(username.isDefined)
     assumeTrue(password.isDefined)
@@ -53,7 +53,7 @@ object SparkConnectorAuraTest {
     neo4j = GraphDatabase.driver(url.get, AuthTokens.basic(username.get, password.get))
   }
 
-  @AfterClass
+  @AfterAll
   def tearDown(): Unit = {
     TestUtil.closeSafely(neo4j)
     TestUtil.closeSafely(sparkSession)
@@ -66,7 +66,7 @@ class SparkConnectorAuraTest {
 
   import ss.implicits._
 
-  @Before
+  @BeforeEach
   def setUp(): Unit = {
     use(neo4j.session(SessionConfig.forDatabase("system"))) {
       session =>

--- a/src/test/scala/org/neo4j/spark/TransactionTimeoutIT.scala
+++ b/src/test/scala/org/neo4j/spark/TransactionTimeoutIT.scala
@@ -17,12 +17,10 @@
 package org.neo4j.spark
 
 import org.apache.spark.sql.SparkSession
-import org.junit.AfterClass
-import org.junit.Assert.assertEquals
-import org.junit.Assert.assertThrows
-import org.junit.Assert.assertTrue
-import org.junit.BeforeClass
-import org.junit.Test
+import org.junit.jupiter.api.AfterAll
+import org.junit.jupiter.api.Assertions._
+import org.junit.jupiter.api.BeforeAll
+import org.junit.jupiter.api.Test
 import org.neo4j.driver.exceptions.ClientException
 import org.neo4j.spark.TransactionTimeoutIT.NEO4J_LOW_TX_TIMEOUT
 import org.neo4j.spark.testsupport.Neo4jContainerExtension
@@ -140,12 +138,12 @@ object TransactionTimeoutIT {
     .withNeo4jConfig("db.transaction.timeout", "10s")
     .withDatabases(Seq("db1", "db2"))
 
-  @BeforeClass
+  @BeforeAll
   def setUp(): Unit = {
     NEO4J_LOW_TX_TIMEOUT.start()
   }
 
-  @AfterClass
+  @AfterAll
   def tearDown() = {
     TestUtil.closeSafely(NEO4J_LOW_TX_TIMEOUT)
   }

--- a/src/test/scala/org/neo4j/spark/service/AuthenticationTest.scala
+++ b/src/test/scala/org/neo4j/spark/service/AuthenticationTest.scala
@@ -16,29 +16,23 @@
  */
 package org.neo4j.spark.service
 
-import org.junit.Test
-import org.junit.runner.RunWith
+import org.junit.jupiter.api.Test
 import org.mockito.ArgumentCaptor
 import org.mockito.ArgumentMatchers._
+import org.mockito.Mockito
 import org.mockito.Mockito.times
 import org.neo4j.driver.AuthTokenManager
 import org.neo4j.driver.AuthTokens
 import org.neo4j.driver.Config
+import org.neo4j.driver.Driver
 import org.neo4j.driver.GraphDatabase
 import org.neo4j.spark.util.DriverCache
 import org.neo4j.spark.util.Neo4jOptions
-import org.powermock.api.mockito.PowerMockito
-import org.powermock.core.classloader.annotations.PowerMockIgnore
-import org.powermock.core.classloader.annotations.PrepareForTest
-import org.powermock.modules.junit4.PowerMockRunner
 import org.testcontainers.shaded.com.google.common.io.BaseEncoding
 
 import java.net.URI
 import java.util
 
-@PrepareForTest(Array(classOf[GraphDatabase]))
-@RunWith(classOf[PowerMockRunner])
-@PowerMockIgnore(Array("javax.management.*"))
 class AuthenticationTest {
 
   @Test
@@ -54,14 +48,22 @@ class AuthenticationTest {
     val neo4jDriverOptions = neo4jOptions.connection
     val driverCache = new DriverCache(neo4jDriverOptions)
 
-    PowerMockito.spy(classOf[GraphDatabase])
+    val mockedGraphDatabase = Mockito.mockStatic(classOf[GraphDatabase])
+    try {
+      mockedGraphDatabase.when(() => GraphDatabase.driver(any[URI](), any[AuthTokenManager](), any[Config]()))
+        .thenReturn(Mockito.mock(classOf[Driver]))
 
-    driverCache.getOrCreate()
+      driverCache.getOrCreate()
 
-    PowerMockito.verifyStatic(classOf[GraphDatabase], times(1))
-    val managerCaptor = ArgumentCaptor.forClass(classOf[AuthTokenManager])
-    GraphDatabase.driver(any[URI](), managerCaptor.capture(), any[Config]())
-    assert(AuthTokens.custom("", token, "", "") == managerCaptor.getValue.getToken.toCompletableFuture.join())
+      val managerCaptor = ArgumentCaptor.forClass(classOf[AuthTokenManager])
+      mockedGraphDatabase.verify(
+        () => GraphDatabase.driver(any[URI](), managerCaptor.capture(), any[Config]()),
+        times(1)
+      )
+      assert(AuthTokens.custom("", token, "", "") == managerCaptor.getValue.getToken.toCompletableFuture.join())
+    } finally {
+      mockedGraphDatabase.close()
+    }
   }
 
   @Test
@@ -76,13 +78,21 @@ class AuthenticationTest {
     val neo4jDriverOptions = neo4jOptions.connection
     val driverCache = new DriverCache(neo4jDriverOptions)
 
-    PowerMockito.spy(classOf[GraphDatabase])
+    val mockedGraphDatabase = Mockito.mockStatic(classOf[GraphDatabase])
+    try {
+      mockedGraphDatabase.when(() => GraphDatabase.driver(any[URI](), any[AuthTokenManager](), any[Config]()))
+        .thenReturn(Mockito.mock(classOf[Driver]))
 
-    driverCache.getOrCreate()
+      driverCache.getOrCreate()
 
-    PowerMockito.verifyStatic(classOf[GraphDatabase], times(1))
-    val managerCaptor = ArgumentCaptor.forClass(classOf[AuthTokenManager])
-    GraphDatabase.driver(any[URI](), managerCaptor.capture(), any[Config]())
-    assert(AuthTokens.bearer(token) == managerCaptor.getValue.getToken.toCompletableFuture.join())
+      val managerCaptor = ArgumentCaptor.forClass(classOf[AuthTokenManager])
+      mockedGraphDatabase.verify(
+        () => GraphDatabase.driver(any[URI](), managerCaptor.capture(), any[Config]()),
+        times(1)
+      )
+      assert(AuthTokens.bearer(token) == managerCaptor.getValue.getToken.toCompletableFuture.join())
+    } finally {
+      mockedGraphDatabase.close()
+    }
   }
 }

--- a/src/test/scala/org/neo4j/spark/service/AuthenticationTest.scala
+++ b/src/test/scala/org/neo4j/spark/service/AuthenticationTest.scala
@@ -21,6 +21,7 @@ import org.mockito.ArgumentCaptor
 import org.mockito.ArgumentMatchers._
 import org.mockito.Mockito
 import org.mockito.Mockito.times
+import org.neo4j.driver.AuthToken
 import org.neo4j.driver.AuthTokenManager
 import org.neo4j.driver.AuthTokens
 import org.neo4j.driver.Config
@@ -44,26 +45,7 @@ class AuthenticationTest {
     options.put("authentication.custom.credentials", token)
     options.put("labels", "Person")
 
-    val neo4jOptions = new Neo4jOptions(options)
-    val neo4jDriverOptions = neo4jOptions.connection
-    val driverCache = new DriverCache(neo4jDriverOptions)
-
-    val mockedGraphDatabase = Mockito.mockStatic(classOf[GraphDatabase])
-    try {
-      mockedGraphDatabase.when(() => GraphDatabase.driver(any[URI](), any[AuthTokenManager](), any[Config]()))
-        .thenReturn(Mockito.mock(classOf[Driver]))
-
-      driverCache.getOrCreate()
-
-      val managerCaptor = ArgumentCaptor.forClass(classOf[AuthTokenManager])
-      mockedGraphDatabase.verify(
-        () => GraphDatabase.driver(any[URI](), managerCaptor.capture(), any[Config]()),
-        times(1)
-      )
-      assert(AuthTokens.custom("", token, "", "") == managerCaptor.getValue.getToken.toCompletableFuture.join())
-    } finally {
-      mockedGraphDatabase.close()
-    }
+    stubGraphDatabaseConnectionCallAndAssertToken(options, AuthTokens.custom("", token, "", ""))
   }
 
   @Test
@@ -74,10 +56,13 @@ class AuthenticationTest {
     options.put("authentication.type", "bearer")
     options.put("authentication.bearer.token", token)
 
+    stubGraphDatabaseConnectionCallAndAssertToken(options, AuthTokens.bearer(token))
+  }
+
+  def stubGraphDatabaseConnectionCallAndAssertToken(options: java.util.Map[String, String], token: AuthToken): Unit = {
     val neo4jOptions = new Neo4jOptions(options)
     val neo4jDriverOptions = neo4jOptions.connection
     val driverCache = new DriverCache(neo4jDriverOptions)
-
     val mockedGraphDatabase = Mockito.mockStatic(classOf[GraphDatabase])
     try {
       mockedGraphDatabase.when(() => GraphDatabase.driver(any[URI](), any[AuthTokenManager](), any[Config]()))
@@ -90,7 +75,7 @@ class AuthenticationTest {
         () => GraphDatabase.driver(any[URI](), managerCaptor.capture(), any[Config]()),
         times(1)
       )
-      assert(AuthTokens.bearer(token) == managerCaptor.getValue.getToken.toCompletableFuture.join())
+      assert(token == managerCaptor.getValue.getToken.toCompletableFuture.join())
     } finally {
       mockedGraphDatabase.close()
     }

--- a/src/test/scala/org/neo4j/spark/service/Neo4jQueryServiceIT.scala
+++ b/src/test/scala/org/neo4j/spark/service/Neo4jQueryServiceIT.scala
@@ -33,7 +33,6 @@ import org.neo4j.spark.util.Neo4jOptions
 
 import scala.language.postfixOps
 
-@TestMethodOrder(classOf[MethodOrderer.MethodName])
 class Neo4jQueryServiceIT extends SparkConnectorScalaSuiteWithGdsBase {
 
   @AfterEach

--- a/src/test/scala/org/neo4j/spark/service/Neo4jQueryServiceIT.scala
+++ b/src/test/scala/org/neo4j/spark/service/Neo4jQueryServiceIT.scala
@@ -20,24 +20,23 @@ import org.apache.spark.sql.connector.expressions.aggregate.Count
 import org.apache.spark.sql.connector.expressions.aggregate.Max
 import org.apache.spark.sql.connector.expressions.aggregate.Min
 import org.apache.spark.sql.connector.expressions.aggregate.Sum
-import org.junit.After
-import org.junit.FixMethodOrder
-import org.junit.Test
-import org.junit.runners.MethodSorters
+import org.junit.jupiter.api.AfterEach
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.MethodOrderer
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.TestMethodOrder
 import org.neo4j.spark.testsupport.SparkConnectorScalaSuiteWithGdsBase
 import org.neo4j.spark.testsupport.SparkConnectorScalaSuiteWithGdsBase.neo4j
 import org.neo4j.spark.util.DriverCache
 import org.neo4j.spark.util.DummyNamedReference
 import org.neo4j.spark.util.Neo4jOptions
-import org.scalatest.matchers.must.Matchers.convertToAnyMustWrapper
-import org.scalatest.matchers.must.Matchers.endWith
 
 import scala.language.postfixOps
 
-@FixMethodOrder(MethodSorters.JVM)
+@TestMethodOrder(classOf[MethodOrderer.MethodName])
 class Neo4jQueryServiceIT extends SparkConnectorScalaSuiteWithGdsBase {
 
-  @After
+  @AfterEach
   def cleanUp(): Unit = {
     val options: java.util.Map[String, String] = new java.util.HashMap[String, String]()
     options.put(Neo4jOptions.URL, SparkConnectorScalaSuiteWithGdsBase.server.getBoltUrl)
@@ -80,13 +79,13 @@ class Neo4jQueryServiceIT extends SparkConnectorScalaSuiteWithGdsBase {
       )
     ).createQuery()
 
-    query must endWith(
+    assertTrue(query.endsWith(
       """CALL gds.pageRank.stream($graphName)
         |YIELD nodeId, score
         |RETURN nodeId AS nodeId, max(score) AS `MAX(score)`, min(score) AS `MIN(score)`, count(score) AS `COUNT(score)`, count(DISTINCT score) AS `COUNT(DISTINCT score)`, sum(score) AS `SUM(score)`, sum(DISTINCT score) AS `SUM(DISTINCT score)`"""
         .stripMargin
         .replaceAll("\n", " ")
-    )
+    ))
   }
 
 }

--- a/src/test/scala/org/neo4j/spark/service/Neo4jQueryServiceTest.scala
+++ b/src/test/scala/org/neo4j/spark/service/Neo4jQueryServiceTest.scala
@@ -28,9 +28,10 @@ import org.apache.spark.sql.connector.expressions.aggregate.Max
 import org.apache.spark.sql.connector.expressions.aggregate.Min
 import org.apache.spark.sql.connector.expressions.aggregate.Sum
 import org.apache.spark.sql.sources._
-import org.junit.Assert._
-import org.junit.Test
-import org.junit.runner.RunWith
+import org.junit.jupiter.api.Assertions._
+import org.junit.jupiter.api.TestInstance
+import org.junit.jupiter.params.ParameterizedTest
+import org.junit.jupiter.params.provider.MethodSource
 import org.neo4j.caniuse.Neo4j
 import org.neo4j.caniuse.Neo4jDeploymentType.SELF_MANAGED
 import org.neo4j.caniuse.Neo4jEdition
@@ -45,11 +46,11 @@ import org.neo4j.spark.util.QueryType
 
 import scala.collection.immutable.HashMap
 
-@RunWith(classOf[JUnitParamsRunner])
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
 class Neo4jQueryServiceTest {
 
-  @Test
-  @Parameters(method = "versions_and_prefixes")
+  @ParameterizedTest
+  @MethodSource(Array("versions_and_prefixes"))
   def testNodeOneLabel(neo4j: Neo4j, prefix: String): Unit = {
     val options: java.util.Map[String, String] = new java.util.HashMap[String, String]()
     options.put(Neo4jOptions.URL, "bolt://localhost")
@@ -61,8 +62,8 @@ class Neo4jQueryServiceTest {
     assertEquals(s"${prefix}MATCH (n:`Person`) RETURN n", query)
   }
 
-  @Test
-  @Parameters(method = "versions_and_prefixes")
+  @ParameterizedTest
+  @MethodSource(Array("versions_and_prefixes"))
   def testNodeMultipleLabels(neo4j: Neo4j, prefix: String): Unit = {
     val options: java.util.Map[String, String] = new java.util.HashMap[String, String]()
     options.put(Neo4jOptions.URL, "bolt://localhost")
@@ -74,8 +75,8 @@ class Neo4jQueryServiceTest {
     assertEquals(s"${prefix}MATCH (n:`Person`:`Player`:`Midfield`) RETURN n", query)
   }
 
-  @Test
-  @Parameters(method = "versions_and_prefixes")
+  @ParameterizedTest
+  @MethodSource(Array("versions_and_prefixes"))
   def testNodeMultipleLabelsWithPartitions(neo4j: Neo4j, prefix: String): Unit = {
     val options: java.util.Map[String, String] = new java.util.HashMap[String, String]()
     options.put(Neo4jOptions.URL, "bolt://localhost")
@@ -93,8 +94,8 @@ class Neo4jQueryServiceTest {
     assertEquals(s"${prefix}MATCH (n:`Person`:`Player`:`Midfield`) RETURN n LIMIT 100", query)
   }
 
-  @Test
-  @Parameters(method = "versions_and_prefixes")
+  @ParameterizedTest
+  @MethodSource(Array("versions_and_prefixes"))
   def testNodeOneLabelWithOneSelectedColumn(neo4j: Neo4j, prefix: String): Unit = {
     val options: java.util.Map[String, String] = new java.util.HashMap[String, String]()
     options.put(Neo4jOptions.URL, "bolt://localhost")
@@ -109,8 +110,8 @@ class Neo4jQueryServiceTest {
     assertEquals(s"${prefix}MATCH (n:`Person`) RETURN n.name AS name", query)
   }
 
-  @Test
-  @Parameters(method = "versions_and_prefixes")
+  @ParameterizedTest
+  @MethodSource(Array("versions_and_prefixes"))
   def testNodeOneLabelWithMultipleColumnSelected(neo4j: Neo4j, prefix: String): Unit = {
     val options: java.util.Map[String, String] = new java.util.HashMap[String, String]()
     options.put(Neo4jOptions.URL, "bolt://localhost")
@@ -125,8 +126,8 @@ class Neo4jQueryServiceTest {
     assertEquals(s"${prefix}MATCH (n:`Person`) RETURN n.name AS name, n.bornDate AS bornDate", query)
   }
 
-  @Test
-  @Parameters(method = "versions_and_prefixes")
+  @ParameterizedTest
+  @MethodSource(Array("versions_and_prefixes"))
   def testNodeOneLabelWithInternalIdSelected(neo4j: Neo4j, prefix: String): Unit = {
     val options: java.util.Map[String, String] = new java.util.HashMap[String, String]()
     options.put(Neo4jOptions.URL, "bolt://localhost")
@@ -141,8 +142,8 @@ class Neo4jQueryServiceTest {
     assertEquals(s"${prefix}MATCH (n:`Person`) RETURN id(n) AS `<id>`", query)
   }
 
-  @Test
-  @Parameters(method = "versions_and_prefixes")
+  @ParameterizedTest
+  @MethodSource(Array("versions_and_prefixes"))
   def testNodeFilterEqualTo(neo4j: Neo4j, prefix: String): Unit = {
     val options: java.util.Map[String, String] = new java.util.HashMap[String, String]()
     options.put(Neo4jOptions.URL, "bolt://localhost")
@@ -160,8 +161,8 @@ class Neo4jQueryServiceTest {
     assertEquals(s"${prefix}MATCH (n:`Person`) WHERE n.name = $paramName RETURN n", query)
   }
 
-  @Test
-  @Parameters(method = "versions_and_prefixes")
+  @ParameterizedTest
+  @MethodSource(Array("versions_and_prefixes"))
   def testNodeFilterEqualNullSafe(neo4j: Neo4j, prefix: String): Unit = {
     val options: java.util.Map[String, String] = new java.util.HashMap[String, String]()
     options.put(Neo4jOptions.URL, "bolt://localhost")
@@ -187,8 +188,8 @@ class Neo4jQueryServiceTest {
     )
   }
 
-  @Test
-  @Parameters(method = "versions_and_prefixes")
+  @ParameterizedTest
+  @MethodSource(Array("versions_and_prefixes"))
   def testNodeFilterEqualNullSafeWithNullValue(neo4j: Neo4j, prefix: String): Unit = {
     val options: java.util.Map[String, String] = new java.util.HashMap[String, String]()
     options.put(Neo4jOptions.URL, "bolt://localhost")
@@ -211,8 +212,8 @@ class Neo4jQueryServiceTest {
     )
   }
 
-  @Test
-  @Parameters(method = "versions_and_prefixes")
+  @ParameterizedTest
+  @MethodSource(Array("versions_and_prefixes"))
   def testNodeFilterStartsEndsWith(neo4j: Neo4j, prefix: String): Unit = {
     val options: java.util.Map[String, String] = new java.util.HashMap[String, String]()
     options.put(Neo4jOptions.URL, "bolt://localhost")
@@ -238,8 +239,8 @@ class Neo4jQueryServiceTest {
     )
   }
 
-  @Test
-  @Parameters(method = "versions_and_prefixes")
+  @ParameterizedTest
+  @MethodSource(Array("versions_and_prefixes"))
   def testRelationshipWithOneColumnSelected(neo4j: Neo4j, prefix: String): Unit = {
     val options: java.util.Map[String, String] = new java.util.HashMap[String, String]()
     options.put(Neo4jOptions.URL, "bolt://localhost")
@@ -267,8 +268,8 @@ class Neo4jQueryServiceTest {
     )
   }
 
-  @Test
-  @Parameters(method = "versions_and_prefixes")
+  @ParameterizedTest
+  @MethodSource(Array("versions_and_prefixes"))
   def testRelationshipWithMoreColumnSelected(neo4j: Neo4j, prefix: String): Unit = {
     val options: java.util.Map[String, String] = new java.util.HashMap[String, String]()
     options.put(Neo4jOptions.URL, "bolt://localhost")
@@ -296,8 +297,8 @@ class Neo4jQueryServiceTest {
     )
   }
 
-  @Test
-  @Parameters(method = "versions_and_prefixes")
+  @ParameterizedTest
+  @MethodSource(Array("versions_and_prefixes"))
   def testRelationshipWithMoreColumnSelectedWithPartitions(neo4j: Neo4j, prefix: String): Unit = {
     val options: java.util.Map[String, String] = new java.util.HashMap[String, String]()
     options.put(Neo4jOptions.URL, "bolt://localhost")
@@ -329,8 +330,8 @@ class Neo4jQueryServiceTest {
     )
   }
 
-  @Test
-  @Parameters(method = "versions_and_prefixes")
+  @ParameterizedTest
+  @MethodSource(Array("versions_and_prefixes"))
   def testRelationshipWithMoreColumnsSelected(neo4j: Neo4j, prefix: String): Unit = {
     val options: java.util.Map[String, String] = new java.util.HashMap[String, String]()
     options.put(Neo4jOptions.URL, "bolt://localhost")
@@ -358,8 +359,8 @@ class Neo4jQueryServiceTest {
     )
   }
 
-  @Test
-  @Parameters(method = "versions_and_prefixes")
+  @ParameterizedTest
+  @MethodSource(Array("versions_and_prefixes"))
   def testRelationshipFilterEqualTo(neo4j: Neo4j, prefix: String): Unit = {
     val options: java.util.Map[String, String] = new java.util.HashMap[String, String]()
     options.put(Neo4jOptions.URL, "bolt://localhost")
@@ -385,8 +386,8 @@ class Neo4jQueryServiceTest {
     )
   }
 
-  @Test
-  @Parameters(method = "versions_and_prefixes")
+  @ParameterizedTest
+  @MethodSource(Array("versions_and_prefixes"))
   def testRelationshipFilterNotEqualTo(neo4j: Neo4j, prefix: String): Unit = {
     val options: java.util.Map[String, String] = new java.util.HashMap[String, String]()
     options.put(Neo4jOptions.URL, "bolt://localhost")
@@ -413,8 +414,8 @@ class Neo4jQueryServiceTest {
     )
   }
 
-  @Test
-  @Parameters(method = "versions_and_prefixes")
+  @ParameterizedTest
+  @MethodSource(Array("versions_and_prefixes"))
   def testRelationshipAndFilterEqualTo(neo4j: Neo4j, prefix: String): Unit = {
     val options: java.util.Map[String, String] = new java.util.HashMap[String, String]()
     options.put(Neo4jOptions.URL, "bolt://localhost")
@@ -445,8 +446,8 @@ class Neo4jQueryServiceTest {
     )
   }
 
-  @Test
-  @Parameters(method = "versions_and_prefixes")
+  @ParameterizedTest
+  @MethodSource(Array("versions_and_prefixes"))
   def testComplexNodeConditions(neo4j: Neo4j, prefix: String): Unit = {
     val options: java.util.Map[String, String] = new java.util.HashMap[String, String]()
     options.put(Neo4jOptions.URL, "bolt://localhost")
@@ -480,8 +481,8 @@ class Neo4jQueryServiceTest {
     )
   }
 
-  @Test
-  @Parameters(method = "versions_and_prefixes")
+  @ParameterizedTest
+  @MethodSource(Array("versions_and_prefixes"))
   def testRelationshipFilterComplexConditionsNoMap(neo4j: Neo4j, prefix: String): Unit = {
     val options: java.util.Map[String, String] = new java.util.HashMap[String, String]()
     options.put(Neo4jOptions.URL, "bolt://localhost")
@@ -527,8 +528,8 @@ class Neo4jQueryServiceTest {
     )
   }
 
-  @Test
-  @Parameters(method = "versions_and_prefixes")
+  @ParameterizedTest
+  @MethodSource(Array("versions_and_prefixes"))
   def testRelationshipFilterComplexConditionsWithMap(neo4j: Neo4j, prefix: String): Unit = {
     val options: java.util.Map[String, String] = new java.util.HashMap[String, String]()
     options.put(Neo4jOptions.URL, "bolt://localhost")
@@ -575,8 +576,8 @@ class Neo4jQueryServiceTest {
     )
   }
 
-  @Test
-  @Parameters(method = "versions_and_prefixes")
+  @ParameterizedTest
+  @MethodSource(Array("versions_and_prefixes"))
   def testCompoundKeysForNodes(neo4j: Neo4j, prefix: String): Unit = {
     val options: java.util.Map[String, String] = new java.util.HashMap[String, String]()
     options.put(Neo4jOptions.URL, "bolt://localhost")
@@ -596,8 +597,8 @@ class Neo4jQueryServiceTest {
     )
   }
 
-  @Test
-  @Parameters(method = "versions_and_prefixes")
+  @ParameterizedTest
+  @MethodSource(Array("versions_and_prefixes"))
   def testCompoundKeysForRelationship(neo4j: Neo4j, prefix: String): Unit = {
     val options: java.util.Map[String, String] = new java.util.HashMap[String, String]()
     options.put(Neo4jOptions.URL, "bolt://localhost")
@@ -623,8 +624,8 @@ class Neo4jQueryServiceTest {
     )
   }
 
-  @Test
-  @Parameters(method = "versions_and_prefixes")
+  @ParameterizedTest
+  @MethodSource(Array("versions_and_prefixes"))
   def testCompoundKeysForRelationshipMergeMatch(neo4j: Neo4j, prefix: String): Unit = {
     val options: java.util.Map[String, String] = new java.util.HashMap[String, String]()
     options.put(Neo4jOptions.URL, "bolt://localhost")
@@ -653,8 +654,8 @@ class Neo4jQueryServiceTest {
     )
   }
 
-  @Test
-  @Parameters(method = "versions_and_prefixes")
+  @ParameterizedTest
+  @MethodSource(Array("versions_and_prefixes"))
   def testShouldDoSumAggregationOnLabels(neo4j: Neo4j, prefix: String): Unit = {
     val options: java.util.Map[String, String] = new java.util.HashMap[String, String]()
     options.put(Neo4jOptions.URL, "bolt://localhost")
@@ -721,8 +722,8 @@ class Neo4jQueryServiceTest {
     )
   }
 
-  @Test
-  @Parameters(method = "versions_and_prefixes")
+  @ParameterizedTest
+  @MethodSource(Array("versions_and_prefixes"))
   def testShouldDoSumAggregationOnRelationships(neo4j: Neo4j, prefix: String): Unit = {
     val options: java.util.Map[String, String] = new java.util.HashMap[String, String]()
     options.put(Neo4jOptions.URL, "bolt://localhost")
@@ -806,8 +807,8 @@ class Neo4jQueryServiceTest {
     )
   }
 
-  @Test
-  @Parameters(method = "versions_and_prefixes")
+  @ParameterizedTest
+  @MethodSource(Array("versions_and_prefixes"))
   def testTopNForLabels(neo4j: Neo4j, prefix: String): Unit = {
     val options: java.util.Map[String, String] = new java.util.HashMap[String, String]()
     options.put(Neo4jOptions.URL, "bolt://localhost")
@@ -838,8 +839,8 @@ class Neo4jQueryServiceTest {
     assertEquals(s"${prefix}MATCH (n:`Person`) RETURN n ORDER BY n.name ASC LIMIT 42", query)
   }
 
-  @Test
-  @Parameters(method = "versions_and_prefixes")
+  @ParameterizedTest
+  @MethodSource(Array("versions_and_prefixes"))
   def testTopNForLabelsWithRequiredColumn(neo4j: Neo4j, prefix: String): Unit = {
     val options: java.util.Map[String, String] = new java.util.HashMap[String, String]()
     options.put(Neo4jOptions.URL, "bolt://localhost")
@@ -871,8 +872,8 @@ class Neo4jQueryServiceTest {
     assertEquals(s"${prefix}MATCH (n:`Person`) RETURN n.name AS name ORDER BY n.name ASC LIMIT 42", query)
   }
 
-  @Test
-  @Parameters(method = "versions_and_prefixes")
+  @ParameterizedTest
+  @MethodSource(Array("versions_and_prefixes"))
   def testTopNForRelationships(neo4j: Neo4j, prefix: String): Unit = {
     val options: java.util.Map[String, String] = new java.util.HashMap[String, String]()
     options.put(Neo4jOptions.URL, "bolt://localhost")
@@ -913,8 +914,8 @@ class Neo4jQueryServiceTest {
     )
   }
 
-  @Test
-  @Parameters(method = "versions_and_prefixes")
+  @ParameterizedTest
+  @MethodSource(Array("versions_and_prefixes"))
   def testTopNForRelationshipWithOneRequiredColumn(neo4j: Neo4j, prefix: String): Unit = {
     val options: java.util.Map[String, String] = new java.util.HashMap[String, String]()
     options.put(Neo4jOptions.URL, "bolt://localhost")
@@ -958,8 +959,8 @@ class Neo4jQueryServiceTest {
     )
   }
 
-  @Test
-  @Parameters(method = "versions_and_prefixes")
+  @ParameterizedTest
+  @MethodSource(Array("versions_and_prefixes"))
   def testTopNForCustomQueryIgnoresAggregation(neo4j: Neo4j, ignored: String): Unit = {
     val options: java.util.Map[String, String] = new java.util.HashMap[String, String]()
     options.put(Neo4jOptions.URL, "bolt://localhost")

--- a/src/test/scala/org/neo4j/spark/service/SchemaServiceTSE.scala
+++ b/src/test/scala/org/neo4j/spark/service/SchemaServiceTSE.scala
@@ -37,7 +37,6 @@ import org.neo4j.spark.util.QueryType
 
 import java.util
 
-@TestMethodOrder(classOf[MethodOrderer.MethodName])
 class SchemaServiceTSE extends SparkConnectorScalaBaseTSE {
 
   @BeforeEach

--- a/src/test/scala/org/neo4j/spark/service/SchemaServiceTSE.scala
+++ b/src/test/scala/org/neo4j/spark/service/SchemaServiceTSE.scala
@@ -19,11 +19,11 @@ package org.neo4j.spark.service
 import org.apache.spark.sql.types.DataTypes
 import org.apache.spark.sql.types.StructField
 import org.apache.spark.sql.types.StructType
-import org.junit.Assert._
-import org.junit.Before
-import org.junit.FixMethodOrder
-import org.junit.Test
-import org.junit.runners.MethodSorters
+import org.junit.jupiter.api.Assertions._
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.MethodOrderer
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.TestMethodOrder
 import org.neo4j.driver.TransactionContext
 import org.neo4j.spark.converter.CypherToSparkTypeConverter
 import org.neo4j.spark.testsupport.Closeables.use
@@ -37,10 +37,10 @@ import org.neo4j.spark.util.QueryType
 
 import java.util
 
-@FixMethodOrder(MethodSorters.JVM)
+@TestMethodOrder(classOf[MethodOrderer.MethodName])
 class SchemaServiceTSE extends SparkConnectorScalaBaseTSE {
 
-  @Before
+  @BeforeEach
   def beforeEach(): Unit = {
     use(SparkConnectorScalaSuiteIT.session("system")) {
       session =>

--- a/src/test/scala/org/neo4j/spark/service/SchemaServiceTest.scala
+++ b/src/test/scala/org/neo4j/spark/service/SchemaServiceTest.scala
@@ -16,8 +16,8 @@
  */
 package org.neo4j.spark.service
 
-import org.junit.Assert.assertEquals
-import org.junit.Test
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Test
 import org.mockito.Mockito.RETURNS_DEEP_STUBS
 import org.mockito.Mockito.mock
 import org.neo4j.caniuse.Neo4j

--- a/src/test/scala/org/neo4j/spark/service/SchemaServiceWithApocTSE.scala
+++ b/src/test/scala/org/neo4j/spark/service/SchemaServiceWithApocTSE.scala
@@ -40,7 +40,6 @@ import org.neo4j.spark.util.QueryType
 
 import java.util
 
-@TestMethodOrder(classOf[MethodOrderer.MethodName])
 class SchemaServiceWithApocTSE extends SparkConnectorScalaBaseWithApocTSE {
 
   @BeforeEach

--- a/src/test/scala/org/neo4j/spark/service/SchemaServiceWithApocTSE.scala
+++ b/src/test/scala/org/neo4j/spark/service/SchemaServiceWithApocTSE.scala
@@ -20,10 +20,10 @@ import org.apache.spark.sql.types.DataTypes
 import org.apache.spark.sql.types.StructField
 import org.apache.spark.sql.types.StructType
 import org.junit.Assert._
-import org.junit.Before
-import org.junit.FixMethodOrder
-import org.junit.Test
-import org.junit.runners.MethodSorters
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.MethodOrderer
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.TestMethodOrder
 import org.neo4j.caniuse.Neo4j
 import org.neo4j.caniuse.Neo4jDeploymentType
 import org.neo4j.caniuse.Neo4jEdition
@@ -40,10 +40,10 @@ import org.neo4j.spark.util.QueryType
 
 import java.util
 
-@FixMethodOrder(MethodSorters.JVM)
+@TestMethodOrder(classOf[MethodOrderer.MethodName])
 class SchemaServiceWithApocTSE extends SparkConnectorScalaBaseWithApocTSE {
 
-  @Before
+  @BeforeEach
   def beforeEach(): Unit = {
     use(SparkConnectorScalaSuiteWithApocIT.session("system")) {
       session =>

--- a/src/test/scala/org/neo4j/spark/testsupport/SparkConnectorScalaBaseTSE.scala
+++ b/src/test/scala/org/neo4j/spark/testsupport/SparkConnectorScalaBaseTSE.scala
@@ -18,26 +18,22 @@ package org.neo4j.spark.testsupport
 
 import org.apache.spark.SparkConf
 import org.apache.spark.sql.SparkSession
-import org.junit._
-import org.junit.rules.TestName
+import org.junit.jupiter.api._
 import org.neo4j.spark.testsupport.Closeables.use
-import org.scalatestplus.junit.AssertionsForJUnit
-
-import scala.annotation.meta.getter
 
 object SparkConnectorScalaBaseTSE {
 
   private var startedFromSuite = true
 
-  @BeforeClass
+  @BeforeAll
   def setUpContainer() = {
     if (!SparkConnectorScalaSuiteIT.server.isRunning) {
       startedFromSuite = false
-      SparkConnectorScalaSuiteIT.setUpContainer()
     }
+    SparkConnectorScalaSuiteIT.setUpContainer()
   }
 
-  @AfterClass
+  @AfterAll
   def tearDownContainer() = {
     if (!startedFromSuite) {
       SparkConnectorScalaSuiteIT.tearDownContainer()
@@ -46,23 +42,25 @@ object SparkConnectorScalaBaseTSE {
 
 }
 
-class SparkConnectorScalaBaseTSE extends AssertionsForJUnit {
+class SparkConnectorScalaBaseTSE {
 
   val conf: SparkConf = SparkConnectorScalaSuiteIT.conf
   val ss: SparkSession = SparkConnectorScalaSuiteIT.ss
 
-  @(Rule @getter)
-  val testName: TestName = new TestName
+  private var _testInfo: TestInfo = _
 
-  @Before
-  def before(): Unit = {
+  @BeforeEach
+  def before(testInfo: TestInfo): Unit = {
+    _testInfo = testInfo
     use(SparkConnectorScalaSuiteIT.session("system")) { session =>
       session
         .run("CREATE OR REPLACE DATABASE neo4j WAIT 30 seconds").consume()
     }
   }
 
-  @After
+  def testName: String = _testInfo.getDisplayName
+
+  @AfterEach
   def after(): Unit = {
     ss.catalog.listTables()
       .collect()

--- a/src/test/scala/org/neo4j/spark/testsupport/SparkConnectorScalaBaseWithApocTSE.scala
+++ b/src/test/scala/org/neo4j/spark/testsupport/SparkConnectorScalaBaseWithApocTSE.scala
@@ -18,25 +18,22 @@ package org.neo4j.spark.testsupport
 
 import org.apache.spark.SparkConf
 import org.apache.spark.sql.SparkSession
-import org.junit._
-import org.junit.rules.TestName
+import org.junit.jupiter.api._
 import org.neo4j.spark.testsupport.Closeables.use
-
-import scala.annotation.meta.getter
 
 object SparkConnectorScalaBaseWithApocTSE {
 
   private var startedFromSuite = true
 
-  @BeforeClass
+  @BeforeAll
   def setUpContainer() = {
     if (!SparkConnectorScalaSuiteWithApocIT.server.isRunning) {
       startedFromSuite = false
-      SparkConnectorScalaSuiteWithApocIT.setUpContainer()
     }
+    SparkConnectorScalaSuiteWithApocIT.setUpContainer()
   }
 
-  @AfterClass
+  @AfterAll
   def tearDownContainer() = {
     if (!startedFromSuite) {
       SparkConnectorScalaSuiteWithApocIT.tearDownContainer()
@@ -50,11 +47,14 @@ class SparkConnectorScalaBaseWithApocTSE {
   val conf: SparkConf = SparkConnectorScalaSuiteWithApocIT.conf
   val ss: SparkSession = SparkConnectorScalaSuiteWithApocIT.ss
 
-  @(Rule @getter)
-  val testName: TestName = new TestName
+  @Test
+  def myTest(testInfo: TestInfo): Unit = {
+    val testName = testInfo.getDisplayName
+    println(testName)
+  }
 
-  @Before
-  def before() {
+  @BeforeEach
+  def before(): Unit = {
     use(SparkConnectorScalaSuiteWithApocIT.session("system")) {
       session =>
         session.run("CREATE OR REPLACE DATABASE neo4j WAIT 30 seconds")

--- a/src/test/scala/org/neo4j/spark/testsupport/SparkConnectorScalaBaseWithApocTSE.scala
+++ b/src/test/scala/org/neo4j/spark/testsupport/SparkConnectorScalaBaseWithApocTSE.scala
@@ -47,12 +47,6 @@ class SparkConnectorScalaBaseWithApocTSE {
   val conf: SparkConf = SparkConnectorScalaSuiteWithApocIT.conf
   val ss: SparkSession = SparkConnectorScalaSuiteWithApocIT.ss
 
-  @Test
-  def myTest(testInfo: TestInfo): Unit = {
-    val testName = testInfo.getDisplayName
-    println(testName)
-  }
-
   @BeforeEach
   def before(): Unit = {
     use(SparkConnectorScalaSuiteWithApocIT.session("system")) {

--- a/src/test/scala/org/neo4j/spark/testsupport/SparkConnectorScalaSuiteIT.scala
+++ b/src/test/scala/org/neo4j/spark/testsupport/SparkConnectorScalaSuiteIT.scala
@@ -18,9 +18,9 @@ package org.neo4j.spark.testsupport
 
 import org.apache.spark.SparkConf
 import org.apache.spark.sql.SparkSession
-import org.junit.AfterClass
-import org.junit.Assume
-import org.junit.BeforeClass
+import org.junit.jupiter.api.AfterAll
+import org.junit.jupiter.api.Assumptions.assumeTrue
+import org.junit.jupiter.api.BeforeAll
 import org.neo4j.caniuse.Neo4j
 import org.neo4j.caniuse.Neo4jDetector
 import org.neo4j.driver._
@@ -43,7 +43,7 @@ object SparkConnectorScalaSuiteIT {
   var tmpDir: File = _
   var neo4j: Neo4j = _
 
-  @BeforeClass
+  @BeforeAll
   def setUpContainer(): Unit = {
     if (!server.isRunning) {
       try {
@@ -51,7 +51,8 @@ object SparkConnectorScalaSuiteIT {
       } catch {
         case _: Throwable => //
       }
-      Assume.assumeTrue("Neo4j container is not started", server.isRunning)
+    }
+    if (server.isRunning && driver == null) {
       tmpDir = Files.createTempDirectory("spark-warehouse").toFile
       tmpDir.deleteOnExit()
       conf = new SparkConf()
@@ -63,11 +64,13 @@ object SparkConnectorScalaSuiteIT {
       driver = GraphDatabase.driver(server.getBoltUrl, AuthTokens.none())
       neo4j = Neo4jDetector.INSTANCE.detect(driver)
     }
+    assumeTrue(server.isRunning, "Neo4j container is not started")
   }
 
-  @AfterClass
+  @AfterAll
   def tearDownContainer() = {
     TestUtil.closeSafely(driver)
+    driver = null
     TestUtil.closeSafely(server)
     TestUtil.closeSafely(ss)
   }

--- a/src/test/scala/org/neo4j/spark/testsupport/SparkConnectorScalaSuiteWithApocIT.scala
+++ b/src/test/scala/org/neo4j/spark/testsupport/SparkConnectorScalaSuiteWithApocIT.scala
@@ -18,9 +18,9 @@ package org.neo4j.spark.testsupport
 
 import org.apache.spark.SparkConf
 import org.apache.spark.sql.SparkSession
-import org.junit.AfterClass
-import org.junit.Assume
-import org.junit.BeforeClass
+import org.junit.jupiter.api.AfterAll
+import org.junit.jupiter.api.Assumptions.assumeTrue
+import org.junit.jupiter.api.BeforeAll
 import org.neo4j.caniuse.Neo4j
 import org.neo4j.caniuse.Neo4jDetector
 import org.neo4j.driver._
@@ -41,7 +41,7 @@ object SparkConnectorScalaSuiteWithApocIT {
   var driver: Driver = _
   var neo4j: Neo4j = _
 
-  @BeforeClass
+  @BeforeAll
   def setUpContainer(): Unit = {
     if (!server.isRunning) {
       try {
@@ -49,7 +49,8 @@ object SparkConnectorScalaSuiteWithApocIT {
       } catch {
         case _: Throwable => //
       }
-      Assume.assumeTrue("Neo4j container is not started", server.isRunning)
+    }
+    if (server.isRunning && driver == null) {
       conf = new SparkConf()
         .setAppName("neoTest")
         .setMaster("local[*]")
@@ -58,12 +59,14 @@ object SparkConnectorScalaSuiteWithApocIT {
       driver = GraphDatabase.driver(server.getBoltUrl, AuthTokens.none())
       neo4j = Neo4jDetector.INSTANCE.detect(driver)
     }
-    Assume.assumeTrue("Neo4j Preview versions doesn't have APOC", TestUtil.hasApoc(session()))
+    assumeTrue(server.isRunning, "Neo4j container is not started")
+    assumeTrue(TestUtil.hasApoc(session()), "Neo4j Preview versions doesn't have APOC")
   }
 
-  @AfterClass
+  @AfterAll
   def tearDownContainer() = {
     TestUtil.closeSafely(driver)
+    driver = null
     TestUtil.closeSafely(server)
     TestUtil.closeSafely(ss)
   }

--- a/src/test/scala/org/neo4j/spark/testsupport/SparkConnectorScalaSuiteWithGdsBase.scala
+++ b/src/test/scala/org/neo4j/spark/testsupport/SparkConnectorScalaSuiteWithGdsBase.scala
@@ -18,16 +18,16 @@ package org.neo4j.spark.testsupport
 
 import org.apache.spark.SparkConf
 import org.apache.spark.sql.SparkSession
-import org.junit._
-import org.junit.rules.TestName
+import org.junit.jupiter.api.AfterAll
+import org.junit.jupiter.api.Assumptions.assumeTrue
+import org.junit.jupiter.api.BeforeAll
+import org.junit.jupiter.api._
 import org.neo4j.caniuse.Neo4j
 import org.neo4j.caniuse.Neo4jDetector
 import org.neo4j.driver._
 import org.neo4j.spark.testsupport.Closeables.use
 
 import java.util.TimeZone
-
-import scala.annotation.meta.getter
 
 object SparkConnectorScalaSuiteWithGdsBase {
 
@@ -43,7 +43,7 @@ object SparkConnectorScalaSuiteWithGdsBase {
   var driver: Driver = _
   var neo4j: Neo4j = _
 
-  @BeforeClass
+  @BeforeAll
   def setUpContainer(): Unit = {
     if (!server.isRunning) {
       try {
@@ -51,7 +51,8 @@ object SparkConnectorScalaSuiteWithGdsBase {
       } catch {
         case _: Throwable => //
       }
-      Assume.assumeTrue("Neo4j container is not started", server.isRunning)
+    }
+    if (server.isRunning && driver == null) {
       conf = new SparkConf()
         .setAppName("neoTest")
         .setMaster("local[*]")
@@ -60,11 +61,13 @@ object SparkConnectorScalaSuiteWithGdsBase {
       driver = GraphDatabase.driver(server.getBoltUrl, AuthTokens.none())
       neo4j = Neo4jDetector.INSTANCE.detect(driver)
     }
+    assumeTrue(server.isRunning, "Neo4j container is not started")
   }
 
-  @AfterClass
+  @AfterAll
   def tearDownContainer(): Unit = {
     TestUtil.closeSafely(driver)
+    driver = null
     TestUtil.closeSafely(server)
     TestUtil.closeSafely(ss)
   }
@@ -83,10 +86,13 @@ class SparkConnectorScalaSuiteWithGdsBase {
   val conf: SparkConf = SparkConnectorScalaSuiteWithGdsBase.conf
   val ss: SparkSession = SparkConnectorScalaSuiteWithGdsBase.ss
 
-  @(Rule @getter)
-  val testName: TestName = new TestName
+  @Test
+  def myTest(testInfo: TestInfo): Unit = {
+    val testName = testInfo.getDisplayName
+    println(testName)
+  }
 
-  @Before
+  @BeforeEach
   def before(): Unit = {
     use(SparkConnectorScalaSuiteWithGdsBase.session("system")) {
       session =>

--- a/src/test/scala/org/neo4j/spark/testsupport/SparkConnectorScalaSuiteWithGdsBase.scala
+++ b/src/test/scala/org/neo4j/spark/testsupport/SparkConnectorScalaSuiteWithGdsBase.scala
@@ -86,12 +86,6 @@ class SparkConnectorScalaSuiteWithGdsBase {
   val conf: SparkConf = SparkConnectorScalaSuiteWithGdsBase.conf
   val ss: SparkSession = SparkConnectorScalaSuiteWithGdsBase.ss
 
-  @Test
-  def myTest(testInfo: TestInfo): Unit = {
-    val testName = testInfo.getDisplayName
-    println(testName)
-  }
-
   @BeforeEach
   def before(): Unit = {
     use(SparkConnectorScalaSuiteWithGdsBase.session("system")) {

--- a/src/test/scala/org/neo4j/spark/testsupport/VersionTest.scala
+++ b/src/test/scala/org/neo4j/spark/testsupport/VersionTest.scala
@@ -16,8 +16,8 @@
  */
 package org.neo4j.spark.testsupport
 
-import org.junit.Assert.assertEquals
-import org.junit.Test
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Test
 
 class VersionTest {
 

--- a/src/test/scala/org/neo4j/spark/util/Neo4jImplicitsTest.scala
+++ b/src/test/scala/org/neo4j/spark/util/Neo4jImplicitsTest.scala
@@ -24,9 +24,8 @@ import org.apache.spark.sql.sources.EqualTo
 import org.apache.spark.sql.types.DataTypes
 import org.apache.spark.sql.types.StructField
 import org.apache.spark.sql.types.StructType
-import org.junit.Assert
-import org.junit.Assert._
-import org.junit.Test
+import org.junit.jupiter.api.Assertions._
+import org.junit.jupiter.api.Test
 import org.neo4j.spark.util.Neo4jImplicits._
 
 import scala.collection.JavaConverters.mapAsJavaMapConverter
@@ -189,7 +188,7 @@ class Neo4jImplicitsTest {
       "key.innerKey.innerKey2" -> "value"
     )
     val actual = input.flattenMap()
-    Assert.assertEquals(expected, actual)
+    assertEquals(expected, actual)
   }
 
   @Test
@@ -206,7 +205,7 @@ class Neo4jImplicitsTest {
       "my.inner.key" -> 42
     )
     val actual = input.flattenMap()
-    Assert.assertEquals(expected, actual)
+    assertEquals(expected, actual)
   }
 
   @Test
@@ -223,7 +222,7 @@ class Neo4jImplicitsTest {
       "my.inner.key" -> Seq(42424242, 424242, 4242, 42).asJava
     )
     val actual = input.flattenMap(groupDuplicateKeys = true)
-    Assert.assertEquals(expected, actual)
+    assertEquals(expected, actual)
   }
 
   @Test
@@ -238,7 +237,7 @@ class Neo4jImplicitsTest {
     )
     val expected = Seq("my.inner.key", "my.inner.key", "my.inner.key", "my.inner.key")
     val actual = input.flattenKeys()
-    Assert.assertEquals(expected, actual)
+    assertEquals(expected, actual)
   }
 
   @Test
@@ -269,7 +268,7 @@ class Neo4jImplicitsTest {
         ).asJava
       ).asJava
     ).asJava
-    Assert.assertEquals(expected, actual)
+    assertEquals(expected, actual)
 
     val ucActual = Map(
       "graphName" -> "myGraph",
@@ -285,6 +284,6 @@ class Neo4jImplicitsTest {
         ).asJava
       ).asJava
     ).asJava
-    Assert.assertEquals(ucExpected, ucActual)
+    assertEquals(ucExpected, ucActual)
   }
 }

--- a/src/test/scala/org/neo4j/spark/util/Neo4jOptionsIT.scala
+++ b/src/test/scala/org/neo4j/spark/util/Neo4jOptionsIT.scala
@@ -16,10 +16,9 @@
  */
 package org.neo4j.spark.util
 
-import org.junit.Assert.assertEquals
-import org.junit.Assert.assertNotNull
-import org.junit.Ignore
-import org.junit.Test
+import org.junit.jupiter.api.Assertions._
+import org.junit.jupiter.api.Disabled
+import org.junit.jupiter.api.Test
 import org.neo4j.spark.testsupport.Closeables.use
 import org.neo4j.spark.testsupport.SparkConnectorScalaSuiteIT
 import org.neo4j.spark.testsupport.SparkConnectorScalaSuiteIT.server
@@ -44,7 +43,7 @@ class Neo4jOptionsIT extends SparkConnectorScalaSuiteIT {
   }
 
   @Test
-  @Ignore("This requires a fix on driver, ignoring until it is implemented")
+  @Disabled("This requires a fix on driver, ignoring until it is implemented")
   def shouldConstructDriverWithResolver(): Unit = {
     val options: java.util.Map[String, String] = new java.util.HashMap[String, String]()
     options.put(

--- a/src/test/scala/org/neo4j/spark/util/Neo4jOptionsTest.scala
+++ b/src/test/scala/org/neo4j/spark/util/Neo4jOptionsTest.scala
@@ -16,34 +16,31 @@
  */
 package org.neo4j.spark.util
 
-import org.junit.Assert._
-import org.junit.Test
+import org.junit.jupiter.api.Assertions._
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.function.Executable
 import org.neo4j.driver.AccessMode
 import org.neo4j.driver.net.ServerAddress
 
 import java.net.URI
 import java.time.Duration
 
-import scala.annotation.meta.getter
 import scala.collection.JavaConverters._
 
 class Neo4jOptionsTest {
-
-  import org.junit.Rule
-  import org.junit.rules.ExpectedException
-
-  @(Rule @getter)
-  val _expectedException: ExpectedException = ExpectedException.none
 
   @Test
   def testUrlIsRequired(): Unit = {
     val options: java.util.Map[String, String] = new java.util.HashMap[String, String]()
     options.put(QueryType.QUERY.toString.toLowerCase, "Person")
 
-    _expectedException.expect(classOf[IllegalArgumentException])
-    _expectedException.expectMessage("Parameter 'url' is required")
-
-    new Neo4jOptions(options)
+    val exception = assertThrows(
+      classOf[IllegalArgumentException],
+      new Executable {
+        override def execute(): Unit = new Neo4jOptions(options)
+      }
+    )
+    assertTrue(exception.getMessage.contains("Parameter 'url' is required"))
   }
 
   @Test
@@ -93,10 +90,13 @@ class Neo4jOptionsTest {
     options.put(QueryType.LABELS.toString.toLowerCase, "PERSON")
     options.put("relationship.save.strategy", "nope")
 
-    _expectedException.expect(classOf[NoSuchElementException])
-    _expectedException.expectMessage("No value found for 'NOPE'")
-
-    new Neo4jOptions(options)
+    val exception = assertThrows(
+      classOf[NoSuchElementException],
+      new Executable {
+        override def execute(): Unit = new Neo4jOptions(options)
+      }
+    )
+    assertEquals("No value found for 'NOPE'", exception.getMessage)
   }
 
   @Test

--- a/src/test/scala/org/neo4j/spark/util/Neo4jUtilTest.scala
+++ b/src/test/scala/org/neo4j/spark/util/Neo4jUtilTest.scala
@@ -17,8 +17,8 @@
 package org.neo4j.spark.util
 
 import org.apache.commons.lang3.StringUtils
-import org.junit.Assert
-import org.junit.Test
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Test
 
 class Neo4jUtilTest {
 
@@ -35,14 +35,14 @@ class Neo4jUtilTest {
       "spark"
     }
     val actual = Neo4jUtil.connectorEnv
-    Assert.assertEquals(expected, actual)
+    assertEquals(expected, actual)
   }
 
   @Test
   def testConnectorEnvForCustom(): Unit = {
     System.setProperty("neo4j.spark.platform", "abc")
     val actual = Neo4jUtil.connectorEnv
-    Assert.assertEquals("abc", actual)
+    assertEquals("abc", actual)
   }
 
 }

--- a/src/test/scala/org/neo4j/spark/util/ValidationsIT.scala
+++ b/src/test/scala/org/neo4j/spark/util/ValidationsIT.scala
@@ -16,137 +16,169 @@
  */
 package org.neo4j.spark.util
 
-import org.hamcrest.CoreMatchers
-import org.junit.Rule
-import org.junit.Test
-import org.junit.rules.ExpectedException
+import org.junit.jupiter.api.Assertions._
+import org.junit.jupiter.api.Test
 import org.neo4j.driver.AccessMode
 import org.neo4j.spark.testsupport.SparkConnectorScalaSuiteIT
 import org.neo4j.spark.testsupport.SparkConnectorScalaSuiteIT.neo4j
 
-import scala.annotation.meta.getter
-
 class ValidationsIT extends SparkConnectorScalaSuiteIT {
-
-  @(Rule @getter)
-  val expectedException: ExpectedException = ExpectedException.none
 
   @Test
   def testReadQueryShouldBeSyntacticallyInvalid(): Unit = {
-    // then
-    expectedException.expect(classOf[IllegalArgumentException])
-    expectedException.expectMessage(
-      CoreMatchers.containsString("Query not compiled for the following exception: ClientException: Invalid input ")
-    )
-    val query = "MATCH (f{) RETURN f"
-    expectedException.expectMessage(CoreMatchers.containsString(query))
-
     // given
     val readOpts: java.util.Map[String, String] = new java.util.HashMap[String, String]()
+    val query = "MATCH (f{) RETURN f"
     readOpts.put(Neo4jOptions.URL, SparkConnectorScalaSuiteIT.server.getBoltUrl)
     readOpts.put("query", query)
 
-    // when
-    Validations.validate(ValidateRead(neo4j, new Neo4jOptions(readOpts), "1"))
+    // when & then
+    val exception = assertThrows(
+      classOf[IllegalArgumentException],
+      () => {
+        Validations.validate(ValidateRead(neo4j, new Neo4jOptions(readOpts), "1"))
+      }
+    )
+    assertTrue(
+      exception.getMessage.contains(
+        "Query not compiled for the following exception: ClientException: Invalid input "
+      )
+    )
+    assertTrue(
+      exception.getMessage.contains(query)
+    )
   }
 
   @Test
   def testReadQueryShouldBeSemanticallyInvalid(): Unit = {
-    // then
-    val query = "MERGE (n:TestNode{id: 1}) RETURN n"
-    expectedException.expect(classOf[IllegalArgumentException])
-    expectedException.expectMessage(
-      s"Invalid query `$query` because the accepted types are [READ_ONLY], but the actual type is READ_WRITE"
-    )
-
     // given
+    val query = "MERGE (n:TestNode{id: 1}) RETURN n"
     val readOpts: java.util.Map[String, String] = new java.util.HashMap[String, String]()
     readOpts.put(Neo4jOptions.URL, SparkConnectorScalaSuiteIT.server.getBoltUrl)
     readOpts.put("query", query)
 
-    // when
-    Validations.validate(ValidateRead(neo4j, new Neo4jOptions(readOpts), "1"))
+    // when & then
+    val exception = assertThrows(
+      classOf[IllegalArgumentException],
+      () => {
+        Validations.validate(ValidateRead(neo4j, new Neo4jOptions(readOpts), "1"))
+      }
+    )
+    assertTrue(
+      exception.getMessage.contains(
+        s"Invalid query `$query` because the accepted types are [READ_ONLY], but the actual type is READ_WRITE"
+      )
+    )
   }
 
   @Test
   def testReadQueryCountBeSyntacticallyInvalid(): Unit = {
-    // then
-    val query = "MATCH (f{) RETURN f"
-    expectedException.expect(classOf[IllegalArgumentException])
-    expectedException.expectMessage(CoreMatchers.containsString(
-      "Query count not compiled for the following exception: ClientException: Invalid input "
-    ))
-    expectedException.expectMessage(CoreMatchers.containsString(s"EXPLAIN $query"))
-
     // given
+    val query = "MATCH (f{) RETURN f"
     val readOpts: java.util.Map[String, String] = new java.util.HashMap[String, String]()
     readOpts.put(Neo4jOptions.URL, SparkConnectorScalaSuiteIT.server.getBoltUrl)
     readOpts.put("query", "MATCH (f) RETURN f")
     readOpts.put("query.count", query)
 
-    // when
-    Validations.validate(ValidateRead(neo4j, new Neo4jOptions(readOpts), "1"))
+    // when & then
+    val exception = assertThrows(
+      classOf[IllegalArgumentException],
+      () => {
+        Validations.validate(ValidateRead(neo4j, new Neo4jOptions(readOpts), "1"))
+      }
+    )
+    assertTrue(
+      exception.getMessage.contains(
+        "Query count not compiled for the following exception: ClientException: Invalid input "
+      )
+    )
+    assertTrue(
+      exception.getMessage.contains(s"EXPLAIN $query")
+    )
   }
 
   @Test
   def testScriptQueryCountShouldContainAnInvalidQuery(): Unit = {
-    // then
-    expectedException.expect(classOf[IllegalArgumentException])
-    expectedException.expectMessage(
-      CoreMatchers.containsString("The following queries inside the `script` are not valid,")
-    )
-    expectedException.expectMessage(
-      CoreMatchers.containsString("Query not compiled for the following exception: ClientException: Invalid input ")
-    )
-    expectedException.expectMessage(CoreMatchers.containsString("EXPLAIN RETUR 2 AS two"))
-
     // given
     val readOpts: java.util.Map[String, String] = new java.util.HashMap[String, String]()
     readOpts.put(Neo4jOptions.URL, SparkConnectorScalaSuiteIT.server.getBoltUrl)
     readOpts.put("query", "MATCH (f) RETURN f")
     readOpts.put("script", "RETURN 1 AS one; RETUR 2 AS two; RETURN 3 AS three")
 
-    // when
-    Validations.validate(ValidateRead(neo4j, new Neo4jOptions(readOpts), "1"))
+    // when & then
+    val exception = assertThrows(
+      classOf[IllegalArgumentException],
+      () => {
+        Validations.validate(ValidateRead(neo4j, new Neo4jOptions(readOpts), "1"))
+      }
+    )
+    assertTrue(
+      exception.getMessage.contains(
+        "The following queries inside the `script` are not valid,"
+      )
+    )
+
+    assertTrue(
+      exception.getMessage.contains(
+        "Query not compiled for the following exception: ClientException: Invalid input "
+      )
+    )
+
+    assertTrue(
+      exception.getMessage.contains(
+        "EXPLAIN RETUR 2 AS two"
+      )
+    )
+
   }
 
   @Test
   def testWriteQueryShouldBeSyntacticallyInvalid(): Unit = {
-    // then
-    val query = "MERGE (f{) RETURN f"
-    expectedException.expect(classOf[IllegalArgumentException])
-    expectedException.expectMessage(
-      CoreMatchers.containsString("Query not compiled for the following exception: ClientException: Invalid input ")
-    )
-    expectedException.expectMessage(CoreMatchers.containsString(query))
-
     // given
+    val query = "MERGE (f{) RETURN f"
     val writeOpts: java.util.Map[String, String] = new java.util.HashMap[String, String]()
     writeOpts.put(Neo4jOptions.URL, SparkConnectorScalaSuiteIT.server.getBoltUrl)
     writeOpts.put(Neo4jOptions.ACCESS_MODE, AccessMode.WRITE.toString)
     writeOpts.put("query", query)
 
-    // when
-    Validations.validate(ValidateWrite(neo4j, new Neo4jOptions(writeOpts), "1", null))
+    // when & then
+    val exception = assertThrows(
+      classOf[IllegalArgumentException],
+      () => {
+        Validations.validate(ValidateWrite(neo4j, new Neo4jOptions(writeOpts), "1", null))
+      }
+    )
+    assertTrue(
+      exception.getMessage.contains(
+        "Query not compiled for the following exception: ClientException: Invalid input "
+      )
+    )
+    assertTrue(
+      exception.getMessage.contains(query)
+    )
   }
 
   @Test
   def testWriteQueryShouldBeSemanticallyInvalid(): Unit = {
-    // then
-    val query = "MATCH (n:TestNode{id: 1}) RETURN n"
-    expectedException.expect(classOf[IllegalArgumentException])
-    expectedException.expectMessage(
-      s"Invalid query `$query` because the accepted types are [WRITE_ONLY, READ_WRITE], but the actual type is READ_ONLY"
-    )
-
     // given
+    val query = "MATCH (n:TestNode{id: 1}) RETURN n"
     val writeOpts: java.util.Map[String, String] = new java.util.HashMap[String, String]()
     writeOpts.put(Neo4jOptions.URL, SparkConnectorScalaSuiteIT.server.getBoltUrl)
     writeOpts.put(Neo4jOptions.ACCESS_MODE, AccessMode.WRITE.toString)
     writeOpts.put("query", query)
 
-    // when
-    Validations.validate(ValidateWrite(neo4j, new Neo4jOptions(writeOpts), "1", null))
+    // when & then
+    val exception = assertThrows(
+      classOf[IllegalArgumentException],
+      () => {
+        Validations.validate(ValidateWrite(neo4j, new Neo4jOptions(writeOpts), "1", null))
+      }
+    )
+    assertTrue(
+      exception.getMessage.contains(
+        s"Invalid query `$query` because the accepted types are [WRITE_ONLY, READ_WRITE], but the actual type is READ_ONLY"
+      )
+    )
   }
 
 }

--- a/src/test/scala/org/neo4j/spark/util/ValidationsTest.scala
+++ b/src/test/scala/org/neo4j/spark/util/ValidationsTest.scala
@@ -17,9 +17,8 @@
 package org.neo4j.spark.util
 
 import org.apache.spark.sql.SparkSession
-import org.junit
-import org.junit.Assert.assertEquals
-import org.junit.Test
+import org.junit.jupiter.api.Assertions._
+import org.junit.jupiter.api.Test
 import org.neo4j.spark.testsupport.SparkConnectorScalaBaseTSE
 
 class ValidationsTest extends SparkConnectorScalaBaseTSE {
@@ -63,13 +62,13 @@ class ValidationsTest extends SparkConnectorScalaBaseTSE {
   @Test
   def testVersionShouldValidateTheVersion(): Unit = {
     val version = ValidateSparkMinVersion("2.3.0")
-    junit.Assert.assertTrue(version.isSupported("2.3.0-amzn-1"))
-    junit.Assert.assertTrue(version.isSupported("2.3.1-amzn-1"))
-    junit.Assert.assertTrue(version.isSupported("3.3.0-amzn-1"))
-    junit.Assert.assertTrue(version.isSupported("3.3.0"))
-    junit.Assert.assertTrue(version.isSupported("3.1.0"))
-    junit.Assert.assertTrue(version.isSupported("3.2.0"))
-    junit.Assert.assertFalse(version.isSupported("2.2.10"))
+    assertTrue(version.isSupported("2.3.0-amzn-1"))
+    assertTrue(version.isSupported("2.3.1-amzn-1"))
+    assertTrue(version.isSupported("3.3.0-amzn-1"))
+    assertTrue(version.isSupported("3.3.0"))
+    assertTrue(version.isSupported("3.1.0"))
+    assertTrue(version.isSupported("3.2.0"))
+    assertFalse(version.isSupported("2.2.10"))
   }
 
 }


### PR DESCRIPTION
Migrated tests from JUnit 4 to JUnit 6 (Jupiter) by removing deprecated APIs (e.g., @Rule, ExpectedException, TemporaryFolder, @RunWith, Assert, Assume) and replacing them with equivalents such as assertThrows,  @Suite, Assertions, and Assumptions. 