### PR TITLE
build(test): bump mockito to v5, remove powermock

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -58,11 +58,10 @@
         <maven-site-plugin.version>3.21.0</maven-site-plugin.version>
         <maven-source-plugin.version>3.4.0</maven-source-plugin.version>
         <maven-surefire-plugin.version>3.5.5</maven-surefire-plugin.version>
-        <mockito.version>3.12.4</mockito.version>
+        <mockito.version>5.23.0</mockito.version>
         <neo4j.experimental>false</neo4j.experimental>
         <neo4j.version>4.4.20</neo4j.version>
         <netty-bom.version>4.1.128.Final</netty-bom.version>
-        <powermock.version>2.0.9</powermock.version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <scala-maven-plugin.version>4.9.10</scala-maven-plugin.version>
         <scala.binary.version>2.13</scala.binary.version>
@@ -223,12 +222,6 @@
             <scope>test</scope>
         </dependency>
         <dependency>
-            <groupId>org.mockito</groupId>
-            <artifactId>mockito-inline</artifactId>
-            <version>${mockito.version}</version>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
             <groupId>org.neo4j.connectors</groupId>
             <artifactId>commons-authn-keycloak</artifactId>
             <version>${connectors-commons.version}</version>
@@ -238,18 +231,6 @@
             <groupId>org.objenesis</groupId>
             <artifactId>objenesis</artifactId>
             <version>3.5</version>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
-            <groupId>org.powermock</groupId>
-            <artifactId>powermock-api-mockito2</artifactId>
-            <version>${powermock.version}</version>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
-            <groupId>org.powermock</groupId>
-            <artifactId>powermock-module-junit4</artifactId>
-            <version>${powermock.version}</version>
             <scope>test</scope>
         </dependency>
         <dependency>


### PR DESCRIPTION
inline mocks did not work for both java 17 and java 21 when we used
version v3.x.x.

this PR bumps to latest major version and remove inline-mocks.
since v3 the default mock maker is inline so we can use the core
package only.

moreover we no longer need powermock for junit4