### PR TITLE
ci: use dedicated connectors build image

### DIFF
--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,6 +1,7 @@
 #!/usr/bin/env sh
 
-./mvnw sortpom:sort spotless:apply -f .teamcity
-./mvnw sortpom:sort spotless:apply
+$(git rev-parse --show-toplevel)/mvnw sortpom:sort spotless:apply -f .teamcity
+$(git rev-parse --show-toplevel)/mvnw sortpom:sort spotless:apply
+
 git update-index --again
 

--- a/.teamcity/builds/Common.kt
+++ b/.teamcity/builds/Common.kt
@@ -28,6 +28,7 @@ const val DEFAULT_BRANCH = "5.0"
 val MAVEN_DEFAULT_ARGS = buildString {
   append("--no-transfer-progress ")
   append("--batch-mode ")
+  append("--threads 1C ")
   append("-Dmaven.repo.local=%teamcity.build.checkoutDir%/.m2/repository ")
   append("-Dmaven.wagon.http.retryHandler.class=standard ")
   append("-Dmaven.wagon.http.retryHandler.timeout=60 ")
@@ -35,7 +36,9 @@ val MAVEN_DEFAULT_ARGS = buildString {
   append(
       "-Dmaven.wagon.http.retryHandler.nonRetryableClasses=java.io.InterruptedIOException,java.net.UnknownHostException,java.net.ConnectException ")
 }
-const val SEMGREP_DOCKER_IMAGE = "semgrep/semgrep:1.146.0"
+const val NODE_DOCKER_IMAGE = "%ecr-registry-connectors%:node-24-latest"
+
+const val SEMGREP_DOCKER_IMAGE = "%ecr-registry-connectors%:semgrep-latest"
 const val FULL_GITHUB_REPOSITORY = "$GITHUB_OWNER/$GITHUB_REPOSITORY"
 const val GITHUB_URL = "https://github.com/$FULL_GITHUB_REPOSITORY"
 
@@ -46,7 +49,8 @@ const val SLACK_CONNECTION_ID = "PROJECT_EXT_83"
 const val SLACK_CHANNEL = "#team-connectors-feed"
 
 // Look into Root Project's settings -> Connections
-const val ECR_CONNECTION_ID = "PROJECT_EXT_124"
+const val ECR_CONNECTION_ID_ENG = "PROJECT_EXT_124"
+const val ECR_CONNECTION_ID_BUILD = "PROJECT_EXT_107"
 
 enum class LinuxSize(val value: String) {
   SMALL("small"),
@@ -54,10 +58,10 @@ enum class LinuxSize(val value: String) {
 }
 
 enum class JavaVersion(val version: String, val dockerImage: String) {
-  V_8(version = "8", dockerImage = "eclipse-temurin:8-jdk"),
-  V_11(version = "11", dockerImage = "eclipse-temurin:11-jdk"),
-  V_17(version = "17", dockerImage = "eclipse-temurin:17-jdk"),
-  V_21(version = "21", dockerImage = "eclipse-temurin:21-jdk"),
+  V_8(version = "8", dockerImage = "%ecr-registry-connectors%:jdk-8-latest"),
+  V_11(version = "11", dockerImage = "%ecr-registry-connectors%:jdk-11-latest"),
+  V_17(version = "17", dockerImage = "%ecr-registry-connectors%:jdk-17-latest"),
+  V_21(version = "21", dockerImage = "%ecr-registry-connectors%:jdk-21-latest"),
 }
 
 enum class ScalaVersion(val version: String) {
@@ -203,7 +207,8 @@ fun BuildFeatures.requireDiskSpace(size: String = "3gb") = freeDiskSpace {
 
 fun BuildFeatures.loginToECR() = dockerRegistryConnections {
   cleanupPushedImages = true
-  loginToRegistry = on { dockerRegistryId = ECR_CONNECTION_ID }
+  loginToRegistry = on { dockerRegistryId = ECR_CONNECTION_ID_ENG }
+  loginToRegistry = on { dockerRegistryId = ECR_CONNECTION_ID_BUILD }
 }
 
 fun BuildFeatures.buildCache(javaVersion: JavaVersion, scalaVersion: ScalaVersion) = buildCache {

--- a/.teamcity/builds/PRCheck.kt
+++ b/.teamcity/builds/PRCheck.kt
@@ -28,7 +28,7 @@ class PRCheck(id: String, name: String) :
             """
                   .trimIndent()
 
-          dockerImage = "node:18.4"
+          dockerImage = NODE_DOCKER_IMAGE
           dockerImagePlatform = ScriptBuildStep.ImagePlatform.Linux
         }
       }

--- a/.teamcity/builds/PythonIntegrationTests.kt
+++ b/.teamcity/builds/PythonIntegrationTests.kt
@@ -40,16 +40,8 @@ class PythonIntegrationTests(
                   """
               #!/bin/bash -eu
               
-              apt-get update
-              apt-get install -o Acquire::Retries=10 --yes build-essential libssl-dev zlib1g-dev libbz2-dev libreadline-dev libsqlite3-dev curl git libncursesw5-dev xz-utils tk-dev libxml2-dev libxmlsec1-dev libffi-dev liblzma-dev
-              curl -fsSL https://pyenv.run | bash
-              
-              export PYENV_ROOT="${'$'}HOME/.pyenv"
-              export PATH="${'$'}PYENV_ROOT/bin:${'$'}PATH"
-              eval "$(pyenv init - bash)"
-              pyenv install ${pythonVersion.version}
-              pyenv global ${pythonVersion.version}
-                 
+              mise use -g python@${pythonVersion.version}
+                
               python -m pip install --upgrade pip
               pip install pyspark==${sparkVersion.version} "testcontainers[neo4j]" six tzlocal==2.1 
               

--- a/.teamcity/builds/Release.kt
+++ b/.teamcity/builds/Release.kt
@@ -76,15 +76,6 @@ class Release(id: String, name: String, javaVersion: JavaVersion) :
                 
                 set -eux
                 
-                apt-get update
-                apt-get install -o Acquire::Retries=10 --yes build-essential curl git unzip zip
-                
-                # Get the jreleaser downloader
-                curl -sL https://raw.githubusercontent.com/jreleaser/release-action/refs/tags/2.5.0/get_jreleaser.java > get_jreleaser.java
-
-                # Download JReleaser
-                java get_jreleaser.java 1.22.0
-
                 if [ "%dry-run%" = "true" ]; then
                   echo "we are on a dry run, only performing upload to maven central"
                   export JRELEASER_MAVENCENTRAL_STAGE=UPLOAD
@@ -94,10 +85,11 @@ class Release(id: String, name: String, javaVersion: JavaVersion) :
                   export JRELEASER_MAVENCENTRAL_STAGE=FULL
                   export JRELEASER_ANNOUNCE_SLACK_ACTIVE=ALWAYS
                 fi
+                export MAVEN_ARGS="${'$'}MAVEN_DEFAULT_ARGS"
                 
                 # Execute JReleaser
-                java -jar jreleaser-cli.jar assemble
-                java -jar jreleaser-cli.jar full-release --debug
+                jreleaser assemble
+                jreleaser full-release --debug
               """
                       .trimIndent()
 
@@ -122,13 +114,6 @@ class Release(id: String, name: String, javaVersion: JavaVersion) :
             +:out/jreleaser => jreleaser
             """
                   .trimIndent()
-
-          dependencies {
-            artifacts(AbsoluteId("Tools_ReleaseTool")) {
-              buildRule = lastSuccessful()
-              artifactRules = "rt.jar => lib"
-            }
-          }
 
           requirements { runOnLinux(LinuxSize.SMALL) }
         },

--- a/.teamcity/builds/SemgrepCheck.kt
+++ b/.teamcity/builds/SemgrepCheck.kt
@@ -26,8 +26,7 @@ class SemgrepCheck(id: String, name: String, scalaVersion: ScalaVersion) :
           scriptContent = "semgrep ci --no-git-ignore"
           dockerImagePlatform = ScriptBuildStep.ImagePlatform.Linux
           dockerImage = SEMGREP_DOCKER_IMAGE
-          dockerRunParameters =
-              "--volume /var/run/docker.sock:/var/run/docker.sock --volume %teamcity.build.checkoutDir%/signingkeysandbox:/root/.gnupg"
+          dockerRunParameters = "--volume /var/run/docker.sock:/var/run/docker.sock"
         })
   }
 }


