### PR TITLE
feat: allow override of cypher version as option

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -33,7 +33,7 @@
     </scm>
     <properties>
         <build-resources.version>2026.02.5</build-resources.version>
-        <caniuse.version>1.3.3</caniuse.version>
+        <caniuse.version>1.4.0</caniuse.version>
         <commons-compress.version>1.28.0</commons-compress.version>
         <commons-lang3.version>3.20.0</commons-lang3.version>
         <connectors-commons.version>1.0.0-rc2</connectors-commons.version>

--- a/src/main/scala/org/neo4j/spark/DataSource.scala
+++ b/src/main/scala/org/neo4j/spark/DataSource.scala
@@ -79,7 +79,7 @@ class DataSource extends TableProvider
         Neo4jOptions.fromSession(SparkSession.getActiveSession, caseInsensitiveStringMap.asCaseSensitiveMap())
     }
 
-    ValidateNeo4jOptionsConsistency(neo4jOptions).validate()
+    ValidateNeo4jOptionsConsistency(getNeo4jInfo(neo4jOptions.connection), neo4jOptions).validate()
     neo4jOptions
   }
 

--- a/src/main/scala/org/neo4j/spark/cypher/CypherPreamble.scala
+++ b/src/main/scala/org/neo4j/spark/cypher/CypherPreamble.scala
@@ -19,13 +19,14 @@ package org.neo4j.spark.cypher
 import org.neo4j.caniuse.CanIUse.INSTANCE.canIUse
 import org.neo4j.caniuse.Cypher.{INSTANCE => Cypher}
 import org.neo4j.caniuse.Neo4j
