### PR TITLE
ci: move over to dedicated build images

### DIFF
--- a/.teamcity/builds/Common.kt
+++ b/.teamcity/builds/Common.kt
@@ -28,6 +28,7 @@ const val DEFAULT_BRANCH = "6.0"
 val MAVEN_DEFAULT_ARGS = buildString {
   append("--no-transfer-progress ")
   append("--batch-mode ")
+  append("--threads 1C ")
   append("-Dmaven.repo.local=%teamcity.build.checkoutDir%/.m2/repository ")
   append("-Dmaven.wagon.http.retryHandler.class=standard ")
   append("-Dmaven.wagon.http.retryHandler.timeout=60 ")
@@ -35,9 +36,12 @@ val MAVEN_DEFAULT_ARGS = buildString {
   append(
       "-Dmaven.wagon.http.retryHandler.nonRetryableClasses=java.io.InterruptedIOException,java.net.UnknownHostException,java.net.ConnectException ")
 }
-const val SEMGREP_DOCKER_IMAGE = "semgrep/semgrep:1.146.0"
 const val FULL_GITHUB_REPOSITORY = "$GITHUB_OWNER/$GITHUB_REPOSITORY"
 const val GITHUB_URL = "https://github.com/$FULL_GITHUB_REPOSITORY"
+
+const val NODE_DOCKER_IMAGE = "%ecr-registry-connectors%:node-24-latest"
+
+const val SEMGREP_DOCKER_IMAGE = "%ecr-registry-connectors%:semgrep-latest"
 
 val DEFAULT_JAVA_VERSION = JavaVersion.V_17
 
@@ -46,7 +50,8 @@ const val SLACK_CONNECTION_ID = "PROJECT_EXT_83"
 const val SLACK_CHANNEL = "#team-connectors-feed"
 
 // Look into Root Project's settings -> Connections
-const val ECR_CONNECTION_ID = "PROJECT_EXT_124"
+const val ECR_CONNECTION_ID_ENG = "PROJECT_EXT_124"
+const val ECR_CONNECTION_ID_BUILD = "PROJECT_EXT_107"
 
 enum class LinuxSize(val value: String) {
   SMALL("small"),
@@ -54,8 +59,8 @@ enum class LinuxSize(val value: String) {
 }
 
 enum class JavaVersion(val version: String, val dockerImage: String) {
-  V_17(version = "17", dockerImage = "eclipse-temurin:17-jdk"),
-  V_21(version = "21", dockerImage = "eclipse-temurin:21-jdk"),
+  V_17(version = "17", dockerImage = "%ecr-registry-connectors%:jdk-17-latest"),
+  V_21(version = "21", dockerImage = "%ecr-registry-connectors%:jdk-21-latest"),
 }
 
 enum class ScalaVersion(val version: String) {
@@ -198,7 +203,8 @@ fun BuildFeatures.requireDiskSpace(size: String = "3gb") = freeDiskSpace {
 
 fun BuildFeatures.loginToECR() = dockerRegistryConnections {
   cleanupPushedImages = true
-  loginToRegistry = on { dockerRegistryId = ECR_CONNECTION_ID }
+  loginToRegistry = on { dockerRegistryId = ECR_CONNECTION_ID_ENG }
+  loginToRegistry = on { dockerRegistryId = ECR_CONNECTION_ID_BUILD }
 }
 
 fun BuildFeatures.buildCache(javaVersion: JavaVersion, scalaVersion: ScalaVersion) = buildCache {

--- a/.teamcity/builds/PRCheck.kt
+++ b/.teamcity/builds/PRCheck.kt
@@ -28,7 +28,7 @@ class PRCheck(id: String, name: String) :
             """
                   .trimIndent()
 
-          dockerImage = "node:18.4"
+          dockerImage = NODE_DOCKER_IMAGE
           dockerImagePlatform = ScriptBuildStep.ImagePlatform.Linux
         }
       }

--- a/.teamcity/builds/PythonIntegrationTests.kt
+++ b/.teamcity/builds/PythonIntegrationTests.kt
@@ -39,17 +39,8 @@ class PythonIntegrationTests(
               scriptContent =
                   """
               #!/bin/bash -eu
+              mise use -g python@${pythonVersion.version}
               
-              apt-get update
-              apt-get install -o Acquire::Retries=10 --yes build-essential libssl-dev zlib1g-dev libbz2-dev libreadline-dev libsqlite3-dev curl git libncursesw5-dev xz-utils tk-dev libxml2-dev libxmlsec1-dev libffi-dev liblzma-dev
-              curl -fsSL https://pyenv.run | bash
-              
-              export PYENV_ROOT="${'$'}HOME/.pyenv"
-              export PATH="${'$'}PYENV_ROOT/bin:${'$'}PATH"
-              eval "$(pyenv init - bash)"
-              pyenv install ${pythonVersion.version}
-              pyenv global ${pythonVersion.version}
-                 
               python -m pip install --upgrade pip
               pip install pyspark==${sparkVersion.version} "testcontainers[neo4j]" six tzlocal==2.1 
               

--- a/.teamcity/builds/Release.kt
+++ b/.teamcity/builds/Release.kt
@@ -76,15 +76,6 @@ class Release(id: String, name: String, javaVersion: JavaVersion) :
                 
                 set -eux
                 
-                apt-get update
-                apt-get install -o Acquire::Retries=10 --yes build-essential curl git unzip zip
-                
-                # Get the jreleaser downloader
-                curl -sL https://raw.githubusercontent.com/jreleaser/release-action/refs/tags/2.4.2/get_jreleaser.java > get_jreleaser.java
-
-                # Download JReleaser with version = 1.18.0
-                java get_jreleaser.java 1.18.0
-
                 if [ "%dry-run%" = "true" ]; then
                   echo "we are on a dry run, only performing upload to maven central"
                   export JRELEASER_MAVENCENTRAL_STAGE=UPLOAD
@@ -94,10 +85,11 @@ class Release(id: String, name: String, javaVersion: JavaVersion) :
                   export JRELEASER_MAVENCENTRAL_STAGE=FULL
                   export JRELEASER_ANNOUNCE_SLACK_ACTIVE=ALWAYS
                 fi
+                export MAVEN_ARGS="$MAVEN_DEFAULT_ARGS"
                 
                 # Execute JReleaser
-                java -jar jreleaser-cli.jar assemble
-                java -jar jreleaser-cli.jar full-release --debug
+                jreleaser assemble
+                jreleaser full-release --debug
               """
                       .trimIndent()
 


### PR DESCRIPTION
This pull request updates the TeamCity build configuration to use internal, consistently versioned Docker images and refines several build and release steps for improved maintainability and reliability. The most important changes are grouped below.

**Docker Image and Registry Management:**

* Introduced new constants for Docker images (`NODE_DOCKER_IMAGE`, `SEMGREP_DOCKER_IMAGE`) and updated all references to use these instead of hardcoded image names, ensuring builds use the latest internal images. (`.teamcity/builds/Common.kt`, `.teamcity/builds/PRCheck.kt`) [[1]](diffhunk://#diff-28bbcb11ae9f3a86436663153f0859b15d2db31b2de62c1b2fafdb4e7fab277cR31-R63) [[2]](diffhunk://#diff-36aa04e5784b11d55c3482c87ec59b58dbe489af210e1ad6ee28db74c7e0d590L31-R31)
* Changed Java Docker images in the `JavaVersion` enum to use internal registry tags, replacing public images with `%ecr-registry-connectors%` references. (`.teamcity/builds/Common.kt`)
* Updated ECR Docker registry login logic to use two connection IDs (`ECR_CONNECTION_ID_ENG` and `ECR_CONNECTION_ID_BUILD`) instead of a single one, improving flexibility for different build contexts. (`.teamcity/builds/Common.kt`) [[1]](diffhunk://#diff-28bbcb11ae9f3a86436663153f0859b15d2db31b2de62c1b2fafdb4e7fab277cR31-R63) [[2]](diffhunk://#diff-28bbcb11ae9f3a86436663153f0859b15d2db31b2de62c1b2fafdb4e7fab277cL201-R207)

**Build and Release Process Improvements:**

* Updated the Python integration test setup to use `mise` for managing Python versions, removing manual `apt-get` and `pyenv` steps for a more streamlined and reproducible environment. (`.teamcity/builds/PythonIntegrationTests.kt`)
* Simplified the release process by removing manual installation steps for JReleaser and switching from direct `java -jar` calls to the `jreleaser` CLI, relying on the environment to provide the necessary tool. Also, set `MAVEN_ARGS` explicitly. (`.teamcity/builds/Release.kt`) [[1]](diffhunk://#diff-1dffba3524dd8e727aed15b38fdd46643c4d0699f44931d3563e5b928b46e0e2L79-L87) [[2]](diffhunk://#diff-1dffba3524dd8e727aed15b38fdd46643c4d0699f44931d3563e5b928b46e0e2R88-R92)

These changes collectively improve build environment consistency, reduce external dependencies, and make the build scripts easier to maintain.