### PR DESCRIPTION
This pull request updates the TeamCity build scripts and supporting files to improve consistency, standardize Docker image usage, and simplify build and test steps. The changes focus on using centrally managed Docker images, updating ECR connection handling, and modernizing build steps for Python and release processes.

**Docker image and registry standardization:**

* Updated all Java, Node, and Semgrep Docker images to use centrally managed ECR image references (e.g., `%ecr-registry-connectors%:jdk-XX-latest`, `%ecr-registry-connectors%:node-24-latest`, `%ecr-registry-connectors%:semgrep-latest`) for consistency and easier maintenance. (`.teamcity/builds/Common.kt`, `.teamcity/builds/PRCheck.kt`, `.teamcity/builds/SemgrepCheck.kt`) [[1]](diffhunk://#diff-28bbcb11ae9f3a86436663153f0859b15d2db31b2de62c1b2fafdb4e7fab277cR31-R41) [[2]](diffhunk://#diff-36aa04e5784b11d55c3482c87ec59b58dbe489af210e1ad6ee28db74c7e0d590L31-R31) [[3]](diffhunk://#diff-7e045682bc773deb0625b913319ed61f7494b232e475529ce1749f38dc5f3167L29-R29)

* Split ECR connection IDs into separate values for engineering and build pipelines, and updated the Docker registry login logic to use both connections. (`.teamcity/builds/Common.kt`) [[1]](diffhunk://#diff-28bbcb11ae9f3a86436663153f0859b15d2db31b2de62c1b2fafdb4e7fab277cL49-R64) [[2]](diffhunk://#diff-28bbcb11ae9f3a86436663153f0859b15d2db31b2de62c1b2fafdb4e7fab277cL206-R211)

**Build and test process improvements:**

* Switched Python integration test environment setup from manual `pyenv` installation to using `mise` for managing Python versions, making the process more reliable and streamlined. (`.teamcity/builds/PythonIntegrationTests.kt`)

* Simplified the release process by removing redundant manual installation steps for JReleaser and switching to using the `jreleaser` CLI directly with updated environment variables. Also removed unnecessary dependencies on the release tool artifact. (`.teamcity/builds/Release.kt`) [[1]](diffhunk://#diff-1dffba3524dd8e727aed15b38fdd46643c4d0699f44931d3563e5b928b46e0e2L79-L87) [[2]](diffhunk://#diff-1dffba3524dd8e727aed15b38fdd46643c4d0699f44931d3563e5b928b46e0e2R88-R92) [[3]](diffhunk://#diff-1dffba3524dd8e727aed15b38fdd46643c4d0699f44931d3563e5b928b46e0e2L126-L132)

**Pre-commit hook improvement:**

* Updated the pre-commit hook to use an absolute path to the Maven wrapper, ensuring it works regardless of the current working directory. (`.husky/pre-commit`)