+import org.neo4j.spark.util.Neo4jOptions
 import org.neo4j.spark.util.Neo4jTuningOptions
 
 object CypherPreamble {
 
-  def fullPreamble(neo4j: Neo4j, tuningOptions: Neo4jTuningOptions): String = {
-    val version = versionPreamble(neo4j)
-    val tuning = tuningPreamble(tuningOptions)
+  def fullPreamble(neo4j: Neo4j, neo4jOptions: Neo4jOptions): String = {
+    val version = versionPreamble(neo4j, neo4jOptions)
+    val tuning = tuningPreamble(neo4jOptions.tuning)
 
     if (tuning.isEmpty) {
       s"$version"
@@ -34,7 +35,15 @@ object CypherPreamble {
     }
   }
 
-  private def versionPreamble(neo4j: Neo4j): String = {
+  private def versionPreamble(neo4j: Neo4j, neo4jOptions: Neo4jOptions): String = {
+    if (neo4jOptions.cypherVersion == "5") {
+      return "CYPHER 5 "
+    }
+
+    if (neo4jOptions.cypherVersion == "25") {
+      return "CYPHER 25 "
+    }
+
     if (canIUse(Cypher.explicitCypher5Selection()).withNeo4j(neo4j)) {
       "CYPHER 5 "
     } else {

--- a/src/main/scala/org/neo4j/spark/cypher/CypherPreamble.scala
+++ b/src/main/scala/org/neo4j/spark/cypher/CypherPreamble.scala
@@ -36,12 +36,8 @@ object CypherPreamble {
   }
 
   private def versionPreamble(neo4j: Neo4j, neo4jOptions: Neo4jOptions): String = {
-    if (neo4jOptions.cypherVersion == "5") {
-      return "CYPHER 5 "
-    }
-
-    if (neo4jOptions.cypherVersion == "25") {
-      return "CYPHER 25 "
+    if (neo4jOptions.cypherVersion != null && neo4jOptions.cypherVersion.nonEmpty) {
+      return s"CYPHER ${neo4jOptions.cypherVersion} "
     }
 
     if (canIUse(Cypher.explicitCypher5Selection()).withNeo4j(neo4j)) {

--- a/src/main/scala/org/neo4j/spark/cypher/CypherRenderer.scala
+++ b/src/main/scala/org/neo4j/spark/cypher/CypherRenderer.scala
@@ -16,6 +16,8 @@
  */
 package org.neo4j.spark.cypher
 
+import org.neo4j.caniuse.CanIUse.INSTANCE.canIUse
+import org.neo4j.caniuse.Cypher.{INSTANCE => Cypher}
 import org.neo4j.caniuse.Neo4j
 import org.neo4j.caniuse.Neo4jVersion
 import org.neo4j.cypherdsl.core.Statement
@@ -23,30 +25,44 @@ import org.neo4j.cypherdsl.core.renderer.Configuration
 import org.neo4j.cypherdsl.core.renderer.Dialect
 import org.neo4j.cypherdsl.core.renderer.Renderer
 import org.neo4j.spark.cypher.CypherRenderer.Neo4jV5_23
-import org.neo4j.spark.cypher.CypherRenderer.Neo4j_2025
+import org.neo4j.spark.util.Neo4jOptions
 
-case class CypherRenderer(private val neo4j: Neo4j) {
-
-  private def dialect(): Dialect = {
-    if (neo4j.getVersion.compareTo(Neo4jV5_23) < 0) {
-      return Dialect.NEO4J_5
-    }
-
-    if (neo4j.getVersion.compareTo(Neo4j_2025) >= 0) {
-      return Dialect.NEO4J_2025
-    }
-
-    Dialect.NEO4J_5_23
-  }
-
-  private val cached = Renderer.getRenderer(Configuration.newConfig().withDialect(dialect()).build())
+case class CypherRenderer(private val neo4j: Neo4j, private val neo4jOptions: Neo4jOptions) {
 
   def render(statement: Statement): String = {
     cached.render(statement)
   }
+
+  private val cached = Renderer.getRenderer(Configuration.newConfig().withDialect(dialect).build())
+
+  private def dialect: Dialect =
+    if (neo4jOptions.cypherVersion != null && neo4jOptions.cypherVersion.nonEmpty) {
+      dialectFromOptions()
+    } else {
+      dialectFromVersion()
+    }
+
+  private def dialectFromVersion(): Dialect =
+    neo4j.getVersion match {
+      case version if version.compareTo(Neo4jV5_23) < 0 =>
+        Dialect.NEO4J_5 // this assumes server is at least neo4j 5+, as per documented connector support
+      case _ if canIUse(Cypher.explicitCypher25Selection()).withNeo4j(neo4j) =>
+        Dialect.NEO4J_2025
+      case _ =>
+        Dialect.NEO4J_5_DEFAULT_CYPHER
+    }
+
+  private def dialectFromOptions(): Dialect =
+    neo4jOptions.cypherVersion match {
+      case "5" =>
+        Dialect.NEO4J_5
+      case "25" =>
+        Dialect.NEO4J_2025
+      case _ =>
+        dialectFromVersion()
+    }
 }
 
 object CypherRenderer {
   private val Neo4jV5_23 = new Neo4jVersion(5, 23, 0)
-  private val Neo4j_2025 = new Neo4jVersion(2025, 0, 0)
 }

--- a/src/main/scala/org/neo4j/spark/reader/BasePartitionReader.scala
+++ b/src/main/scala/org/neo4j/spark/reader/BasePartitionReader.scala
@@ -26,6 +26,7 @@ import org.neo4j.driver.Record
 import org.neo4j.driver.Session
 import org.neo4j.driver.Transaction
 import org.neo4j.driver.Values
+import org.neo4j.spark.cypher.CypherRenderer
 import org.neo4j.spark.service._
 import org.neo4j.spark.util.DriverCache
 import org.neo4j.spark.util.Neo4jOptions
@@ -151,6 +152,7 @@ abstract class BasePartitionReader(
       options,
       new Neo4jQueryReadStrategy(
         neo4j,
+        new CypherRenderer(neo4j, options),
         filters,
         partitionSkipLimit,
         requiredColumns.fieldNames.toIndexedSeq,

--- a/src/main/scala/org/neo4j/spark/service/Neo4jQueryService.scala
+++ b/src/main/scala/org/neo4j/spark/service/Neo4jQueryService.scala
@@ -27,7 +27,6 @@ import org.apache.spark.sql.sources.Filter
 import org.apache.spark.sql.sources.Or
 import org.neo4j.caniuse.Neo4j
 import org.neo4j.cypherdsl.core._
-import org.neo4j.cypherdsl.core.renderer.Renderer
 import org.neo4j.spark.cypher.CypherPreamble.fullPreamble
 import org.neo4j.spark.cypher.CypherRenderer
 import org.neo4j.spark.util.Neo4jImplicits._
@@ -153,6 +152,7 @@ class Neo4jQueryWriteStrategy(
 
 class Neo4jQueryReadStrategy(
   private val neo4j: Neo4j,
+  private val renderer: CypherRenderer,
   private val filters: Array[Filter] = Array.empty[Filter],
   private val partitionPagination: PartitionPagination = PartitionPagination.EMPTY,
   private val requiredColumns: Seq[String] = Seq.empty,
@@ -160,7 +160,6 @@ class Neo4jQueryReadStrategy(
   private val jobId: String = "",
   private val withPreamble: Boolean = true
 ) extends Neo4jQueryStrategy with Logging {
-  private val renderer: CypherRenderer = new CypherRenderer(neo4j)
 
   private val hasSkipLimit: Boolean = partitionPagination.skip != -1 && partitionPagination.topN.limit != -1
 

--- a/src/main/scala/org/neo4j/spark/service/Neo4jQueryService.scala
+++ b/src/main/scala/org/neo4j/spark/service/Neo4jQueryService.scala
@@ -47,7 +47,7 @@ class Neo4jQueryWriteStrategy(
 
   override def createStatementForQuery(options: Neo4jOptions): String = {
     val scriptResult = Neo4jQueryStrategy.scriptResultClause(options)
-    val preamble = if (withPreamble) fullPreamble(neo4j, options.tuning) else ""
+    val preamble = if (withPreamble) fullPreamble(neo4j, options) else ""
     s"""$preamble${scriptResult}UNWIND ${"$"}events AS ${Neo4jQueryStrategy.VARIABLE_EVENT}
        |${options.query.value}
        |""".stripMargin
@@ -121,7 +121,7 @@ class Neo4jQueryWriteStrategy(
       ""
     }
 
-    s"""${fullPreamble(neo4j, options.tuning)}UNWIND ${"$"}events AS ${Neo4jQueryStrategy.VARIABLE_EVENT}
+    s"""${fullPreamble(neo4j, options)}UNWIND ${"$"}events AS ${Neo4jQueryStrategy.VARIABLE_EVENT}
        |$sourceQueryPart$withQueryPart
        |$targetQueryPart
        |$relationshipKeyword (${Neo4jUtil.RELATIONSHIP_SOURCE_ALIAS})-[${Neo4jUtil.RELATIONSHIP_ALIAS}:$relationship$relKeys]->(${Neo4jUtil.RELATIONSHIP_TARGET_ALIAS})
@@ -141,7 +141,7 @@ class Neo4jQueryWriteStrategy(
       Neo4jWriteMappingStrategy.KEYS
     )
 
-    s"""${fullPreamble(neo4j, options.tuning)}UNWIND ${"$"}events AS ${Neo4jQueryStrategy.VARIABLE_EVENT}
+    s"""${fullPreamble(neo4j, options)}UNWIND ${"$"}events AS ${Neo4jQueryStrategy.VARIABLE_EVENT}
        |$keyword (node${if (labels.isEmpty) "" else s":$labels"} ${if (keys.isEmpty) "" else s"{$keys}"})
        |SET node += ${Neo4jQueryStrategy.VARIABLE_EVENT}.${Neo4jWriteMappingStrategy.PROPERTIES}
        |""".stripMargin
@@ -180,7 +180,7 @@ class Neo4jQueryReadStrategy(
     }
 
     val scriptResult = Neo4jQueryStrategy.scriptResultClause(options)
-    val preamble = if (withPreamble) fullPreamble(neo4j, options.tuning) else ""
+    val preamble = if (withPreamble) fullPreamble(neo4j, options) else ""
     s"$preamble$scriptResult$limitedQuery"
   }
 
@@ -201,7 +201,7 @@ class Neo4jQueryReadStrategy(
       buildStatementAggregation(options, matchQuery, relationship, returnExpressions)
     }
 
-    val preamble = if (withPreamble) fullPreamble(neo4j, options.tuning) else ""
+    val preamble = if (withPreamble) fullPreamble(neo4j, options) else ""
     s"$preamble${renderer.render(stmt)}"
   }
 
@@ -448,7 +448,7 @@ class Neo4jQueryReadStrategy(
       buildStatement(options, ret, node)
     }
 
-    val preamble = if (withPreamble) fullPreamble(neo4j, options.tuning) else ""
+    val preamble = if (withPreamble) fullPreamble(neo4j, options) else ""
     s"$preamble${renderer.render(stmt)}"
   }
 

--- a/src/main/scala/org/neo4j/spark/service/SchemaService.scala
+++ b/src/main/scala/org/neo4j/spark/service/SchemaService.scala
@@ -77,7 +77,7 @@ class SchemaService(
   private def structForNode(labels: Seq[String] = options.nodeMetadata.labels) = {
     val structFields: mutable.Buffer[StructField] = (try {
       val query =
-        s"""${fullPreamble(neo4j, options.tuning)}CALL apoc.meta.nodeTypeProperties($$config)
+        s"""${fullPreamble(neo4j, options)}CALL apoc.meta.nodeTypeProperties($$config)
            |YIELD propertyName, propertyTypes
            |WITH DISTINCT propertyName, propertyTypes
            |WITH propertyName, collect(propertyTypes) AS propertyTypes
@@ -94,7 +94,7 @@ class SchemaService(
         val query =
           s"""${fullPreamble(
               neo4j,
-              options.tuning
+              options
             )}MATCH (${Neo4jUtil.NODE_ALIAS}:${labels.map(_.quote()).mkString(":")})
              |RETURN ${Neo4jUtil.NODE_ALIAS}
              |ORDER BY rand()
@@ -225,7 +225,7 @@ class SchemaService(
       val query =
         s"""${fullPreamble(
             neo4j,
-            options.tuning
+            options
           )}CALL apoc.meta.relTypeProperties($$config) YIELD sourceNodeLabels, targetNodeLabels,
            | propertyName, propertyTypes
            |WITH *
@@ -250,7 +250,7 @@ class SchemaService(
         val query =
           s"""${fullPreamble(
               neo4j,
-              options.tuning
+              options
             )}MATCH (${Neo4jUtil.RELATIONSHIP_SOURCE_ALIAS}:${options.relationshipMetadata.source.labels.map(
               _.quote()
             ).mkString(":")})
@@ -336,7 +336,7 @@ class SchemaService(
   private def structForGDS() = {
     val query =
       s"""
-         |${fullPreamble(neo4j, options.tuning)}CALL gds.list() YIELD name, signature, type
+         |${fullPreamble(neo4j, options)}CALL gds.list() YIELD name, signature, type
          |WHERE name = $$procName AND type = 'procedure'
          |WITH split(signature, ') :: (')[1] AS fields
          |WITH substring(fields, 0, size(fields) - 1) AS fields

--- a/src/main/scala/org/neo4j/spark/service/SchemaService.scala
+++ b/src/main/scala/org/neo4j/spark/service/SchemaService.scala
@@ -34,6 +34,7 @@ import org.neo4j.spark.config.TopN
 import org.neo4j.spark.converter.CypherToSparkTypeConverter
 import org.neo4j.spark.converter.SparkToCypherTypeConverter
 import org.neo4j.spark.cypher.CypherPreamble.fullPreamble
+import org.neo4j.spark.cypher.CypherRenderer
 import org.neo4j.spark.service.SchemaService.normalizedClassName
 import org.neo4j.spark.service.SchemaService.normalizedClassNameFromGraphEntity
 import org.neo4j.spark.util.Neo4jImplicits.CypherImplicits
@@ -64,7 +65,8 @@ class SchemaService(
   private val filters: Array[Filter] = Array.empty
 ) extends AutoCloseable with Logging {
 
-  private val queryReadStrategy = new Neo4jQueryReadStrategy(neo4j, filters, withPreamble = false)
+  private val queryReadStrategy =
+    new Neo4jQueryReadStrategy(neo4j, new CypherRenderer(neo4j, options), filters, withPreamble = false)
 
   private val session: Session = driverCache.getOrCreate().session(options.session.toNeo4jSession())
 

--- a/src/main/scala/org/neo4j/spark/streaming/BaseStreamingPartitionReader.scala
+++ b/src/main/scala/org/neo4j/spark/streaming/BaseStreamingPartitionReader.scala
@@ -130,7 +130,7 @@ class BaseStreamingPartitionReader(
           .build()
           .getCypher
 
-        s"${fullPreamble(neo4j, options.tuning)}$cypher"
+        s"${fullPreamble(neo4j, options)}$cypher"
       // we don't need to rewrite the queries for LABELS and RELATIONSHIPS because spark filters already cover our
       // criteria, which are added to the query text in Neo4jQueryService
       case LABELS       => super.query()

--- a/src/main/scala/org/neo4j/spark/streaming/BaseStreamingPartitionReader.scala
+++ b/src/main/scala/org/neo4j/spark/streaming/BaseStreamingPartitionReader.scala
@@ -24,6 +24,7 @@ import org.apache.spark.sql.types.StructType
 import org.neo4j.caniuse.Neo4j
 import org.neo4j.cypherdsl.core.Cypher
 import org.neo4j.spark.cypher.CypherPreamble.fullPreamble
+import org.neo4j.spark.cypher.CypherRenderer
 import org.neo4j.spark.reader.BasePartitionReader
 import org.neo4j.spark.service.Neo4jQueryReadStrategy
 import org.neo4j.spark.service.Neo4jQueryService
@@ -100,6 +101,7 @@ class BaseStreamingPartitionReader(
           options,
           new Neo4jQueryReadStrategy(
             neo4j,
+            new CypherRenderer(neo4j, options),
             filters,
             partitionSkipLimit,
             requiredColumns.fieldNames.toIndexedSeq,

--- a/src/main/scala/org/neo4j/spark/util/Neo4jOptions.scala
+++ b/src/main/scala/org/neo4j/spark/util/Neo4jOptions.scala
@@ -148,6 +148,8 @@ class Neo4jOptions(private val options: java.util.Map[String, String]) extends S
       )
   }
 
+  val cypherVersion: String = getParameter(CYPHER_VERSION)
+
   val tuning: Neo4jTuningOptions = Neo4jTuningOptions(
     getParameter(TUNING_EXPRESSION_ENGINE),
     getParameter(TUNING_INFER_SCHEMA_PARTS),
@@ -727,7 +729,8 @@ object Neo4jOptions {
 
   val SCRIPT = "script"
 
-  // custom cypher tuning parameters
+  // custom cypher version and query tuning parameters
+  val CYPHER_VERSION = "cypher.version"
   val TUNING_EXPRESSION_ENGINE = "cypher.expression.engine"
   val TUNING_EXPRESSION_ENGINE_IN_CYPHER = "expressionEngine"
   val TUNING_INFER_SCHEMA_PARTS = "cypher.infer.schema.parts"

--- a/src/main/scala/org/neo4j/spark/util/Validations.scala
+++ b/src/main/scala/org/neo4j/spark/util/Validations.scala
@@ -20,6 +20,8 @@ import org.apache.spark.internal.Logging
 import org.apache.spark.sql.SaveMode
 import org.apache.spark.sql.SparkSession
 import org.apache.spark.sql.types.StructType
+import org.neo4j.caniuse.CanIUse.INSTANCE.canIUse
+import org.neo4j.caniuse.Cypher.{INSTANCE => Cypher}
 import org.neo4j.caniuse.Neo4j
 import org.neo4j.driver.AccessMode
 import org.neo4j.driver.summary
@@ -365,7 +367,7 @@ case class ValidateReadNotStreaming(neo4jOptions: Neo4jOptions, jobId: String) e
  *
  * Plus it throws an exception if no QueryType is provided.
  */
-case class ValidateNeo4jOptionsConsistency(neo4jOptions: Neo4jOptions) extends Validation {
+case class ValidateNeo4jOptionsConsistency(neo4j: Neo4j, neo4jOptions: Neo4jOptions) extends Validation {
 
   override def validate(): Unit = {
     if (neo4jOptions.query.value.isEmpty) {
@@ -394,10 +396,8 @@ case class ValidateNeo4jOptionsConsistency(neo4jOptions: Neo4jOptions) extends V
     }
 
     if (neo4jOptions.cypherVersion != null && neo4jOptions.cypherVersion.nonEmpty) {
-      if (neo4jOptions.cypherVersion != "5" && neo4jOptions.cypherVersion != "25") {
-        throw new IllegalArgumentException(
-          s"No valid cypher version found. Only empty string, '5' and '25' are supported."
-        )
+      if (!canIUse(Cypher.version(neo4jOptions.cypherVersion)).withNeo4j(neo4j)) {
+        throw new IllegalArgumentException(s"The provided cypher version '${neo4jOptions.cypherVersion}' is not valid.")
       }
     }
   }

--- a/src/main/scala/org/neo4j/spark/util/Validations.scala
+++ b/src/main/scala/org/neo4j/spark/util/Validations.scala
@@ -392,6 +392,14 @@ case class ValidateNeo4jOptionsConsistency(neo4jOptions: Neo4jOptions) extends V
         ignoreNodeMetadata(QueryType.GDS)
         ignoreRelMetadata(QueryType.GDS)
     }
+
+    if (neo4jOptions.cypherVersion != null && neo4jOptions.cypherVersion.nonEmpty) {
+      if (neo4jOptions.cypherVersion != "5" && neo4jOptions.cypherVersion != "25") {
+        throw new IllegalArgumentException(
+          s"No valid cypher version found. Only empty string, '5' and '25' are supported."
+        )
+      }
+    }
   }
 
   private def ignoreGdsMetadata(queryType: QueryType.Value): Unit = {

--- a/src/test/scala/org/neo4j/spark/ReadIT.scala
+++ b/src/test/scala/org/neo4j/spark/ReadIT.scala
@@ -132,7 +132,7 @@ class ReadIT {
           .load()
           .show()
       })
-      .withMessage("No valid cypher version found. Only empty string, '5' and '25' are supported.")
+      .withMessage("The provided cypher version '2.3' is not valid.")
   }
 
   @Nested

--- a/src/test/scala/org/neo4j/spark/ReadIT.scala
+++ b/src/test/scala/org/neo4j/spark/ReadIT.scala
@@ -46,6 +46,7 @@ import org.neo4j.spark.testsupport.Neo4jContainerProvider
 import org.neo4j.spark.testsupport.Neo4jExtensions.DriverExtensions
 import org.neo4j.spark.testsupport.Neo4jExtensions.Neo4jContainerExtensions
 import org.neo4j.spark.testsupport.SparkConnectorScalaSuiteIT
+import org.neo4j.spark.util.Neo4jOptions
 import org.testcontainers.neo4j.Neo4jContainer
 
 import java.sql.Date
@@ -119,6 +120,19 @@ class ReadIT {
           .show() // show is needed to trigger the exception because of changes in Spark 3
       })
       .withMessage("You need to specify just one of these options: 'gds', 'labels', 'query', 'relationship'")
+  }
+
+  @Test
+  def throws_exception_when_cypher_version_invalid(): Unit = {
+    assertThatExceptionOfType(classOf[IllegalArgumentException])
+      .isThrownBy(() => {
+        spark.read.format(classOf[DataSource].getName)
+          .option("labels", "Person")
+          .option(Neo4jOptions.CYPHER_VERSION, "2.3")
+          .load()
+          .show()
+      })
+      .withMessage("No valid cypher version found. Only empty string, '5' and '25' are supported.")
   }
 
   @Nested

--- a/src/test/scala/org/neo4j/spark/service/Neo4jQueryServiceIT.scala
+++ b/src/test/scala/org/neo4j/spark/service/Neo4jQueryServiceIT.scala
@@ -24,6 +24,7 @@ import org.junit.jupiter.api.AfterEach
 import org.junit.jupiter.api.Assertions.assertThrows
 import org.junit.jupiter.api.Assertions.assertTrue
 import org.junit.jupiter.api.Test
+import org.neo4j.spark.cypher.CypherRenderer
 import org.neo4j.spark.testsupport.SparkConnectorScalaSuiteWithGdsBase
 import org.neo4j.spark.testsupport.SparkConnectorScalaSuiteWithGdsBase.neo4j
 import org.neo4j.spark.util.DriverCache
@@ -54,6 +55,7 @@ class Neo4jQueryServiceIT extends SparkConnectorScalaSuiteWithGdsBase {
       neo4jOptions,
       new Neo4jQueryReadStrategy(
         neo4j,
+        new CypherRenderer(neo4j, neo4jOptions),
         Array.empty,
         PartitionPagination.EMPTY,
         List(
@@ -103,6 +105,7 @@ class Neo4jQueryServiceIT extends SparkConnectorScalaSuiteWithGdsBase {
           neo4jOptions,
           new Neo4jQueryReadStrategy(
             neo4j,
+            new CypherRenderer(neo4j, neo4jOptions),
             Array.empty,
             PartitionPagination.EMPTY,
             List(

--- a/src/test/scala/org/neo4j/spark/service/Neo4jQueryServiceTest.scala
+++ b/src/test/scala/org/neo4j/spark/service/Neo4jQueryServiceTest.scala
@@ -27,8 +27,6 @@ import org.apache.spark.sql.connector.expressions.aggregate.Min
 import org.apache.spark.sql.connector.expressions.aggregate.Sum
 import org.apache.spark.sql.sources._
 import org.junit.jupiter.api.Assertions._
-import org.junit.jupiter.api.Assumptions.assumeFalse
-import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.TestInstance
 import org.junit.jupiter.params.ParameterizedTest
 import org.junit.jupiter.params.provider.MethodSource
@@ -52,10 +50,11 @@ class Neo4jQueryServiceTest {
 
   @ParameterizedTest
   @MethodSource(Array("versions_and_prefixes"))
-  def testNodeOneLabel(neo4j: Neo4j, prefix: String): Unit = {
+  def testNodeOneLabel(neo4j: Neo4j, customVersion: String, prefix: String): Unit = {
     val options: java.util.Map[String, String] = new java.util.HashMap[String, String]()
     options.put(Neo4jOptions.URL, "bolt://localhost")
     options.put(QueryType.LABELS.toString.toLowerCase, "Person")
+    options.put(Neo4jOptions.CYPHER_VERSION, customVersion)
     val neo4jOptions: Neo4jOptions = new Neo4jOptions(options)
 
     val query: String =
@@ -66,10 +65,11 @@ class Neo4jQueryServiceTest {
 
   @ParameterizedTest
   @MethodSource(Array("versions_and_prefixes"))
-  def testNodeMultipleLabels(neo4j: Neo4j, prefix: String): Unit = {
+  def testNodeMultipleLabels(neo4j: Neo4j, customVersion: String, prefix: String): Unit = {
     val options: java.util.Map[String, String] = new java.util.HashMap[String, String]()
     options.put(Neo4jOptions.URL, "bolt://localhost")
     options.put(QueryType.LABELS.toString.toLowerCase, ":Person:Player:Midfield")
+    options.put(Neo4jOptions.CYPHER_VERSION, customVersion)
     val neo4jOptions: Neo4jOptions = new Neo4jOptions(options)
 
     val query: String =
@@ -80,10 +80,11 @@ class Neo4jQueryServiceTest {
 
   @ParameterizedTest
   @MethodSource(Array("versions_and_prefixes"))
-  def testNodeMultipleLabelsWithPartitions(neo4j: Neo4j, prefix: String): Unit = {
+  def testNodeMultipleLabelsWithPartitions(neo4j: Neo4j, customVersion: String, prefix: String): Unit = {
     val options: java.util.Map[String, String] = new java.util.HashMap[String, String]()
     options.put(Neo4jOptions.URL, "bolt://localhost")
     options.put(QueryType.LABELS.toString.toLowerCase, ":Person:Player:Midfield")
+    options.put(Neo4jOptions.CYPHER_VERSION, customVersion)
     val neo4jOptions: Neo4jOptions = new Neo4jOptions(options)
 
     val query: String = new Neo4jQueryService(
@@ -99,10 +100,11 @@ class Neo4jQueryServiceTest {
 
   @ParameterizedTest
   @MethodSource(Array("versions_and_prefixes"))
-  def testNodeOneLabelWithOneSelectedColumn(neo4j: Neo4j, prefix: String): Unit = {
+  def testNodeOneLabelWithOneSelectedColumn(neo4j: Neo4j, customVersion: String, prefix: String): Unit = {
     val options: java.util.Map[String, String] = new java.util.HashMap[String, String]()
     options.put(Neo4jOptions.URL, "bolt://localhost")
     options.put(QueryType.LABELS.toString.toLowerCase, "Person")
+    options.put(Neo4jOptions.CYPHER_VERSION, customVersion)
     val neo4jOptions: Neo4jOptions = new Neo4jOptions(options)
 
     val query: String = new Neo4jQueryService(
@@ -120,10 +122,11 @@ class Neo4jQueryServiceTest {
 
   @ParameterizedTest
   @MethodSource(Array("versions_and_prefixes"))
-  def testNodeOneLabelWithMultipleColumnSelected(neo4j: Neo4j, prefix: String): Unit = {
+  def testNodeOneLabelWithMultipleColumnSelected(neo4j: Neo4j, customVersion: String, prefix: String): Unit = {
     val options: java.util.Map[String, String] = new java.util.HashMap[String, String]()
     options.put(Neo4jOptions.URL, "bolt://localhost")
     options.put(QueryType.LABELS.toString.toLowerCase, "Person")
+    options.put(Neo4jOptions.CYPHER_VERSION, customVersion)
     val neo4jOptions: Neo4jOptions = new Neo4jOptions(options)
 
     val query: String = new Neo4jQueryService(
@@ -141,10 +144,11 @@ class Neo4jQueryServiceTest {
 
   @ParameterizedTest
   @MethodSource(Array("versions_and_prefixes"))
-  def testNodeOneLabelWithInternalIdSelected(neo4j: Neo4j, prefix: String): Unit = {
+  def testNodeOneLabelWithInternalIdSelected(neo4j: Neo4j, customVersion: String, prefix: String): Unit = {
     val options: java.util.Map[String, String] = new java.util.HashMap[String, String]()
     options.put(Neo4jOptions.URL, "bolt://localhost")
     options.put(QueryType.LABELS.toString.toLowerCase, "Person")
+    options.put(Neo4jOptions.CYPHER_VERSION, customVersion)
     val neo4jOptions: Neo4jOptions = new Neo4jOptions(options)
 
     val query: String = new Neo4jQueryService(
@@ -162,10 +166,11 @@ class Neo4jQueryServiceTest {
 
   @ParameterizedTest
   @MethodSource(Array("versions_and_prefixes"))
-  def testNodeFilterEqualTo(neo4j: Neo4j, prefix: String): Unit = {
+  def testNodeFilterEqualTo(neo4j: Neo4j, customVersion: String, prefix: String): Unit = {
     val options: java.util.Map[String, String] = new java.util.HashMap[String, String]()
     options.put(Neo4jOptions.URL, "bolt://localhost")
     options.put(QueryType.LABELS.toString.toLowerCase, "Person")
+    options.put(Neo4jOptions.CYPHER_VERSION, customVersion)
     val neo4jOptions: Neo4jOptions = new Neo4jOptions(options)
 
     val filters: Array[Filter] = Array[Filter](
@@ -182,10 +187,11 @@ class Neo4jQueryServiceTest {
 
   @ParameterizedTest
   @MethodSource(Array("versions_and_prefixes"))
-  def testNodeFilterEqualNullSafe(neo4j: Neo4j, prefix: String): Unit = {
+  def testNodeFilterEqualNullSafe(neo4j: Neo4j, customVersion: String, prefix: String): Unit = {
     val options: java.util.Map[String, String] = new java.util.HashMap[String, String]()
     options.put(Neo4jOptions.URL, "bolt://localhost")
     options.put(QueryType.LABELS.toString.toLowerCase, "Person")
+    options.put(Neo4jOptions.CYPHER_VERSION, customVersion)
     val neo4jOptions: Neo4jOptions = new Neo4jOptions(options)
 
     val filters: Array[Filter] = Array[Filter](
@@ -210,10 +216,11 @@ class Neo4jQueryServiceTest {
 
   @ParameterizedTest
   @MethodSource(Array("versions_and_prefixes"))
-  def testNodeFilterEqualNullSafeWithNullValue(neo4j: Neo4j, prefix: String): Unit = {
+  def testNodeFilterEqualNullSafeWithNullValue(neo4j: Neo4j, customVersion: String, prefix: String): Unit = {
     val options: java.util.Map[String, String] = new java.util.HashMap[String, String]()
     options.put(Neo4jOptions.URL, "bolt://localhost")
     options.put(QueryType.LABELS.toString.toLowerCase, "Person")
+    options.put(Neo4jOptions.CYPHER_VERSION, customVersion)
     val neo4jOptions: Neo4jOptions = new Neo4jOptions(options)
 
     val filters: Array[Filter] = Array[Filter](
@@ -235,10 +242,11 @@ class Neo4jQueryServiceTest {
 
   @ParameterizedTest
   @MethodSource(Array("versions_and_prefixes"))
-  def testNodeFilterStartsEndsWith(neo4j: Neo4j, prefix: String): Unit = {
+  def testNodeFilterStartsEndsWith(neo4j: Neo4j, customVersion: String, prefix: String): Unit = {
     val options: java.util.Map[String, String] = new java.util.HashMap[String, String]()
     options.put(Neo4jOptions.URL, "bolt://localhost")
     options.put(QueryType.LABELS.toString.toLowerCase, "Person")
+    options.put(Neo4jOptions.CYPHER_VERSION, customVersion)
     val neo4jOptions: Neo4jOptions = new Neo4jOptions(options)
 
     val filters: Array[Filter] = Array[Filter](
@@ -263,13 +271,14 @@ class Neo4jQueryServiceTest {
 
   @ParameterizedTest
   @MethodSource(Array("versions_and_prefixes"))
-  def testRelationshipWithOneColumnSelected(neo4j: Neo4j, prefix: String): Unit = {
+  def testRelationshipWithOneColumnSelected(neo4j: Neo4j, customVersion: String, prefix: String): Unit = {
     val options: java.util.Map[String, String] = new java.util.HashMap[String, String]()
     options.put(Neo4jOptions.URL, "bolt://localhost")
     options.put("relationship", "KNOWS")
     options.put("relationship.nodes.map", "false")
     options.put("relationship.source.labels", "Person")
     options.put("relationship.target.labels", "Person")
+    options.put(Neo4jOptions.CYPHER_VERSION, customVersion)
     val neo4jOptions: Neo4jOptions = new Neo4jOptions(options)
 
     val query: String = new Neo4jQueryService(
@@ -292,13 +301,14 @@ class Neo4jQueryServiceTest {
 
   @ParameterizedTest
   @MethodSource(Array("versions_and_prefixes"))
-  def testRelationshipWithMoreColumnSelected(neo4j: Neo4j, prefix: String): Unit = {
+  def testRelationshipWithMoreColumnSelected(neo4j: Neo4j, customVersion: String, prefix: String): Unit = {
     val options: java.util.Map[String, String] = new java.util.HashMap[String, String]()
     options.put(Neo4jOptions.URL, "bolt://localhost")
     options.put("relationship", "KNOWS")
     options.put("relationship.nodes.map", "false")
     options.put("relationship.source.labels", "Person")
     options.put("relationship.target.labels", "Person")
+    options.put(Neo4jOptions.CYPHER_VERSION, customVersion)
     val neo4jOptions: Neo4jOptions = new Neo4jOptions(options)
 
     val query: String = new Neo4jQueryService(
@@ -321,13 +331,18 @@ class Neo4jQueryServiceTest {
 
   @ParameterizedTest
   @MethodSource(Array("versions_and_prefixes"))
-  def testRelationshipWithMoreColumnSelectedWithPartitions(neo4j: Neo4j, prefix: String): Unit = {
+  def testRelationshipWithMoreColumnSelectedWithPartitions(
+    neo4j: Neo4j,
+    customVersion: String,
+    prefix: String
+  ): Unit = {
     val options: java.util.Map[String, String] = new java.util.HashMap[String, String]()
     options.put(Neo4jOptions.URL, "bolt://localhost")
     options.put("relationship", "KNOWS")
     options.put("relationship.nodes.map", "false")
     options.put("relationship.source.labels", "Person")
     options.put("relationship.target.labels", "Person")
+    options.put(Neo4jOptions.CYPHER_VERSION, customVersion)
     val neo4jOptions: Neo4jOptions = new Neo4jOptions(options)
 
     val query: String = new Neo4jQueryService(
@@ -354,13 +369,14 @@ class Neo4jQueryServiceTest {
 
   @ParameterizedTest
   @MethodSource(Array("versions_and_prefixes"))
-  def testRelationshipWithMoreColumnsSelected(neo4j: Neo4j, prefix: String): Unit = {
+  def testRelationshipWithMoreColumnsSelected(neo4j: Neo4j, customVersion: String, prefix: String): Unit = {
     val options: java.util.Map[String, String] = new java.util.HashMap[String, String]()
     options.put(Neo4jOptions.URL, "bolt://localhost")
     options.put("relationship", "KNOWS")
     options.put("relationship.nodes.map", "false")
     options.put("relationship.source.labels", "Person")
     options.put("relationship.target.labels", "Person")
+    options.put(Neo4jOptions.CYPHER_VERSION, customVersion)
     val neo4jOptions: Neo4jOptions = new Neo4jOptions(options)
 
     val query: String = new Neo4jQueryService(
@@ -383,13 +399,14 @@ class Neo4jQueryServiceTest {
 
   @ParameterizedTest
   @MethodSource(Array("versions_and_prefixes"))
-  def testRelationshipFilterEqualTo(neo4j: Neo4j, prefix: String): Unit = {
+  def testRelationshipFilterEqualTo(neo4j: Neo4j, customVersion: String, prefix: String): Unit = {
     val options: java.util.Map[String, String] = new java.util.HashMap[String, String]()
     options.put(Neo4jOptions.URL, "bolt://localhost")
     options.put("relationship", "KNOWS")
     options.put("relationship.nodes.map", "false")
     options.put("relationship.source.labels", "Person")
     options.put("relationship.target.labels", "Person")
+    options.put(Neo4jOptions.CYPHER_VERSION, customVersion)
     val neo4jOptions: Neo4jOptions = new Neo4jOptions(options)
 
     val filters: Array[Filter] = Array[Filter](
@@ -411,13 +428,14 @@ class Neo4jQueryServiceTest {
 
   @ParameterizedTest
   @MethodSource(Array("versions_and_prefixes"))
-  def testRelationshipFilterNotEqualTo(neo4j: Neo4j, prefix: String): Unit = {
+  def testRelationshipFilterNotEqualTo(neo4j: Neo4j, customVersion: String, prefix: String): Unit = {
     val options: java.util.Map[String, String] = new java.util.HashMap[String, String]()
     options.put(Neo4jOptions.URL, "bolt://localhost")
     options.put("relationship", "KNOWS")
     options.put("relationship.nodes.map", "false")
     options.put("relationship.source.labels", "Person")
     options.put("relationship.target.labels", "Person")
+    options.put(Neo4jOptions.CYPHER_VERSION, customVersion)
     val neo4jOptions: Neo4jOptions = new Neo4jOptions(options)
 
     val filters: Array[Filter] = Array[Filter](
@@ -440,13 +458,14 @@ class Neo4jQueryServiceTest {
 
   @ParameterizedTest
   @MethodSource(Array("versions_and_prefixes"))
-  def testRelationshipAndFilterEqualTo(neo4j: Neo4j, prefix: String): Unit = {
+  def testRelationshipAndFilterEqualTo(neo4j: Neo4j, customVersion: String, prefix: String): Unit = {
     val options: java.util.Map[String, String] = new java.util.HashMap[String, String]()
     options.put(Neo4jOptions.URL, "bolt://localhost")
     options.put("relationship", "KNOWS")
     options.put("relationship.nodes.map", "true")
     options.put("relationship.source.labels", "Person")
     options.put("relationship.target.labels", "Person")
+    options.put(Neo4jOptions.CYPHER_VERSION, customVersion)
     val neo4jOptions: Neo4jOptions = new Neo4jOptions(options)
 
     val filters: Array[Filter] = Array[Filter](
@@ -473,10 +492,11 @@ class Neo4jQueryServiceTest {
 
   @ParameterizedTest
   @MethodSource(Array("versions_and_prefixes"))
-  def testComplexNodeConditions(neo4j: Neo4j, prefix: String): Unit = {
+  def testComplexNodeConditions(neo4j: Neo4j, customVersion: String, prefix: String): Unit = {
     val options: java.util.Map[String, String] = new java.util.HashMap[String, String]()
     options.put(Neo4jOptions.URL, "bolt://localhost")
     options.put("labels", "Person")
+    options.put(Neo4jOptions.CYPHER_VERSION, customVersion)
     val neo4jOptions: Neo4jOptions = new Neo4jOptions(options)
 
     val filters: Array[Filter] = Array[Filter](
@@ -509,13 +529,14 @@ class Neo4jQueryServiceTest {
 
   @ParameterizedTest
   @MethodSource(Array("versions_and_prefixes"))
-  def testRelationshipFilterComplexConditionsNoMap(neo4j: Neo4j, prefix: String): Unit = {
+  def testRelationshipFilterComplexConditionsNoMap(neo4j: Neo4j, customVersion: String, prefix: String): Unit = {
     val options: java.util.Map[String, String] = new java.util.HashMap[String, String]()
     options.put(Neo4jOptions.URL, "bolt://localhost")
     options.put("relationship", "KNOWS")
     options.put("relationship.nodes.map", "false")
     options.put("relationship.source.labels", "Person")
     options.put("relationship.target.labels", "Person:Customer")
+    options.put(Neo4jOptions.CYPHER_VERSION, customVersion)
     val neo4jOptions: Neo4jOptions = new Neo4jOptions(options)
 
     val filters: Array[Filter] = Array[Filter](
@@ -557,13 +578,14 @@ class Neo4jQueryServiceTest {
 
   @ParameterizedTest
   @MethodSource(Array("versions_and_prefixes"))
-  def testRelationshipFilterComplexConditionsWithMap(neo4j: Neo4j, prefix: String): Unit = {
+  def testRelationshipFilterComplexConditionsWithMap(neo4j: Neo4j, customVersion: String, prefix: String): Unit = {
     val options: java.util.Map[String, String] = new java.util.HashMap[String, String]()
     options.put(Neo4jOptions.URL, "bolt://localhost")
     options.put("relationship", "KNOWS")
     options.put("relationship.nodes.map", "true")
     options.put("relationship.source.labels", "Person")
     options.put("relationship.target.labels", "Person:Customer")
+    options.put(Neo4jOptions.CYPHER_VERSION, customVersion)
     val neo4jOptions: Neo4jOptions = new Neo4jOptions(options)
 
     val filters: Array[Filter] = Array[Filter](
@@ -606,11 +628,12 @@ class Neo4jQueryServiceTest {
 
   @ParameterizedTest
   @MethodSource(Array("versions_and_prefixes"))
-  def testCompoundKeysForNodes(neo4j: Neo4j, prefix: String): Unit = {
+  def testCompoundKeysForNodes(neo4j: Neo4j, customVersion: String, prefix: String): Unit = {
     val options: java.util.Map[String, String] = new java.util.HashMap[String, String]()
     options.put(Neo4jOptions.URL, "bolt://localhost")
     options.put("labels", "Location")
     options.put("node.keys", "LocationName:name,LocationType:type,FeatureID:featureId")
+    options.put(Neo4jOptions.CYPHER_VERSION, customVersion)
     val neo4jOptions: Neo4jOptions = new Neo4jOptions(options)
 
     val query: String =
@@ -627,7 +650,7 @@ class Neo4jQueryServiceTest {
 
   @ParameterizedTest
   @MethodSource(Array("versions_and_prefixes"))
-  def testCompoundKeysForRelationship(neo4j: Neo4j, prefix: String): Unit = {
+  def testCompoundKeysForRelationship(neo4j: Neo4j, customVersion: String, prefix: String): Unit = {
     val options: java.util.Map[String, String] = new java.util.HashMap[String, String]()
     options.put(Neo4jOptions.URL, "bolt://localhost")
     options.put("relationship", "BOUGHT")
@@ -636,6 +659,7 @@ class Neo4jQueryServiceTest {
     options.put("relationship.target.labels", "Product")
     options.put("relationship.target.node.keys", "ProductPrice:price,ProductId:id")
 
+    options.put(Neo4jOptions.CYPHER_VERSION, customVersion)
     val neo4jOptions: Neo4jOptions = new Neo4jOptions(options)
 
     val query: String =
@@ -654,7 +678,7 @@ class Neo4jQueryServiceTest {
 
   @ParameterizedTest
   @MethodSource(Array("versions_and_prefixes"))
-  def testCompoundKeysForRelationshipMergeMatch(neo4j: Neo4j, prefix: String): Unit = {
+  def testCompoundKeysForRelationshipMergeMatch(neo4j: Neo4j, customVersion: String, prefix: String): Unit = {
     val options: java.util.Map[String, String] = new java.util.HashMap[String, String]()
     options.put(Neo4jOptions.URL, "bolt://localhost")
     options.put("relationship", "BOUGHT")
@@ -665,6 +689,7 @@ class Neo4jQueryServiceTest {
     options.put("relationship.target.node.keys", "ProductPrice:price,ProductId:id")
     options.put("relationship.target.save.mode", "match")
 
+    options.put(Neo4jOptions.CYPHER_VERSION, customVersion)
     val neo4jOptions: Neo4jOptions = new Neo4jOptions(options)
 
     val query: String =
@@ -684,7 +709,7 @@ class Neo4jQueryServiceTest {
 
   @ParameterizedTest
   @MethodSource(Array("versions_and_prefixes"))
-  def testRelationshipWithKeySaveStrategy(neo4j: Neo4j, prefix: String): Unit = {
+  def testRelationshipWithKeySaveStrategy(neo4j: Neo4j, customVersion: String, prefix: String): Unit = {
     val options: java.util.Map[String, String] = new java.util.HashMap[String, String]()
     options.put(Neo4jOptions.URL, "bolt://localhost")
     options.put("relationship", "DID BUY")
@@ -698,6 +723,7 @@ class Neo4jQueryServiceTest {
     options.put("relationship.properties", "number of items")
     options.put("relationship.keys", "transactionId:transaction identifier")
 
+    options.put(Neo4jOptions.CYPHER_VERSION, customVersion)
     val neo4jOptions: Neo4jOptions = new Neo4jOptions(options)
 
     val query: String =
@@ -717,10 +743,11 @@ class Neo4jQueryServiceTest {
 
   @ParameterizedTest
   @MethodSource(Array("versions_and_prefixes"))
-  def testShouldDoSumAggregationOnLabels(neo4j: Neo4j, prefix: String): Unit = {
+  def testShouldDoSumAggregationOnLabels(neo4j: Neo4j, customVersion: String, prefix: String): Unit = {
     val options: java.util.Map[String, String] = new java.util.HashMap[String, String]()
     options.put(Neo4jOptions.URL, "bolt://localhost")
     options.put(QueryType.LABELS.toString.toLowerCase, "Person")
+    options.put(Neo4jOptions.CYPHER_VERSION, customVersion)
     val neo4jOptions: Neo4jOptions = new Neo4jOptions(options)
 
     val ageField = new DummyNamedReference("age")
@@ -785,13 +812,14 @@ class Neo4jQueryServiceTest {
 
   @ParameterizedTest
   @MethodSource(Array("versions_and_prefixes"))
-  def testShouldDoSumAggregationOnRelationships(neo4j: Neo4j, prefix: String): Unit = {
+  def testShouldDoSumAggregationOnRelationships(neo4j: Neo4j, customVersion: String, prefix: String): Unit = {
     val options: java.util.Map[String, String] = new java.util.HashMap[String, String]()
     options.put(Neo4jOptions.URL, "bolt://localhost")
     options.put("relationship", "BOUGHT")
     options.put("relationship.nodes.map", "false")
     options.put("relationship.source.labels", "Person")
     options.put("relationship.target.labels", "Product")
+    options.put(Neo4jOptions.CYPHER_VERSION, customVersion)
     val neo4jOptions: Neo4jOptions = new Neo4jOptions(options)
 
     val targetPriceField = new DummyNamedReference("`target.price`")
@@ -870,10 +898,11 @@ class Neo4jQueryServiceTest {
 
   @ParameterizedTest
   @MethodSource(Array("versions_and_prefixes"))
-  def testTopNForLabels(neo4j: Neo4j, prefix: String): Unit = {
+  def testTopNForLabels(neo4j: Neo4j, customVersion: String, prefix: String): Unit = {
     val options: java.util.Map[String, String] = new java.util.HashMap[String, String]()
     options.put(Neo4jOptions.URL, "bolt://localhost")
     options.put(QueryType.LABELS.toString.toLowerCase, "Person")
+    options.put(Neo4jOptions.CYPHER_VERSION, customVersion)
     val neo4jOptions: Neo4jOptions = new Neo4jOptions(options)
 
     val query: String = new Neo4jQueryService(
@@ -902,10 +931,11 @@ class Neo4jQueryServiceTest {
 
   @ParameterizedTest
   @MethodSource(Array("versions_and_prefixes"))
-  def testTopNForLabelsWithRequiredColumn(neo4j: Neo4j, prefix: String): Unit = {
+  def testTopNForLabelsWithRequiredColumn(neo4j: Neo4j, customVersion: String, prefix: String): Unit = {
     val options: java.util.Map[String, String] = new java.util.HashMap[String, String]()
     options.put(Neo4jOptions.URL, "bolt://localhost")
     options.put(QueryType.LABELS.toString.toLowerCase, "Person")
+    options.put(Neo4jOptions.CYPHER_VERSION, customVersion)
     val neo4jOptions: Neo4jOptions = new Neo4jOptions(options)
 
     val query: String = new Neo4jQueryService(
@@ -935,13 +965,14 @@ class Neo4jQueryServiceTest {
 
   @ParameterizedTest
   @MethodSource(Array("versions_and_prefixes"))
-  def testTopNForRelationships(neo4j: Neo4j, prefix: String): Unit = {
+  def testTopNForRelationships(neo4j: Neo4j, customVersion: String, prefix: String): Unit = {
     val options: java.util.Map[String, String] = new java.util.HashMap[String, String]()
     options.put(Neo4jOptions.URL, "bolt://localhost")
     options.put("relationship", "KNOWS")
     options.put("relationship.nodes.map", "false")
     options.put("relationship.source.labels", "Person")
     options.put("relationship.target.labels", "Person")
+    options.put(Neo4jOptions.CYPHER_VERSION, customVersion)
     val neo4jOptions: Neo4jOptions = new Neo4jOptions(options)
 
     val query: String = new Neo4jQueryService(
@@ -977,13 +1008,14 @@ class Neo4jQueryServiceTest {
 
   @ParameterizedTest
   @MethodSource(Array("versions_and_prefixes"))
-  def testTopNForRelationshipWithOneRequiredColumn(neo4j: Neo4j, prefix: String): Unit = {
+  def testTopNForRelationshipWithOneRequiredColumn(neo4j: Neo4j, customVersion: String, prefix: String): Unit = {
     val options: java.util.Map[String, String] = new java.util.HashMap[String, String]()
     options.put(Neo4jOptions.URL, "bolt://localhost")
     options.put("relationship", "KNOWS")
     options.put("relationship.nodes.map", "false")
     options.put("relationship.source.labels", "Person")
     options.put("relationship.target.labels", "Person")
+    options.put(Neo4jOptions.CYPHER_VERSION, customVersion)
     val neo4jOptions: Neo4jOptions = new Neo4jOptions(options)
 
     val query: String = new Neo4jQueryService(
@@ -1022,10 +1054,11 @@ class Neo4jQueryServiceTest {
 
   @ParameterizedTest
   @MethodSource(Array("versions_and_prefixes"))
-  def testTopNForCustomQueryIgnoresAggregation(neo4j: Neo4j, prefix: String): Unit = {
+  def testTopNForCustomQueryIgnoresAggregation(neo4j: Neo4j, customVersion: String, prefix: String): Unit = {
     val options: java.util.Map[String, String] = new java.util.HashMap[String, String]()
     options.put(Neo4jOptions.URL, "bolt://localhost")
     options.put(QueryType.QUERY.toString.toLowerCase, "MATCH (p:Person) RETURN p")
+    options.put(Neo4jOptions.CYPHER_VERSION, customVersion)
     val neo4jOptions: Neo4jOptions = new Neo4jOptions(options)
 
     val query: String = new Neo4jQueryService(
@@ -1117,35 +1150,6 @@ class Neo4jQueryServiceTest {
 
   @ParameterizedTest
   @MethodSource(Array("tuning_parameters"))
-  def testTuningPreambleForCustomQuery(tuningOptions: Neo4jTuningOptions, prefix: String, mode: String): Unit = {
-    val options: java.util.Map[String, String] = new java.util.HashMap[String, String]()
-    options.put(Neo4jOptions.URL, "bolt://localhost")
-    options.put(QueryType.QUERY.toString.toLowerCase, "MATCH (o:Object) RETURN o")
-    val neo4jOptions: Neo4jOptions = new Neo4jOptions(withTuning(options, tuningOptions))
-
-    val (strategy, wantQuery) = mode match {
-      case "READ" => (
-          new Neo4jQueryReadStrategy(
-            neo4j(version(5, 0), COMMUNITY)
-          ),
-          "MATCH (o:Object) RETURN o"
-        )
-      case "WRITE" => (
-          new Neo4jQueryWriteStrategy(
-            neo4j(version(5, 0), COMMUNITY),
-            SaveMode.Overwrite
-          ),
-          "UNWIND $events AS event\nMATCH (o:Object) RETURN o"
-        )
-    }
-
-    val gotQuery = new Neo4jQueryService(neo4jOptions, strategy).createQuery().trim
-
-    assertEquals(s"$prefix\n$wantQuery".trim, gotQuery)
-  }
-
-  @ParameterizedTest
-  @MethodSource(Array("tuning_parameters"))
   def testCanSkipPreamble(tuningOptions: Neo4jTuningOptions, ignored: String, mode: String): Unit = {
     val options: java.util.Map[String, String] = new java.util.HashMap[String, String]()
     options.put(Neo4jOptions.URL, "bolt://localhost")
@@ -1168,96 +1172,91 @@ class Neo4jQueryServiceTest {
     assertEquals(wantQuery, gotQuery)
   }
 
-  @Test
-  def testTuningAndVersionInclusionInCustomReadQuery(): Unit = {
+  @ParameterizedTest
+  @MethodSource(Array("versions_prefix_and_tuning_cross_combination"))
+  def testTuningAndVersionInclusionInCustomQuery(
+    neo4j: Neo4j,
+    customVersion: String,
+    versionPrefix: String,
+    tuningOptions: Neo4jTuningOptions,
+    tuningPrefix: String,
+    mode: String
+  ): Unit = {
     val options: java.util.Map[String, String] = new java.util.HashMap[String, String]()
     options.put(Neo4jOptions.URL, "bolt://localhost")
     options.put(QueryType.QUERY.toString.toLowerCase, "MATCH (o:Object) RETURN o")
-
-    val tuningOptions = Neo4jTuningOptions.empty.copy(replan = "force", operatorEngine = "compiled")
+    options.put(Neo4jOptions.CYPHER_VERSION, customVersion)
     val neo4jOptions: Neo4jOptions = new Neo4jOptions(withTuning(options, tuningOptions))
+
+    val (strategy, wantQuery) = mode match {
+      case "READ" => (
+          new Neo4jQueryReadStrategy(neo4j),
+          s"$tuningPrefix\n${versionPrefix}MATCH (o:Object) RETURN o".trim
+        )
+      case "WRITE" => (
+          new Neo4jQueryWriteStrategy(neo4j, SaveMode.Overwrite),
+          s"$tuningPrefix\n${versionPrefix}UNWIND $$events AS event\nMATCH (o:Object) RETURN o".trim
+        )
+    }
 
     val actual = new Neo4jQueryService(
       neo4jOptions,
-      new Neo4jQueryReadStrategy(neo4j(version(2025, 1), ENTERPRISE))
+      strategy
     ).createQuery().trim
 
-    assertEquals(
-      "CYPHER replan=force operatorEngine=compiled\nCYPHER 5 MATCH (o:Object) RETURN o",
-      actual
-    )
+    assertEquals(wantQuery, actual)
   }
 
-  @Test
-  def testTuningAndVersionInclusionInCustomWriteQuery(): Unit = {
-    val options: java.util.Map[String, String] = new java.util.HashMap[String, String]()
-    options.put(Neo4jOptions.URL, "bolt://localhost")
-    options.put(QueryType.QUERY.toString.toLowerCase, "MATCH (o:Object) RETURN o")
-
-    val tuningOptions = Neo4jTuningOptions.empty.copy(replan = "force", operatorEngine = "compiled")
-    val neo4jOptions: Neo4jOptions = new Neo4jOptions(withTuning(options, tuningOptions))
-
-    val actual = new Neo4jQueryService(
-      neo4jOptions,
-      new Neo4jQueryWriteStrategy(neo4j(version(2025, 1), ENTERPRISE), SaveMode.Overwrite)
-    ).createQuery().trim
-
-    assertEquals(
-      "CYPHER replan=force operatorEngine=compiled\nCYPHER 5 UNWIND $events AS event\nMATCH (o:Object) RETURN o",
-      actual
-    )
-  }
-
-  @Test
-  def testScriptResultInclusionInCustomReadQuery(): Unit = {
+  @ParameterizedTest
+  @MethodSource(Array("versions_prefix_and_tuning_cross_combination"))
+  def testScriptResultInclusionInCustomQuery(
+    neo4j: Neo4j,
+    customVersion: String,
+    versionPrefix: String,
+    tuningOptions: Neo4jTuningOptions,
+    tuningPrefix: String,
+    mode: String
+  ): Unit = {
     val options: java.util.Map[String, String] = new java.util.HashMap[String, String]()
     options.put(Neo4jOptions.URL, "bolt://localhost")
     options.put(QueryType.QUERY.toString.toLowerCase, "MATCH (o:Object) RETURN o")
     options.put("script", "return 'foo'")
+    options.put(Neo4jOptions.CYPHER_VERSION, customVersion)
+    val neo4jOptions: Neo4jOptions = new Neo4jOptions(withTuning(options, tuningOptions))
 
-    val neo4jOptions: Neo4jOptions = new Neo4jOptions(options)
-
-    val actual = new Neo4jQueryService(
-      neo4jOptions,
-      new Neo4jQueryReadStrategy(neo4j(version(5, 0), COMMUNITY))
-    ).createQuery().trim
-
-    assertEquals(
-      "WITH $scriptResult AS scriptResult MATCH (o:Object) RETURN o",
-      actual
-    )
-  }
-
-  @Test
-  def testScriptResultInclusionInCustomWriteQuery(): Unit = {
-    val options: java.util.Map[String, String] = new java.util.HashMap[String, String]()
-    options.put(Neo4jOptions.URL, "bolt://localhost")
-    options.put(QueryType.QUERY.toString.toLowerCase, "MATCH (o:Object) RETURN o")
-    options.put("script", "return 'foo'")
-
-    val neo4jOptions: Neo4jOptions = new Neo4jOptions(options)
+    val (strategy, wantQuery) = mode match {
+      case "READ" => (
+          new Neo4jQueryReadStrategy(neo4j),
+          s"$tuningPrefix\n${versionPrefix}WITH $$scriptResult AS scriptResult MATCH (o:Object) RETURN o".trim
+        )
+      case "WRITE" => (
+          new Neo4jQueryWriteStrategy(neo4j, SaveMode.Overwrite),
+          s"$tuningPrefix\n${versionPrefix}WITH $$scriptResult AS scriptResult UNWIND $$events AS event\nMATCH (o:Object) RETURN o".trim
+        )
+    }
 
     val actual = new Neo4jQueryService(
       neo4jOptions,
-      new Neo4jQueryWriteStrategy(neo4j(version(5, 0), COMMUNITY), SaveMode.Overwrite)
+      strategy
     ).createQuery().trim
 
-    assertEquals(
-      "WITH $scriptResult AS scriptResult UNWIND $events AS event\nMATCH (o:Object) RETURN o",
-      actual
-    )
+    assertEquals(wantQuery, actual)
   }
 
   def versions_and_prefixes(): Array[Array[Any]] = {
     Array(
-      Array(neo4j(version(5, 0), COMMUNITY), ""),
-      Array(neo4j(version(5, 0), ENTERPRISE), ""),
-      Array(neo4j(version(5, 21), COMMUNITY), "CYPHER 5 "),
-      Array(neo4j(version(5, 21), ENTERPRISE), "CYPHER 5 "),
-      Array(neo4j(version(5, 26), COMMUNITY), "CYPHER 5 "),
-      Array(neo4j(version(5, 26), ENTERPRISE), "CYPHER 5 "),
-      Array(neo4j(version(2025, 1), COMMUNITY), "CYPHER 5 "),
-      Array(neo4j(version(2025, 1), ENTERPRISE), "CYPHER 5 ")
+      Array(neo4j(version(5, 0), COMMUNITY), "", ""),
+      Array(neo4j(version(5, 0), ENTERPRISE), "", ""),
+      Array(neo4j(version(5, 21), COMMUNITY), "", "CYPHER 5 "),
+      Array(neo4j(version(5, 21), ENTERPRISE), "", "CYPHER 5 "),
+      Array(neo4j(version(5, 26), COMMUNITY), "", "CYPHER 5 "),
+      Array(neo4j(version(5, 26), ENTERPRISE), "", "CYPHER 5 "),
+      Array(neo4j(version(2025, 1), COMMUNITY), "", "CYPHER 5 "),
+      Array(neo4j(version(2025, 1), ENTERPRISE), "", "CYPHER 5 "),
+      Array(neo4j(version(5, 0), COMMUNITY), "25", "CYPHER 25 "),
+      Array(neo4j(version(5, 0), ENTERPRISE), "25", "CYPHER 25 "),
+      Array(neo4j(version(5, 0), COMMUNITY), "5", "CYPHER 5 "),
+      Array(neo4j(version(5, 0), ENTERPRISE), "5", "CYPHER 5 ")
     )
   }
 
@@ -1288,15 +1287,31 @@ class Neo4jQueryServiceTest {
     )
   }
 
+  def versions_prefix_and_tuning_cross_combination(): Array[Array[Any]] = {
+    val tuningParams = tuning_parameters()
+    val versionPrefixes = versions_and_prefixes()
+
+    for {
+      tuningParam <- tuningParams
+      versionPrefix <- versionPrefixes
+    } yield Array(
+      versionPrefix(0), // neo4j: Neo4j
+      versionPrefix(1), // customVersion: String
+      versionPrefix(2), // versionPrefix: String
+      tuningParam(0), // tuningOptions: Neo4jTuningOptions
+      tuningParam(1), // tuningPrefix: String
+      tuningParam(2) // mode: String
+    )
+  }
+
   private def withTuning(
     options: java.util.Map[String, String],
     tuning: Neo4jTuningOptions
   ): java.util.Map[String, String] = {
     tuning.toMap.foreach {
-      case (key, value) => {
+      case (key, value) =>
         val dotCasedKey = key.replaceAll("([A-Z])", ".$1").toLowerCase
         options.put(s"cypher.$dotCasedKey", value)
-      }
     }
     options
   }

--- a/src/test/scala/org/neo4j/spark/service/Neo4jQueryServiceTest.scala
+++ b/src/test/scala/org/neo4j/spark/service/Neo4jQueryServiceTest.scala
@@ -50,11 +50,11 @@ class Neo4jQueryServiceTest {
 
   @ParameterizedTest
   @MethodSource(Array("versions_and_prefixes"))
-  def testNodeOneLabel(neo4j: Neo4j, customVersion: String, prefix: String): Unit = {
+  def testNodeOneLabel(neo4j: Neo4j, customCypherVersion: String, prefix: String): Unit = {
     val options: java.util.Map[String, String] = new java.util.HashMap[String, String]()
     options.put(Neo4jOptions.URL, "bolt://localhost")
     options.put(QueryType.LABELS.toString.toLowerCase, "Person")
-    options.put(Neo4jOptions.CYPHER_VERSION, customVersion)
+    options.put(Neo4jOptions.CYPHER_VERSION, customCypherVersion)
     val neo4jOptions: Neo4jOptions = new Neo4jOptions(options)
 
     val query: String =
@@ -65,11 +65,11 @@ class Neo4jQueryServiceTest {
 
   @ParameterizedTest
   @MethodSource(Array("versions_and_prefixes"))
-  def testNodeMultipleLabels(neo4j: Neo4j, customVersion: String, prefix: String): Unit = {
+  def testNodeMultipleLabels(neo4j: Neo4j, customCypherVersion: String, prefix: String): Unit = {
     val options: java.util.Map[String, String] = new java.util.HashMap[String, String]()
     options.put(Neo4jOptions.URL, "bolt://localhost")
     options.put(QueryType.LABELS.toString.toLowerCase, ":Person:Player:Midfield")
-    options.put(Neo4jOptions.CYPHER_VERSION, customVersion)
+    options.put(Neo4jOptions.CYPHER_VERSION, customCypherVersion)
     val neo4jOptions: Neo4jOptions = new Neo4jOptions(options)
 
     val query: String =
@@ -80,11 +80,11 @@ class Neo4jQueryServiceTest {
 
   @ParameterizedTest
   @MethodSource(Array("versions_and_prefixes"))
-  def testNodeMultipleLabelsWithPartitions(neo4j: Neo4j, customVersion: String, prefix: String): Unit = {
+  def testNodeMultipleLabelsWithPartitions(neo4j: Neo4j, customCypherVersion: String, prefix: String): Unit = {
     val options: java.util.Map[String, String] = new java.util.HashMap[String, String]()
     options.put(Neo4jOptions.URL, "bolt://localhost")
     options.put(QueryType.LABELS.toString.toLowerCase, ":Person:Player:Midfield")
-    options.put(Neo4jOptions.CYPHER_VERSION, customVersion)
+    options.put(Neo4jOptions.CYPHER_VERSION, customCypherVersion)
     val neo4jOptions: Neo4jOptions = new Neo4jOptions(options)
 
     val query: String = new Neo4jQueryService(
@@ -100,11 +100,11 @@ class Neo4jQueryServiceTest {
 
   @ParameterizedTest
   @MethodSource(Array("versions_and_prefixes"))
-  def testNodeOneLabelWithOneSelectedColumn(neo4j: Neo4j, customVersion: String, prefix: String): Unit = {
+  def testNodeOneLabelWithOneSelectedColumn(neo4j: Neo4j, customCypherVersion: String, prefix: String): Unit = {
     val options: java.util.Map[String, String] = new java.util.HashMap[String, String]()
     options.put(Neo4jOptions.URL, "bolt://localhost")
     options.put(QueryType.LABELS.toString.toLowerCase, "Person")
-    options.put(Neo4jOptions.CYPHER_VERSION, customVersion)
+    options.put(Neo4jOptions.CYPHER_VERSION, customCypherVersion)
     val neo4jOptions: Neo4jOptions = new Neo4jOptions(options)
 
     val query: String = new Neo4jQueryService(
@@ -122,11 +122,11 @@ class Neo4jQueryServiceTest {
 
   @ParameterizedTest
   @MethodSource(Array("versions_and_prefixes"))
-  def testNodeOneLabelWithMultipleColumnSelected(neo4j: Neo4j, customVersion: String, prefix: String): Unit = {
+  def testNodeOneLabelWithMultipleColumnSelected(neo4j: Neo4j, customCypherVersion: String, prefix: String): Unit = {
     val options: java.util.Map[String, String] = new java.util.HashMap[String, String]()
     options.put(Neo4jOptions.URL, "bolt://localhost")
     options.put(QueryType.LABELS.toString.toLowerCase, "Person")
-    options.put(Neo4jOptions.CYPHER_VERSION, customVersion)
+    options.put(Neo4jOptions.CYPHER_VERSION, customCypherVersion)
     val neo4jOptions: Neo4jOptions = new Neo4jOptions(options)
 
     val query: String = new Neo4jQueryService(
@@ -144,11 +144,11 @@ class Neo4jQueryServiceTest {
 
   @ParameterizedTest
   @MethodSource(Array("versions_and_prefixes"))
-  def testNodeOneLabelWithInternalIdSelected(neo4j: Neo4j, customVersion: String, prefix: String): Unit = {
+  def testNodeOneLabelWithInternalIdSelected(neo4j: Neo4j, customCypherVersion: String, prefix: String): Unit = {
     val options: java.util.Map[String, String] = new java.util.HashMap[String, String]()
     options.put(Neo4jOptions.URL, "bolt://localhost")
     options.put(QueryType.LABELS.toString.toLowerCase, "Person")
-    options.put(Neo4jOptions.CYPHER_VERSION, customVersion)
+    options.put(Neo4jOptions.CYPHER_VERSION, customCypherVersion)
     val neo4jOptions: Neo4jOptions = new Neo4jOptions(options)
 
     val query: String = new Neo4jQueryService(
@@ -166,11 +166,11 @@ class Neo4jQueryServiceTest {
 
   @ParameterizedTest
   @MethodSource(Array("versions_and_prefixes"))
-  def testNodeFilterEqualTo(neo4j: Neo4j, customVersion: String, prefix: String): Unit = {
+  def testNodeFilterEqualTo(neo4j: Neo4j, customCypherVersion: String, prefix: String): Unit = {
     val options: java.util.Map[String, String] = new java.util.HashMap[String, String]()
     options.put(Neo4jOptions.URL, "bolt://localhost")
     options.put(QueryType.LABELS.toString.toLowerCase, "Person")
-    options.put(Neo4jOptions.CYPHER_VERSION, customVersion)
+    options.put(Neo4jOptions.CYPHER_VERSION, customCypherVersion)
     val neo4jOptions: Neo4jOptions = new Neo4jOptions(options)
 
     val filters: Array[Filter] = Array[Filter](
@@ -187,11 +187,11 @@ class Neo4jQueryServiceTest {
 
   @ParameterizedTest
   @MethodSource(Array("versions_and_prefixes"))
-  def testNodeFilterEqualNullSafe(neo4j: Neo4j, customVersion: String, prefix: String): Unit = {
+  def testNodeFilterEqualNullSafe(neo4j: Neo4j, customCypherVersion: String, prefix: String): Unit = {
     val options: java.util.Map[String, String] = new java.util.HashMap[String, String]()
     options.put(Neo4jOptions.URL, "bolt://localhost")
     options.put(QueryType.LABELS.toString.toLowerCase, "Person")
-    options.put(Neo4jOptions.CYPHER_VERSION, customVersion)
+    options.put(Neo4jOptions.CYPHER_VERSION, customCypherVersion)
     val neo4jOptions: Neo4jOptions = new Neo4jOptions(options)
 
     val filters: Array[Filter] = Array[Filter](
@@ -216,11 +216,11 @@ class Neo4jQueryServiceTest {
 
   @ParameterizedTest
   @MethodSource(Array("versions_and_prefixes"))
-  def testNodeFilterEqualNullSafeWithNullValue(neo4j: Neo4j, customVersion: String, prefix: String): Unit = {
+  def testNodeFilterEqualNullSafeWithNullValue(neo4j: Neo4j, customCypherVersion: String, prefix: String): Unit = {
     val options: java.util.Map[String, String] = new java.util.HashMap[String, String]()
     options.put(Neo4jOptions.URL, "bolt://localhost")
     options.put(QueryType.LABELS.toString.toLowerCase, "Person")
-    options.put(Neo4jOptions.CYPHER_VERSION, customVersion)
+    options.put(Neo4jOptions.CYPHER_VERSION, customCypherVersion)
     val neo4jOptions: Neo4jOptions = new Neo4jOptions(options)
 
     val filters: Array[Filter] = Array[Filter](
@@ -242,11 +242,11 @@ class Neo4jQueryServiceTest {
 
   @ParameterizedTest
   @MethodSource(Array("versions_and_prefixes"))
-  def testNodeFilterStartsEndsWith(neo4j: Neo4j, customVersion: String, prefix: String): Unit = {
+  def testNodeFilterStartsEndsWith(neo4j: Neo4j, customCypherVersion: String, prefix: String): Unit = {
     val options: java.util.Map[String, String] = new java.util.HashMap[String, String]()
     options.put(Neo4jOptions.URL, "bolt://localhost")
     options.put(QueryType.LABELS.toString.toLowerCase, "Person")
-    options.put(Neo4jOptions.CYPHER_VERSION, customVersion)
+    options.put(Neo4jOptions.CYPHER_VERSION, customCypherVersion)
     val neo4jOptions: Neo4jOptions = new Neo4jOptions(options)
 
     val filters: Array[Filter] = Array[Filter](
@@ -271,14 +271,14 @@ class Neo4jQueryServiceTest {
 
   @ParameterizedTest
   @MethodSource(Array("versions_and_prefixes"))
-  def testRelationshipWithOneColumnSelected(neo4j: Neo4j, customVersion: String, prefix: String): Unit = {
+  def testRelationshipWithOneColumnSelected(neo4j: Neo4j, customCypherVersion: String, prefix: String): Unit = {
     val options: java.util.Map[String, String] = new java.util.HashMap[String, String]()
     options.put(Neo4jOptions.URL, "bolt://localhost")
     options.put("relationship", "KNOWS")
     options.put("relationship.nodes.map", "false")
     options.put("relationship.source.labels", "Person")
     options.put("relationship.target.labels", "Person")
-    options.put(Neo4jOptions.CYPHER_VERSION, customVersion)
+    options.put(Neo4jOptions.CYPHER_VERSION, customCypherVersion)
     val neo4jOptions: Neo4jOptions = new Neo4jOptions(options)
 
     val query: String = new Neo4jQueryService(
@@ -301,14 +301,14 @@ class Neo4jQueryServiceTest {
 
   @ParameterizedTest
   @MethodSource(Array("versions_and_prefixes"))
-  def testRelationshipWithMoreColumnSelected(neo4j: Neo4j, customVersion: String, prefix: String): Unit = {
+  def testRelationshipWithMoreColumnSelected(neo4j: Neo4j, customCypherVersion: String, prefix: String): Unit = {
     val options: java.util.Map[String, String] = new java.util.HashMap[String, String]()
     options.put(Neo4jOptions.URL, "bolt://localhost")
     options.put("relationship", "KNOWS")
     options.put("relationship.nodes.map", "false")
     options.put("relationship.source.labels", "Person")
     options.put("relationship.target.labels", "Person")
-    options.put(Neo4jOptions.CYPHER_VERSION, customVersion)
+    options.put(Neo4jOptions.CYPHER_VERSION, customCypherVersion)
     val neo4jOptions: Neo4jOptions = new Neo4jOptions(options)
 
     val query: String = new Neo4jQueryService(
@@ -333,7 +333,7 @@ class Neo4jQueryServiceTest {
   @MethodSource(Array("versions_and_prefixes"))
   def testRelationshipWithMoreColumnSelectedWithPartitions(
     neo4j: Neo4j,
-    customVersion: String,
+    customCypherVersion: String,
     prefix: String
   ): Unit = {
     val options: java.util.Map[String, String] = new java.util.HashMap[String, String]()
@@ -342,7 +342,7 @@ class Neo4jQueryServiceTest {
     options.put("relationship.nodes.map", "false")
     options.put("relationship.source.labels", "Person")
     options.put("relationship.target.labels", "Person")
-    options.put(Neo4jOptions.CYPHER_VERSION, customVersion)
+    options.put(Neo4jOptions.CYPHER_VERSION, customCypherVersion)
     val neo4jOptions: Neo4jOptions = new Neo4jOptions(options)
 
     val query: String = new Neo4jQueryService(
@@ -369,14 +369,14 @@ class Neo4jQueryServiceTest {
 
   @ParameterizedTest
   @MethodSource(Array("versions_and_prefixes"))
-  def testRelationshipWithMoreColumnsSelected(neo4j: Neo4j, customVersion: String, prefix: String): Unit = {
+  def testRelationshipWithMoreColumnsSelected(neo4j: Neo4j, customCypherVersion: String, prefix: String): Unit = {
     val options: java.util.Map[String, String] = new java.util.HashMap[String, String]()
     options.put(Neo4jOptions.URL, "bolt://localhost")
     options.put("relationship", "KNOWS")
     options.put("relationship.nodes.map", "false")
     options.put("relationship.source.labels", "Person")
     options.put("relationship.target.labels", "Person")
-    options.put(Neo4jOptions.CYPHER_VERSION, customVersion)
+    options.put(Neo4jOptions.CYPHER_VERSION, customCypherVersion)
     val neo4jOptions: Neo4jOptions = new Neo4jOptions(options)
 
     val query: String = new Neo4jQueryService(
@@ -399,14 +399,14 @@ class Neo4jQueryServiceTest {
 
   @ParameterizedTest
   @MethodSource(Array("versions_and_prefixes"))
-  def testRelationshipFilterEqualTo(neo4j: Neo4j, customVersion: String, prefix: String): Unit = {
+  def testRelationshipFilterEqualTo(neo4j: Neo4j, customCypherVersion: String, prefix: String): Unit = {
     val options: java.util.Map[String, String] = new java.util.HashMap[String, String]()
     options.put(Neo4jOptions.URL, "bolt://localhost")
     options.put("relationship", "KNOWS")
     options.put("relationship.nodes.map", "false")
     options.put("relationship.source.labels", "Person")
     options.put("relationship.target.labels", "Person")
-    options.put(Neo4jOptions.CYPHER_VERSION, customVersion)
+    options.put(Neo4jOptions.CYPHER_VERSION, customCypherVersion)
     val neo4jOptions: Neo4jOptions = new Neo4jOptions(options)
 
     val filters: Array[Filter] = Array[Filter](
@@ -428,14 +428,14 @@ class Neo4jQueryServiceTest {
 
   @ParameterizedTest
   @MethodSource(Array("versions_and_prefixes"))
-  def testRelationshipFilterNotEqualTo(neo4j: Neo4j, customVersion: String, prefix: String): Unit = {
+  def testRelationshipFilterNotEqualTo(neo4j: Neo4j, customCypherVersion: String, prefix: String): Unit = {
     val options: java.util.Map[String, String] = new java.util.HashMap[String, String]()
     options.put(Neo4jOptions.URL, "bolt://localhost")
     options.put("relationship", "KNOWS")
     options.put("relationship.nodes.map", "false")
     options.put("relationship.source.labels", "Person")
     options.put("relationship.target.labels", "Person")
-    options.put(Neo4jOptions.CYPHER_VERSION, customVersion)
+    options.put(Neo4jOptions.CYPHER_VERSION, customCypherVersion)
     val neo4jOptions: Neo4jOptions = new Neo4jOptions(options)
 
     val filters: Array[Filter] = Array[Filter](
@@ -458,14 +458,14 @@ class Neo4jQueryServiceTest {
 
   @ParameterizedTest
   @MethodSource(Array("versions_and_prefixes"))
-  def testRelationshipAndFilterEqualTo(neo4j: Neo4j, customVersion: String, prefix: String): Unit = {
+  def testRelationshipAndFilterEqualTo(neo4j: Neo4j, customCypherVersion: String, prefix: String): Unit = {
     val options: java.util.Map[String, String] = new java.util.HashMap[String, String]()
     options.put(Neo4jOptions.URL, "bolt://localhost")
     options.put("relationship", "KNOWS")
     options.put("relationship.nodes.map", "true")
     options.put("relationship.source.labels", "Person")
     options.put("relationship.target.labels", "Person")
-    options.put(Neo4jOptions.CYPHER_VERSION, customVersion)
+    options.put(Neo4jOptions.CYPHER_VERSION, customCypherVersion)
     val neo4jOptions: Neo4jOptions = new Neo4jOptions(options)
 
     val filters: Array[Filter] = Array[Filter](
@@ -492,11 +492,11 @@ class Neo4jQueryServiceTest {
 
   @ParameterizedTest
   @MethodSource(Array("versions_and_prefixes"))
-  def testComplexNodeConditions(neo4j: Neo4j, customVersion: String, prefix: String): Unit = {
+  def testComplexNodeConditions(neo4j: Neo4j, customCypherVersion: String, prefix: String): Unit = {
     val options: java.util.Map[String, String] = new java.util.HashMap[String, String]()
     options.put(Neo4jOptions.URL, "bolt://localhost")
     options.put("labels", "Person")
-    options.put(Neo4jOptions.CYPHER_VERSION, customVersion)
+    options.put(Neo4jOptions.CYPHER_VERSION, customCypherVersion)
     val neo4jOptions: Neo4jOptions = new Neo4jOptions(options)
 
     val filters: Array[Filter] = Array[Filter](
@@ -529,14 +529,14 @@ class Neo4jQueryServiceTest {
 
   @ParameterizedTest
   @MethodSource(Array("versions_and_prefixes"))
-  def testRelationshipFilterComplexConditionsNoMap(neo4j: Neo4j, customVersion: String, prefix: String): Unit = {
+  def testRelationshipFilterComplexConditionsNoMap(neo4j: Neo4j, customCypherVersion: String, prefix: String): Unit = {
     val options: java.util.Map[String, String] = new java.util.HashMap[String, String]()
     options.put(Neo4jOptions.URL, "bolt://localhost")
     options.put("relationship", "KNOWS")
     options.put("relationship.nodes.map", "false")
     options.put("relationship.source.labels", "Person")
     options.put("relationship.target.labels", "Person:Customer")
-    options.put(Neo4jOptions.CYPHER_VERSION, customVersion)
+    options.put(Neo4jOptions.CYPHER_VERSION, customCypherVersion)
     val neo4jOptions: Neo4jOptions = new Neo4jOptions(options)
 
     val filters: Array[Filter] = Array[Filter](
@@ -578,14 +578,18 @@ class Neo4jQueryServiceTest {
 
   @ParameterizedTest
   @MethodSource(Array("versions_and_prefixes"))
-  def testRelationshipFilterComplexConditionsWithMap(neo4j: Neo4j, customVersion: String, prefix: String): Unit = {
+  def testRelationshipFilterComplexConditionsWithMap(
+    neo4j: Neo4j,
+    customCypherVersion: String,
+    prefix: String
+  ): Unit = {
     val options: java.util.Map[String, String] = new java.util.HashMap[String, String]()
     options.put(Neo4jOptions.URL, "bolt://localhost")
     options.put("relationship", "KNOWS")
     options.put("relationship.nodes.map", "true")
     options.put("relationship.source.labels", "Person")
     options.put("relationship.target.labels", "Person:Customer")
-    options.put(Neo4jOptions.CYPHER_VERSION, customVersion)
+    options.put(Neo4jOptions.CYPHER_VERSION, customCypherVersion)
     val neo4jOptions: Neo4jOptions = new Neo4jOptions(options)
 
     val filters: Array[Filter] = Array[Filter](
@@ -628,12 +632,12 @@ class Neo4jQueryServiceTest {
 
   @ParameterizedTest
   @MethodSource(Array("versions_and_prefixes"))
-  def testCompoundKeysForNodes(neo4j: Neo4j, customVersion: String, prefix: String): Unit = {
+  def testCompoundKeysForNodes(neo4j: Neo4j, customCypherVersion: String, prefix: String): Unit = {
     val options: java.util.Map[String, String] = new java.util.HashMap[String, String]()
     options.put(Neo4jOptions.URL, "bolt://localhost")
     options.put("labels", "Location")
     options.put("node.keys", "LocationName:name,LocationType:type,FeatureID:featureId")
-    options.put(Neo4jOptions.CYPHER_VERSION, customVersion)
+    options.put(Neo4jOptions.CYPHER_VERSION, customCypherVersion)
     val neo4jOptions: Neo4jOptions = new Neo4jOptions(options)
 
     val query: String =
@@ -650,7 +654,7 @@ class Neo4jQueryServiceTest {
 
   @ParameterizedTest
   @MethodSource(Array("versions_and_prefixes"))
-  def testCompoundKeysForRelationship(neo4j: Neo4j, customVersion: String, prefix: String): Unit = {
+  def testCompoundKeysForRelationship(neo4j: Neo4j, customCypherVersion: String, prefix: String): Unit = {
     val options: java.util.Map[String, String] = new java.util.HashMap[String, String]()
     options.put(Neo4jOptions.URL, "bolt://localhost")
     options.put("relationship", "BOUGHT")
@@ -659,7 +663,7 @@ class Neo4jQueryServiceTest {
     options.put("relationship.target.labels", "Product")
     options.put("relationship.target.node.keys", "ProductPrice:price,ProductId:id")
 
-    options.put(Neo4jOptions.CYPHER_VERSION, customVersion)
+    options.put(Neo4jOptions.CYPHER_VERSION, customCypherVersion)
     val neo4jOptions: Neo4jOptions = new Neo4jOptions(options)
 
     val query: String =
@@ -678,7 +682,7 @@ class Neo4jQueryServiceTest {
 
   @ParameterizedTest
   @MethodSource(Array("versions_and_prefixes"))
-  def testCompoundKeysForRelationshipMergeMatch(neo4j: Neo4j, customVersion: String, prefix: String): Unit = {
+  def testCompoundKeysForRelationshipMergeMatch(neo4j: Neo4j, customCypherVersion: String, prefix: String): Unit = {
     val options: java.util.Map[String, String] = new java.util.HashMap[String, String]()
     options.put(Neo4jOptions.URL, "bolt://localhost")
     options.put("relationship", "BOUGHT")
@@ -689,7 +693,7 @@ class Neo4jQueryServiceTest {
     options.put("relationship.target.node.keys", "ProductPrice:price,ProductId:id")
     options.put("relationship.target.save.mode", "match")
 
-    options.put(Neo4jOptions.CYPHER_VERSION, customVersion)
+    options.put(Neo4jOptions.CYPHER_VERSION, customCypherVersion)
     val neo4jOptions: Neo4jOptions = new Neo4jOptions(options)
 
     val query: String =
@@ -709,7 +713,7 @@ class Neo4jQueryServiceTest {
 
   @ParameterizedTest
   @MethodSource(Array("versions_and_prefixes"))
-  def testRelationshipWithKeySaveStrategy(neo4j: Neo4j, customVersion: String, prefix: String): Unit = {
+  def testRelationshipWithKeySaveStrategy(neo4j: Neo4j, customCypherVersion: String, prefix: String): Unit = {
     val options: java.util.Map[String, String] = new java.util.HashMap[String, String]()
     options.put(Neo4jOptions.URL, "bolt://localhost")
     options.put("relationship", "DID BUY")
@@ -723,7 +727,7 @@ class Neo4jQueryServiceTest {
     options.put("relationship.properties", "number of items")
     options.put("relationship.keys", "transactionId:transaction identifier")
 
-    options.put(Neo4jOptions.CYPHER_VERSION, customVersion)
+    options.put(Neo4jOptions.CYPHER_VERSION, customCypherVersion)
     val neo4jOptions: Neo4jOptions = new Neo4jOptions(options)
 
     val query: String =
@@ -743,11 +747,11 @@ class Neo4jQueryServiceTest {
 
   @ParameterizedTest
   @MethodSource(Array("versions_and_prefixes"))
-  def testShouldDoSumAggregationOnLabels(neo4j: Neo4j, customVersion: String, prefix: String): Unit = {
+  def testShouldDoSumAggregationOnLabels(neo4j: Neo4j, customCypherVersion: String, prefix: String): Unit = {
     val options: java.util.Map[String, String] = new java.util.HashMap[String, String]()
     options.put(Neo4jOptions.URL, "bolt://localhost")
     options.put(QueryType.LABELS.toString.toLowerCase, "Person")
-    options.put(Neo4jOptions.CYPHER_VERSION, customVersion)
+    options.put(Neo4jOptions.CYPHER_VERSION, customCypherVersion)
     val neo4jOptions: Neo4jOptions = new Neo4jOptions(options)
 
     val ageField = new DummyNamedReference("age")
@@ -812,14 +816,14 @@ class Neo4jQueryServiceTest {
 
   @ParameterizedTest
   @MethodSource(Array("versions_and_prefixes"))
-  def testShouldDoSumAggregationOnRelationships(neo4j: Neo4j, customVersion: String, prefix: String): Unit = {
+  def testShouldDoSumAggregationOnRelationships(neo4j: Neo4j, customCypherVersion: String, prefix: String): Unit = {
     val options: java.util.Map[String, String] = new java.util.HashMap[String, String]()
     options.put(Neo4jOptions.URL, "bolt://localhost")
     options.put("relationship", "BOUGHT")
     options.put("relationship.nodes.map", "false")
     options.put("relationship.source.labels", "Person")
     options.put("relationship.target.labels", "Product")
-    options.put(Neo4jOptions.CYPHER_VERSION, customVersion)
+    options.put(Neo4jOptions.CYPHER_VERSION, customCypherVersion)
     val neo4jOptions: Neo4jOptions = new Neo4jOptions(options)
 
     val targetPriceField = new DummyNamedReference("`target.price`")
@@ -898,11 +902,11 @@ class Neo4jQueryServiceTest {
 
   @ParameterizedTest
   @MethodSource(Array("versions_and_prefixes"))
-  def testTopNForLabels(neo4j: Neo4j, customVersion: String, prefix: String): Unit = {
+  def testTopNForLabels(neo4j: Neo4j, customCypherVersion: String, prefix: String): Unit = {
     val options: java.util.Map[String, String] = new java.util.HashMap[String, String]()
     options.put(Neo4jOptions.URL, "bolt://localhost")
     options.put(QueryType.LABELS.toString.toLowerCase, "Person")
-    options.put(Neo4jOptions.CYPHER_VERSION, customVersion)
+    options.put(Neo4jOptions.CYPHER_VERSION, customCypherVersion)
     val neo4jOptions: Neo4jOptions = new Neo4jOptions(options)
 
     val query: String = new Neo4jQueryService(
@@ -931,11 +935,11 @@ class Neo4jQueryServiceTest {
 
   @ParameterizedTest
   @MethodSource(Array("versions_and_prefixes"))
-  def testTopNForLabelsWithRequiredColumn(neo4j: Neo4j, customVersion: String, prefix: String): Unit = {
+  def testTopNForLabelsWithRequiredColumn(neo4j: Neo4j, customCypherVersion: String, prefix: String): Unit = {
     val options: java.util.Map[String, String] = new java.util.HashMap[String, String]()
     options.put(Neo4jOptions.URL, "bolt://localhost")
     options.put(QueryType.LABELS.toString.toLowerCase, "Person")
-    options.put(Neo4jOptions.CYPHER_VERSION, customVersion)
+    options.put(Neo4jOptions.CYPHER_VERSION, customCypherVersion)
     val neo4jOptions: Neo4jOptions = new Neo4jOptions(options)
 
     val query: String = new Neo4jQueryService(
@@ -965,14 +969,14 @@ class Neo4jQueryServiceTest {
 
   @ParameterizedTest
   @MethodSource(Array("versions_and_prefixes"))
-  def testTopNForRelationships(neo4j: Neo4j, customVersion: String, prefix: String): Unit = {
+  def testTopNForRelationships(neo4j: Neo4j, customCypherVersion: String, prefix: String): Unit = {
     val options: java.util.Map[String, String] = new java.util.HashMap[String, String]()
     options.put(Neo4jOptions.URL, "bolt://localhost")
     options.put("relationship", "KNOWS")
     options.put("relationship.nodes.map", "false")
     options.put("relationship.source.labels", "Person")
     options.put("relationship.target.labels", "Person")
-    options.put(Neo4jOptions.CYPHER_VERSION, customVersion)
+    options.put(Neo4jOptions.CYPHER_VERSION, customCypherVersion)
     val neo4jOptions: Neo4jOptions = new Neo4jOptions(options)
 
     val query: String = new Neo4jQueryService(
@@ -1008,14 +1012,14 @@ class Neo4jQueryServiceTest {
 
   @ParameterizedTest
   @MethodSource(Array("versions_and_prefixes"))
-  def testTopNForRelationshipWithOneRequiredColumn(neo4j: Neo4j, customVersion: String, prefix: String): Unit = {
+  def testTopNForRelationshipWithOneRequiredColumn(neo4j: Neo4j, customCypherVersion: String, prefix: String): Unit = {
     val options: java.util.Map[String, String] = new java.util.HashMap[String, String]()
     options.put(Neo4jOptions.URL, "bolt://localhost")
     options.put("relationship", "KNOWS")
     options.put("relationship.nodes.map", "false")
     options.put("relationship.source.labels", "Person")
     options.put("relationship.target.labels", "Person")
-    options.put(Neo4jOptions.CYPHER_VERSION, customVersion)
+    options.put(Neo4jOptions.CYPHER_VERSION, customCypherVersion)
     val neo4jOptions: Neo4jOptions = new Neo4jOptions(options)
 
     val query: String = new Neo4jQueryService(
@@ -1054,11 +1058,11 @@ class Neo4jQueryServiceTest {
 
   @ParameterizedTest
   @MethodSource(Array("versions_and_prefixes"))
-  def testTopNForCustomQueryIgnoresAggregation(neo4j: Neo4j, customVersion: String, prefix: String): Unit = {
+  def testTopNForCustomQueryIgnoresAggregation(neo4j: Neo4j, customCypherVersion: String, prefix: String): Unit = {
     val options: java.util.Map[String, String] = new java.util.HashMap[String, String]()
     options.put(Neo4jOptions.URL, "bolt://localhost")
     options.put(QueryType.QUERY.toString.toLowerCase, "MATCH (p:Person) RETURN p")
-    options.put(Neo4jOptions.CYPHER_VERSION, customVersion)
+    options.put(Neo4jOptions.CYPHER_VERSION, customCypherVersion)
     val neo4jOptions: Neo4jOptions = new Neo4jOptions(options)
 
     val query: String = new Neo4jQueryService(
@@ -1088,37 +1092,55 @@ class Neo4jQueryServiceTest {
 
   @ParameterizedTest
   @MethodSource(Array("tuning_parameters"))
-  def testTuningPreambleForLabels(tuningOptions: Neo4jTuningOptions, prefix: String, mode: String): Unit = {
+  def testTuningPreambleForLabelsWhenRead(tuningOptions: Neo4jTuningOptions, prefix: String): Unit = {
+    val options: java.util.Map[String, String] = new java.util.HashMap[String, String]()
+    options.put(Neo4jOptions.URL, "bolt://localhost")
+    options.put(QueryType.LABELS.toString.toLowerCase, "Person")
+    val neo4jOptions: Neo4jOptions = new Neo4jOptions(withTuning(options, tuningOptions))
+    val readService = new Neo4jQueryService(neo4jOptions, new Neo4jQueryReadStrategy(neo4j(version(5, 0), COMMUNITY)))
+
+    val wantQuery = "MATCH (n:`Person`) RETURN n"
+    assertEquals(s"$prefix\n$wantQuery".trim, readService.createQuery().trim)
+  }
+
+  @ParameterizedTest
+  @MethodSource(Array("tuning_parameters"))
+  def testTuningPreambleForLabelsWhenWrite(tuningOptions: Neo4jTuningOptions, prefix: String): Unit = {
     val options: java.util.Map[String, String] = new java.util.HashMap[String, String]()
     options.put(Neo4jOptions.URL, "bolt://localhost")
     options.put(QueryType.LABELS.toString.toLowerCase, "Person")
     val neo4jOptions: Neo4jOptions = new Neo4jOptions(withTuning(options, tuningOptions))
 
-    val (strategy, wantQuery) = mode match {
-      case "READ" => (
-          new Neo4jQueryReadStrategy(
-            neo4j(version(5, 0), COMMUNITY)
-          ),
-          "MATCH (n:`Person`) RETURN n"
-        )
-      case "WRITE" => (
-          new Neo4jQueryWriteStrategy(
-            neo4j(version(5, 0), COMMUNITY),
-            SaveMode.Overwrite
-          ),
-          "UNWIND $events AS event\nMERGE (node:Person )\nSET node += event.properties"
-        )
-      case _ => throw new IllegalArgumentException(s"Invalid mode: $mode")
-    }
+    val writeService = new Neo4jQueryService(
+      neo4jOptions,
+      new Neo4jQueryWriteStrategy(neo4j(version(5, 0), COMMUNITY), SaveMode.Overwrite)
+    )
 
-    val gotQuery = new Neo4jQueryService(neo4jOptions, strategy).createQuery().trim
-
-    assertEquals(s"$prefix\n$wantQuery".trim, gotQuery)
+    val wantQuery = "UNWIND $events AS event\nMERGE (node:Person )\nSET node += event.properties"
+    assertEquals(s"$prefix\n$wantQuery".trim, writeService.createQuery().trim)
   }
 
   @ParameterizedTest
   @MethodSource(Array("tuning_parameters"))
-  def testTuningPreambleForRelationship(tuningOptions: Neo4jTuningOptions, prefix: String, mode: String): Unit = {
+  def testTuningPreambleForRelationshipWhenRead(tuningOptions: Neo4jTuningOptions, prefix: String): Unit = {
+    val options: java.util.Map[String, String] = new java.util.HashMap[String, String]()
+    options.put(Neo4jOptions.URL, "bolt://localhost")
+    options.put("relationship", "KNOWS")
+    options.put("relationship.nodes.map", "false")
+    options.put("relationship.source.labels", "Person")
+    options.put("relationship.target.labels", "Person")
+    val neo4jOptions: Neo4jOptions = new Neo4jOptions(withTuning(options, tuningOptions))
+    val readService = new Neo4jQueryService(neo4jOptions, new Neo4jQueryReadStrategy(neo4j(version(5, 0), COMMUNITY)))
+
+    val wantQuery =
+      "MATCH (source:`Person`) MATCH (target:`Person`) MATCH (source)-[rel:`KNOWS`]->(target) RETURN rel, source AS source, target AS target"
+
+    assertEquals(s"$prefix\n$wantQuery".trim, readService.createQuery().trim)
+  }
+
+  @ParameterizedTest
+  @MethodSource(Array("tuning_parameters"))
+  def testTuningPreambleForRelationshipWhenWrite(tuningOptions: Neo4jTuningOptions, prefix: String): Unit = {
     val options: java.util.Map[String, String] = new java.util.HashMap[String, String]()
     options.put(Neo4jOptions.URL, "bolt://localhost")
     options.put("relationship", "KNOWS")
@@ -1127,120 +1149,144 @@ class Neo4jQueryServiceTest {
     options.put("relationship.target.labels", "Person")
     val neo4jOptions: Neo4jOptions = new Neo4jOptions(withTuning(options, tuningOptions))
 
-    val (strategy, wantQuery) = mode match {
-      case "READ" => (
-          new Neo4jQueryReadStrategy(
-            neo4j(version(5, 0), COMMUNITY)
-          ),
-          "MATCH (source:`Person`) MATCH (target:`Person`) MATCH (source)-[rel:`KNOWS`]->(target) RETURN rel, source AS source, target AS target"
-        )
-      case "WRITE" => (
-          new Neo4jQueryWriteStrategy(
-            neo4j(version(5, 0), COMMUNITY),
-            SaveMode.Overwrite
-          ),
-          "UNWIND $events AS event\nMATCH (source:Person )\nMATCH (target:Person )\nMERGE (source)-[rel:KNOWS]->(target)\nSET rel += event.rel.properties"
-        )
-    }
+    val writeService = new Neo4jQueryService(
+      neo4jOptions,
+      new Neo4jQueryWriteStrategy(neo4j(version(5, 0), COMMUNITY), SaveMode.Overwrite)
+    )
 
-    val gotQuery = new Neo4jQueryService(neo4jOptions, strategy).createQuery().trim
+    val wantQuery =
+      "UNWIND $events AS event\nMATCH (source:Person )\nMATCH (target:Person )\nMERGE (source)-[rel:KNOWS]->(target)\nSET rel += event.rel.properties"
 
-    assertEquals(s"$prefix\n$wantQuery".trim, gotQuery)
+    assertEquals(s"$prefix\n$wantQuery".trim, writeService.createQuery().trim)
   }
 
   @ParameterizedTest
   @MethodSource(Array("tuning_parameters"))
-  def testCanSkipPreamble(tuningOptions: Neo4jTuningOptions, ignored: String, mode: String): Unit = {
+  def testCanSkipPreambleWhenRead(tuningOptions: Neo4jTuningOptions, ignored: String): Unit = {
     val options: java.util.Map[String, String] = new java.util.HashMap[String, String]()
     options.put(Neo4jOptions.URL, "bolt://localhost")
     options.put(QueryType.QUERY.toString.toLowerCase, "MATCH (o:Object) RETURN o")
     val neo4jOptions: Neo4jOptions = new Neo4jOptions(withTuning(options, tuningOptions))
 
-    val (strategy, wantQuery) = mode match {
-      case "READ" => (
-          new Neo4jQueryReadStrategy(neo4j(version(5, 0), COMMUNITY), withPreamble = false),
-          "MATCH (o:Object) RETURN o"
+    val noPreambleReadService =
+      new Neo4jQueryService(
+        neo4jOptions,
+        new Neo4jQueryReadStrategy(
+          neo4j(version(5, 0), COMMUNITY),
+          withPreamble = false
         )
-      case "WRITE" => (
-          new Neo4jQueryWriteStrategy(neo4j(version(5, 0), COMMUNITY), SaveMode.Overwrite, withPreamble = false),
-          "UNWIND $events AS event\nMATCH (o:Object) RETURN o"
-        )
-    }
+      )
 
-    val gotQuery = new Neo4jQueryService(neo4jOptions, strategy).createQuery().trim
+    val wantQuery = "MATCH (o:Object) RETURN o"
+    assertEquals(wantQuery, noPreambleReadService.createQuery().trim)
+  }
 
-    assertEquals(wantQuery, gotQuery)
+  @ParameterizedTest
+  @MethodSource(Array("tuning_parameters"))
+  def testCanSkipPreambleWhenWrite(tuningOptions: Neo4jTuningOptions, ignored: String): Unit = {
+    val options: java.util.Map[String, String] = new java.util.HashMap[String, String]()
+    options.put(Neo4jOptions.URL, "bolt://localhost")
+    options.put(QueryType.QUERY.toString.toLowerCase, "MATCH (o:Object) RETURN o")
+    val neo4jOptions: Neo4jOptions = new Neo4jOptions(withTuning(options, tuningOptions))
+
+    val noPreambleWriteService =
+      new Neo4jQueryService(
+        neo4jOptions,
+        new Neo4jQueryWriteStrategy(neo4j(version(5, 0), COMMUNITY), SaveMode.Overwrite, false)
+      )
+
+    val wantQuery = "UNWIND $events AS event\nMATCH (o:Object) RETURN o"
+    assertEquals(wantQuery, noPreambleWriteService.createQuery().trim)
   }
 
   @ParameterizedTest
   @MethodSource(Array("versions_prefix_and_tuning_cross_combination"))
-  def testTuningAndVersionInclusionInCustomQuery(
+  def testTuningAndVersionInclusionInCustomQueryWhenRead(
     neo4j: Neo4j,
-    customVersion: String,
-    versionPrefix: String,
+    customCypherVersion: String,
+    cypherVersionPreamble: String,
     tuningOptions: Neo4jTuningOptions,
-    tuningPrefix: String,
-    mode: String
+    tuningPrefix: String
   ): Unit = {
     val options: java.util.Map[String, String] = new java.util.HashMap[String, String]()
     options.put(Neo4jOptions.URL, "bolt://localhost")
     options.put(QueryType.QUERY.toString.toLowerCase, "MATCH (o:Object) RETURN o")
-    options.put(Neo4jOptions.CYPHER_VERSION, customVersion)
+    options.put(Neo4jOptions.CYPHER_VERSION, customCypherVersion)
+    val neo4jOptions: Neo4jOptions = new Neo4jOptions(withTuning(options, tuningOptions))
+    val versionedReadService = new Neo4jQueryService(neo4jOptions, new Neo4jQueryReadStrategy(neo4j))
+
+    val wantQuery = s"$tuningPrefix\n${cypherVersionPreamble}MATCH (o:Object) RETURN o"
+    assertEquals(wantQuery.trim, versionedReadService.createQuery().trim)
+  }
+
+  @ParameterizedTest
+  @MethodSource(Array("versions_prefix_and_tuning_cross_combination"))
+  def testTuningAndVersionInclusionInCustomQueryWhenWrite(
+    neo4j: Neo4j,
+    customCypherVersion: String,
+    cypherVersionPreamble: String,
+    tuningOptions: Neo4jTuningOptions,
+    tuningPrefix: String
+  ): Unit = {
+    val options: java.util.Map[String, String] = new java.util.HashMap[String, String]()
+    options.put(Neo4jOptions.URL, "bolt://localhost")
+    options.put(QueryType.QUERY.toString.toLowerCase, "MATCH (o:Object) RETURN o")
+    options.put(Neo4jOptions.CYPHER_VERSION, customCypherVersion)
     val neo4jOptions: Neo4jOptions = new Neo4jOptions(withTuning(options, tuningOptions))
 
-    val (strategy, wantQuery) = mode match {
-      case "READ" => (
-          new Neo4jQueryReadStrategy(neo4j),
-          s"$tuningPrefix\n${versionPrefix}MATCH (o:Object) RETURN o".trim
-        )
-      case "WRITE" => (
-          new Neo4jQueryWriteStrategy(neo4j, SaveMode.Overwrite),
-          s"$tuningPrefix\n${versionPrefix}UNWIND $$events AS event\nMATCH (o:Object) RETURN o".trim
-        )
-    }
+    val versionedWriteService =
+      new Neo4jQueryService(neo4jOptions, new Neo4jQueryWriteStrategy(neo4j, SaveMode.Overwrite))
 
-    val actual = new Neo4jQueryService(
-      neo4jOptions,
-      strategy
-    ).createQuery().trim
+    val wantQuery = s"$tuningPrefix\n${cypherVersionPreamble}UNWIND $$events AS event\nMATCH (o:Object) RETURN o"
+    assertEquals(wantQuery.trim, versionedWriteService.createQuery().trim)
+  }
 
-    assertEquals(wantQuery, actual)
+  @ParameterizedTest
+  @MethodSource(Array("versions_prefix_and_tuning_cross_combination"))
+  def testScriptResultInclusionInCustomQueryWhenRead(
+    neo4j: Neo4j,
+    customCypherVersion: String,
+    cypherVersionPreamble: String,
+    tuningOptions: Neo4jTuningOptions,
+    tuningPrefix: String
+  ): Unit = {
+    val options: java.util.Map[String, String] = new java.util.HashMap[String, String]()
+    options.put(Neo4jOptions.URL, "bolt://localhost")
+    options.put(QueryType.QUERY.toString.toLowerCase, "MATCH (o:Object) RETURN o")
+    options.put("script", "return 'foo'")
+    options.put(Neo4jOptions.CYPHER_VERSION, customCypherVersion)
+    val neo4jOptions: Neo4jOptions = new Neo4jOptions(withTuning(options, tuningOptions))
+    val versionedReadService = new Neo4jQueryService(neo4jOptions, new Neo4jQueryReadStrategy(neo4j))
+
+    val wantQuery =
+      s"$tuningPrefix\n${cypherVersionPreamble}WITH $$scriptResult AS scriptResult MATCH (o:Object) RETURN o"
+
+    assertEquals(wantQuery.trim, versionedReadService.createQuery().trim)
   }
 
   @ParameterizedTest
   @MethodSource(Array("versions_prefix_and_tuning_cross_combination"))
   def testScriptResultInclusionInCustomQuery(
     neo4j: Neo4j,
-    customVersion: String,
-    versionPrefix: String,
+    customCypherVersion: String,
+    cypherVersionPreamble: String,
     tuningOptions: Neo4jTuningOptions,
-    tuningPrefix: String,
-    mode: String
+    tuningPrefix: String
   ): Unit = {
     val options: java.util.Map[String, String] = new java.util.HashMap[String, String]()
     options.put(Neo4jOptions.URL, "bolt://localhost")
     options.put(QueryType.QUERY.toString.toLowerCase, "MATCH (o:Object) RETURN o")
     options.put("script", "return 'foo'")
-    options.put(Neo4jOptions.CYPHER_VERSION, customVersion)
+    options.put(Neo4jOptions.CYPHER_VERSION, customCypherVersion)
     val neo4jOptions: Neo4jOptions = new Neo4jOptions(withTuning(options, tuningOptions))
 
-    val (strategy, wantQuery) = mode match {
-      case "READ" => (
-          new Neo4jQueryReadStrategy(neo4j),
-          s"$tuningPrefix\n${versionPrefix}WITH $$scriptResult AS scriptResult MATCH (o:Object) RETURN o".trim
-        )
-      case "WRITE" => (
-          new Neo4jQueryWriteStrategy(neo4j, SaveMode.Overwrite),
-          s"$tuningPrefix\n${versionPrefix}WITH $$scriptResult AS scriptResult UNWIND $$events AS event\nMATCH (o:Object) RETURN o".trim
-        )
-    }
+    val versionedWriteService =
+      new Neo4jQueryService(neo4jOptions, new Neo4jQueryWriteStrategy(neo4j, SaveMode.Overwrite))
 
-    val actual = new Neo4jQueryService(
-      neo4jOptions,
-      strategy
-    ).createQuery().trim
+    val wantQuery =
+      s"$tuningPrefix\n${cypherVersionPreamble}WITH $$scriptResult AS scriptResult UNWIND $$events AS event\nMATCH (o:Object) RETURN o"
 
-    assertEquals(wantQuery, actual)
+    assertEquals(wantQuery.trim, versionedWriteService.createQuery().trim)
   }
 
   def versions_and_prefixes(): Array[Array[Any]] = {
@@ -1270,37 +1316,34 @@ class Neo4jQueryServiceTest {
 
   def tuning_parameters(): Array[Array[Any]] = {
     Array(
-      Array(Neo4jTuningOptions.empty, "", "READ"),
-      Array(Neo4jTuningOptions.empty, "", "WRITE"),
-      Array(Neo4jTuningOptions.empty.copy(runtime = "parallel"), "CYPHER runtime=parallel", "READ"),
-      Array(Neo4jTuningOptions.empty.copy(runtime = "parallel"), "CYPHER runtime=parallel", "WRITE"),
+      Array(Neo4jTuningOptions.empty, ""),
+      Array(Neo4jTuningOptions.empty, ""),
+      Array(Neo4jTuningOptions.empty.copy(runtime = "parallel"), "CYPHER runtime=parallel"),
+      Array(Neo4jTuningOptions.empty.copy(runtime = "parallel"), "CYPHER runtime=parallel"),
       Array(
         Neo4jTuningOptions.empty.copy(replan = "force", operatorEngine = "compiled"),
-        "CYPHER replan=force operatorEngine=compiled",
-        "READ"
+        "CYPHER replan=force operatorEngine=compiled"
       ),
       Array(
         Neo4jTuningOptions.empty.copy(replan = "force", operatorEngine = "compiled"),
-        "CYPHER replan=force operatorEngine=compiled",
-        "WRITE"
+        "CYPHER replan=force operatorEngine=compiled"
       )
     )
   }
 
   def versions_prefix_and_tuning_cross_combination(): Array[Array[Any]] = {
-    val tuningParams = tuning_parameters()
-    val versionPrefixes = versions_and_prefixes()
+    val tuningParameters = tuning_parameters()
+    val versionParameters = versions_and_prefixes()
 
     for {
-      tuningParam <- tuningParams
-      versionPrefix <- versionPrefixes
+      versionParameter <- versionParameters
+      tuningParameter <- tuningParameters
     } yield Array(
-      versionPrefix(0), // neo4j: Neo4j
-      versionPrefix(1), // customVersion: String
-      versionPrefix(2), // versionPrefix: String
-      tuningParam(0), // tuningOptions: Neo4jTuningOptions
-      tuningParam(1), // tuningPrefix: String
-      tuningParam(2) // mode: String
+      versionParameter(0), // neo4j: Neo4j
+      versionParameter(1), // customVersion: String
+      versionParameter(2), // versionPrefix: String
+      tuningParameter(0), // tuningOptions: Neo4jTuningOptions
+      tuningParameter(1) // tuningPrefix: String
     )
   }
 
@@ -1315,5 +1358,4 @@ class Neo4jQueryServiceTest {
     }
     options
   }
-
 }

--- a/src/test/scala/org/neo4j/spark/service/Neo4jQueryServiceTest.scala
+++ b/src/test/scala/org/neo4j/spark/service/Neo4jQueryServiceTest.scala
@@ -43,6 +43,8 @@ import org.neo4j.spark.util.Neo4jOptions
 import org.neo4j.spark.util.Neo4jTuningOptions
 import org.neo4j.spark.util.QueryType
 
+import java.util.Collections
+
 import scala.collection.immutable.HashMap
 
 @TestInstance(TestInstance.Lifecycle.PER_CLASS)
@@ -1307,7 +1309,7 @@ class Neo4jQueryServiceTest {
   }
 
   def neo4j(version: Neo4jVersion, edition: Neo4jEdition): Neo4j = {
-    new Neo4j(version, edition, SELF_MANAGED)
+    new Neo4j(version, edition, SELF_MANAGED, Collections.emptySet())
   }
 
   def version(major: Int, minor: Int): Neo4jVersion = {

--- a/src/test/scala/org/neo4j/spark/service/Neo4jQueryServiceTest.scala
+++ b/src/test/scala/org/neo4j/spark/service/Neo4jQueryServiceTest.scala
@@ -37,6 +37,7 @@ import org.neo4j.caniuse.Neo4jEdition.COMMUNITY
 import org.neo4j.caniuse.Neo4jEdition.ENTERPRISE
 import org.neo4j.caniuse.Neo4jVersion
 import org.neo4j.spark.config.TopN
+import org.neo4j.spark.cypher.CypherRenderer
 import org.neo4j.spark.util.DummyNamedReference
 import org.neo4j.spark.util.Neo4jImplicits.CypherImplicits
 import org.neo4j.spark.util.Neo4jOptions
@@ -60,7 +61,7 @@ class Neo4jQueryServiceTest {
     val neo4jOptions: Neo4jOptions = new Neo4jOptions(options)
 
     val query: String =
-      new Neo4jQueryService(neo4jOptions, new Neo4jQueryReadStrategy(neo4j)).createQuery()
+      new Neo4jQueryService(neo4jOptions, plainReadStrategy(neo4j, neo4jOptions)).createQuery()
 
     assertEquals(s"${prefix}MATCH (n:`Person`) RETURN n", query)
   }
@@ -75,7 +76,7 @@ class Neo4jQueryServiceTest {
     val neo4jOptions: Neo4jOptions = new Neo4jOptions(options)
 
     val query: String =
-      new Neo4jQueryService(neo4jOptions, new Neo4jQueryReadStrategy(neo4j)).createQuery()
+      new Neo4jQueryService(neo4jOptions, plainReadStrategy(neo4j, neo4jOptions)).createQuery()
 
     assertEquals(s"${prefix}MATCH (n:`Person`:`Player`:`Midfield`) RETURN n", query)
   }
@@ -93,6 +94,7 @@ class Neo4jQueryServiceTest {
       neo4jOptions,
       new Neo4jQueryReadStrategy(
         neo4j,
+        new CypherRenderer(neo4j, neo4jOptions),
         partitionPagination = PartitionPagination(0, 0, TopN(100))
       )
     ).createQuery()
@@ -113,6 +115,7 @@ class Neo4jQueryServiceTest {
       neo4jOptions,
       new Neo4jQueryReadStrategy(
         neo4j,
+        new CypherRenderer(neo4j, neo4jOptions),
         Array.empty[Filter],
         PartitionPagination.EMPTY,
         Seq("name")
@@ -135,6 +138,7 @@ class Neo4jQueryServiceTest {
       neo4jOptions,
       new Neo4jQueryReadStrategy(
         neo4j,
+        new CypherRenderer(neo4j, neo4jOptions),
         Array.empty[Filter],
         PartitionPagination.EMPTY,
         List("name", "bornDate")
@@ -157,6 +161,7 @@ class Neo4jQueryServiceTest {
       neo4jOptions,
       new Neo4jQueryReadStrategy(
         neo4j,
+        new CypherRenderer(neo4j, neo4jOptions),
         Array.empty[Filter],
         PartitionPagination.EMPTY,
         List("<elementId>")
@@ -180,7 +185,10 @@ class Neo4jQueryServiceTest {
     )
 
     val query: String =
-      new Neo4jQueryService(neo4jOptions, new Neo4jQueryReadStrategy(neo4j, filters)).createQuery()
+      new Neo4jQueryService(
+        neo4jOptions,
+        new Neo4jQueryReadStrategy(neo4j, new CypherRenderer(neo4j, neo4jOptions), filters)
+      ).createQuery()
 
     val paramName = "$" + "name".toParameterName("John Doe")
 
@@ -202,7 +210,10 @@ class Neo4jQueryServiceTest {
     )
 
     val query: String =
-      new Neo4jQueryService(neo4jOptions, new Neo4jQueryReadStrategy(neo4j, filters)).createQuery()
+      new Neo4jQueryService(
+        neo4jOptions,
+        new Neo4jQueryReadStrategy(neo4j, new CypherRenderer(neo4j, neo4jOptions), filters)
+      ).createQuery()
 
     val nameParameterName = "$" + "name".toParameterName("John Doe")
     val ageParameterName = "$" + "age".toParameterName(36)
@@ -231,7 +242,10 @@ class Neo4jQueryServiceTest {
     )
 
     val query: String =
-      new Neo4jQueryService(neo4jOptions, new Neo4jQueryReadStrategy(neo4j, filters)).createQuery()
+      new Neo4jQueryService(
+        neo4jOptions,
+        new Neo4jQueryReadStrategy(neo4j, new CypherRenderer(neo4j, neo4jOptions), filters)
+      ).createQuery()
 
     val nameParameterName = "$" + "name".toParameterName(null)
     val ageParameterName = "$" + "age".toParameterName(36)
@@ -257,7 +271,10 @@ class Neo4jQueryServiceTest {
     )
 
     val query: String =
-      new Neo4jQueryService(neo4jOptions, new Neo4jQueryReadStrategy(neo4j, filters)).createQuery()
+      new Neo4jQueryService(
+        neo4jOptions,
+        new Neo4jQueryReadStrategy(neo4j, new CypherRenderer(neo4j, neo4jOptions), filters)
+      ).createQuery()
 
     val nameOneParameterName = "$" + "name".toParameterName("Person Name")
     val nameTwoParameterName = "$" + "name".toParameterName("Person Surname")
@@ -287,6 +304,7 @@ class Neo4jQueryServiceTest {
       neo4jOptions,
       new Neo4jQueryReadStrategy(
         neo4j,
+        new CypherRenderer(neo4j, neo4jOptions),
         Array.empty[Filter],
         PartitionPagination.EMPTY,
         List("source.name")
@@ -317,6 +335,7 @@ class Neo4jQueryServiceTest {
       neo4jOptions,
       new Neo4jQueryReadStrategy(
         neo4j,
+        new CypherRenderer(neo4j, neo4jOptions),
         Array.empty[Filter],
         PartitionPagination.EMPTY,
         List("source.name", "<source.elementId>")
@@ -351,6 +370,7 @@ class Neo4jQueryServiceTest {
       neo4jOptions,
       new Neo4jQueryReadStrategy(
         neo4j,
+        new CypherRenderer(neo4j, neo4jOptions),
         Array.empty[Filter],
         PartitionPagination(0, 0, TopN(limit = 100)),
         List("source.name", "<source.elementId>")
@@ -385,6 +405,7 @@ class Neo4jQueryServiceTest {
       neo4jOptions,
       new Neo4jQueryReadStrategy(
         neo4j,
+        new CypherRenderer(neo4j, neo4jOptions),
         Array.empty[Filter],
         PartitionPagination.EMPTY,
         List("source.name", "source.id", "rel.someprops", "target.date")
@@ -416,7 +437,10 @@ class Neo4jQueryServiceTest {
     )
 
     val query: String =
-      new Neo4jQueryService(neo4jOptions, new Neo4jQueryReadStrategy(neo4j, filters)).createQuery()
+      new Neo4jQueryService(
+        neo4jOptions,
+        new Neo4jQueryReadStrategy(neo4j, new CypherRenderer(neo4j, neo4jOptions), filters)
+      ).createQuery()
 
     val parameterName = "$" + "source.name".toParameterName("John Doe")
 
@@ -445,7 +469,10 @@ class Neo4jQueryServiceTest {
     )
 
     val query: String =
-      new Neo4jQueryService(neo4jOptions, new Neo4jQueryReadStrategy(neo4j, filters)).createQuery()
+      new Neo4jQueryService(
+        neo4jOptions,
+        new Neo4jQueryReadStrategy(neo4j, new CypherRenderer(neo4j, neo4jOptions), filters)
+      ).createQuery()
 
     val paramOneName = "$" + "source.name".toParameterName("John Doe")
     val paramTwoName = "$" + "target.name".toParameterName("John Doe")
@@ -476,7 +503,10 @@ class Neo4jQueryServiceTest {
     )
 
     val query: String =
-      new Neo4jQueryService(neo4jOptions, new Neo4jQueryReadStrategy(neo4j, filters)).createQuery()
+      new Neo4jQueryService(
+        neo4jOptions,
+        new Neo4jQueryReadStrategy(neo4j, new CypherRenderer(neo4j, neo4jOptions), filters)
+      ).createQuery()
 
     val sourceIdParameterName = "$" + "source.id".toParameterName(14)
     val targetIdParameterName = "$" + "target.id".toParameterName(16)
@@ -508,7 +538,10 @@ class Neo4jQueryServiceTest {
     )
 
     val query: String =
-      new Neo4jQueryService(neo4jOptions, new Neo4jQueryReadStrategy(neo4j, filters)).createQuery()
+      new Neo4jQueryService(
+        neo4jOptions,
+        new Neo4jQueryReadStrategy(neo4j, new CypherRenderer(neo4j, neo4jOptions), filters)
+      ).createQuery()
 
     val parameterNames: Map[String, String] = HashMap(
       "name_1" -> "$".concat("name".toParameterName("John Doe")),
@@ -551,7 +584,10 @@ class Neo4jQueryServiceTest {
     )
 
     val query: String =
-      new Neo4jQueryService(neo4jOptions, new Neo4jQueryReadStrategy(neo4j, filters)).createQuery()
+      new Neo4jQueryService(
+        neo4jOptions,
+        new Neo4jQueryReadStrategy(neo4j, new CypherRenderer(neo4j, neo4jOptions), filters)
+      ).createQuery()
 
     val parameterNames = Map(
       "source.name_1" -> "$".concat("source.name".toParameterName("John Doe")),
@@ -604,7 +640,10 @@ class Neo4jQueryServiceTest {
     )
 
     val query: String =
-      new Neo4jQueryService(neo4jOptions, new Neo4jQueryReadStrategy(neo4j, filters)).createQuery()
+      new Neo4jQueryService(
+        neo4jOptions,
+        new Neo4jQueryReadStrategy(neo4j, new CypherRenderer(neo4j, neo4jOptions), filters)
+      ).createQuery()
 
     val parameterNames = Map(
       "source.name_1" -> "$".concat("source.name".toParameterName("John Doe")),
@@ -761,6 +800,7 @@ class Neo4jQueryServiceTest {
       neo4jOptions,
       new Neo4jQueryReadStrategy(
         neo4j,
+        new CypherRenderer(neo4j, neo4jOptions),
         Array.empty[Filter],
         PartitionPagination.EMPTY,
         Seq("name", "SUM(DISTINCT age)", "SUM(age)"),
@@ -781,6 +821,7 @@ class Neo4jQueryServiceTest {
       neo4jOptions,
       new Neo4jQueryReadStrategy(
         neo4j,
+        new CypherRenderer(neo4j, neo4jOptions),
         Array.empty[Filter],
         PartitionPagination.EMPTY,
         Seq("name", "COUNT(DISTINCT name)", "COUNT(name)"),
@@ -800,6 +841,7 @@ class Neo4jQueryServiceTest {
       neo4jOptions,
       new Neo4jQueryReadStrategy(
         neo4j,
+        new CypherRenderer(neo4j, neo4jOptions),
         Array.empty[Filter],
         PartitionPagination.EMPTY,
         Seq("name", "MAX(age)", "MIN(age)"),
@@ -833,6 +875,7 @@ class Neo4jQueryServiceTest {
       neo4jOptions,
       new Neo4jQueryReadStrategy(
         neo4j,
+        new CypherRenderer(neo4j, neo4jOptions),
         Array.empty,
         PartitionPagination.EMPTY,
         List("source.fullName", "SUM(DISTINCT `target.price`)", "SUM(`target.price`)"),
@@ -858,6 +901,7 @@ class Neo4jQueryServiceTest {
       neo4jOptions,
       new Neo4jQueryReadStrategy(
         neo4j,
+        new CypherRenderer(neo4j, neo4jOptions),
         Array.empty,
         PartitionPagination.EMPTY,
         List("source.fullName", "COUNT(DISTINCT `target.id`)", "COUNT(`target.id`)"),
@@ -881,6 +925,7 @@ class Neo4jQueryServiceTest {
       neo4jOptions,
       new Neo4jQueryReadStrategy(
         neo4j,
+        new CypherRenderer(neo4j, neo4jOptions),
         Array.empty,
         PartitionPagination.EMPTY,
         List("source.fullName", "MAX(`target.price`)", "MIN(`target.price`)"),
@@ -915,6 +960,7 @@ class Neo4jQueryServiceTest {
       neo4jOptions,
       new Neo4jQueryReadStrategy(
         neo4j,
+        new CypherRenderer(neo4j, neo4jOptions),
         partitionPagination = PartitionPagination(
           0,
           0,
@@ -948,6 +994,7 @@ class Neo4jQueryServiceTest {
       neo4jOptions,
       new Neo4jQueryReadStrategy(
         neo4j,
+        new CypherRenderer(neo4j, neo4jOptions),
         requiredColumns = Array("name").toIndexedSeq,
         partitionPagination = PartitionPagination(
           0,
@@ -985,6 +1032,7 @@ class Neo4jQueryServiceTest {
       neo4jOptions,
       new Neo4jQueryReadStrategy(
         neo4j,
+        new CypherRenderer(neo4j, neo4jOptions),
         Array.empty[Filter],
         PartitionPagination(
           0,
@@ -1028,6 +1076,7 @@ class Neo4jQueryServiceTest {
       neo4jOptions,
       new Neo4jQueryReadStrategy(
         neo4j,
+        new CypherRenderer(neo4j, neo4jOptions),
         Array.empty[Filter],
         PartitionPagination(
           0,
@@ -1071,6 +1120,7 @@ class Neo4jQueryServiceTest {
       neo4jOptions,
       new Neo4jQueryReadStrategy(
         neo4j,
+        new CypherRenderer(neo4j, neo4jOptions),
         Array.empty[Filter],
         PartitionPagination(
           0,
@@ -1099,7 +1149,8 @@ class Neo4jQueryServiceTest {
     options.put(Neo4jOptions.URL, "bolt://localhost")
     options.put(QueryType.LABELS.toString.toLowerCase, "Person")
     val neo4jOptions: Neo4jOptions = new Neo4jOptions(withTuning(options, tuningOptions))
-    val readService = new Neo4jQueryService(neo4jOptions, new Neo4jQueryReadStrategy(neo4j(version(5, 0), COMMUNITY)))
+    val readService =
+      new Neo4jQueryService(neo4jOptions, plainReadStrategy(neo4j(version(5, 0), COMMUNITY), neo4jOptions))
 
     val wantQuery = "MATCH (n:`Person`) RETURN n"
     assertEquals(s"$prefix\n$wantQuery".trim, readService.createQuery().trim)
@@ -1132,7 +1183,8 @@ class Neo4jQueryServiceTest {
     options.put("relationship.source.labels", "Person")
     options.put("relationship.target.labels", "Person")
     val neo4jOptions: Neo4jOptions = new Neo4jOptions(withTuning(options, tuningOptions))
-    val readService = new Neo4jQueryService(neo4jOptions, new Neo4jQueryReadStrategy(neo4j(version(5, 0), COMMUNITY)))
+    val readService =
+      new Neo4jQueryService(neo4jOptions, plainReadStrategy(neo4j(version(5, 0), COMMUNITY), neo4jOptions))
 
     val wantQuery =
       "MATCH (source:`Person`) MATCH (target:`Person`) MATCH (source)-[rel:`KNOWS`]->(target) RETURN rel, source AS source, target AS target"
@@ -1169,12 +1221,14 @@ class Neo4jQueryServiceTest {
     options.put(Neo4jOptions.URL, "bolt://localhost")
     options.put(QueryType.QUERY.toString.toLowerCase, "MATCH (o:Object) RETURN o")
     val neo4jOptions: Neo4jOptions = new Neo4jOptions(withTuning(options, tuningOptions))
+    val neo4jVersion = neo4j(version(5, 0), COMMUNITY)
 
     val noPreambleReadService =
       new Neo4jQueryService(
         neo4jOptions,
         new Neo4jQueryReadStrategy(
-          neo4j(version(5, 0), COMMUNITY),
+          neo4jVersion,
+          new CypherRenderer(neo4jVersion, neo4jOptions),
           withPreamble = false
         )
       )
@@ -1215,7 +1269,7 @@ class Neo4jQueryServiceTest {
     options.put(QueryType.QUERY.toString.toLowerCase, "MATCH (o:Object) RETURN o")
     options.put(Neo4jOptions.CYPHER_VERSION, customCypherVersion)
     val neo4jOptions: Neo4jOptions = new Neo4jOptions(withTuning(options, tuningOptions))
-    val versionedReadService = new Neo4jQueryService(neo4jOptions, new Neo4jQueryReadStrategy(neo4j))
+    val versionedReadService = new Neo4jQueryService(neo4jOptions, plainReadStrategy(neo4j, neo4jOptions))
 
     val wantQuery = s"$tuningPrefix\n${cypherVersionPreamble}MATCH (o:Object) RETURN o"
     assertEquals(wantQuery.trim, versionedReadService.createQuery().trim)
@@ -1258,7 +1312,7 @@ class Neo4jQueryServiceTest {
     options.put("script", "return 'foo'")
     options.put(Neo4jOptions.CYPHER_VERSION, customCypherVersion)
     val neo4jOptions: Neo4jOptions = new Neo4jOptions(withTuning(options, tuningOptions))
-    val versionedReadService = new Neo4jQueryService(neo4jOptions, new Neo4jQueryReadStrategy(neo4j))
+    val versionedReadService = new Neo4jQueryService(neo4jOptions, plainReadStrategy(neo4j, neo4jOptions))
 
     val wantQuery =
       s"$tuningPrefix\n${cypherVersionPreamble}WITH $$scriptResult AS scriptResult MATCH (o:Object) RETURN o"
@@ -1290,6 +1344,9 @@ class Neo4jQueryServiceTest {
 
     assertEquals(wantQuery.trim, versionedWriteService.createQuery().trim)
   }
+
+  def plainReadStrategy(neo4j: Neo4j, neo4jOptions: Neo4jOptions): Neo4jQueryReadStrategy =
+    new Neo4jQueryReadStrategy(neo4j, new CypherRenderer(neo4j, neo4jOptions))
 
   def versions_and_prefixes(): Array[Array[Any]] = {
     Array(

--- a/src/test/scala/org/neo4j/spark/service/SchemaServiceTest.scala
+++ b/src/test/scala/org/neo4j/spark/service/SchemaServiceTest.scala
@@ -28,6 +28,8 @@ import org.neo4j.spark.config.TopN
 import org.neo4j.spark.util.DriverCache
 import org.neo4j.spark.util.Neo4jOptions
 
+import java.util.Collections
+
 import scala.jdk.CollectionConverters.MapHasAsJava
 
 class SchemaServiceTest {
@@ -58,6 +60,11 @@ class SchemaServiceTest {
   }
 
   private def neo4j(): Neo4j = {
-    new Neo4j(new Neo4jVersion(2025, 1, 0), Neo4jEdition.COMMUNITY, Neo4jDeploymentType.SELF_MANAGED)
+    new Neo4j(
+      new Neo4jVersion(2025, 1, 0),
+      Neo4jEdition.COMMUNITY,
+      Neo4jDeploymentType.SELF_MANAGED,
+      Collections.emptySet()
+    )
   }
 }

--- a/src/test/scala/org/neo4j/spark/service/SchemaServiceWithApocTSE.scala
+++ b/src/test/scala/org/neo4j/spark/service/SchemaServiceWithApocTSE.scala
@@ -39,6 +39,7 @@ import org.neo4j.spark.util.Neo4jUtil
 import org.neo4j.spark.util.QueryType
 
 import java.util
+import java.util.Collections
 
 class SchemaServiceWithApocTSE extends SparkConnectorScalaBaseWithApocTSE {
 
@@ -249,7 +250,12 @@ class SchemaServiceWithApocTSE extends SparkConnectorScalaBaseWithApocTSE {
     val neo4jOptions: Neo4jOptions = new Neo4jOptions(options)
 
     val driverCache = new DriverCache(neo4jOptions.connection)
-    val neo4j = new Neo4j(new Neo4jVersion(5, 0, 0), Neo4jEdition.ENTERPRISE, Neo4jDeploymentType.SELF_MANAGED)
+    val neo4j = new Neo4j(
+      new Neo4jVersion(5, 0, 0),
+      Neo4jEdition.ENTERPRISE,
+      Neo4jDeploymentType.SELF_MANAGED,
+      Collections.emptySet()
+    )
     val schemaService: SchemaService = new SchemaService(neo4j, neo4jOptions, driverCache)
 
     val schema: StructType = schemaService.struct()


### PR DESCRIPTION
introduce a new way to specify what `CYPHER <version>` will be prefixed
to queries. before we simply picked version `5` if the target neo4j
instance supported the syntax.

new behaviour is to read option `cypher.version`, validate the option
via caniuse. If set, it, will override old behaviour and prefix
queries with `CYPHER 5` or `CYPHER 25` respectively.

updates `CypherRenderer` to also respect the override when
picking dialect.

retains old behaviour if value is unset or empty. lastly, will throw
if the caniuse validation is not successful (bad input from user).