### PR TITLE
fix: constraints inner escaping of names

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -34,3 +34,4 @@ doc/node_modules
 doc/package-lock.json
 scripts/python/local
 node_modules
+.junie

--- a/common/src/main/scala/org/neo4j/spark/service/Neo4jQueryService.scala
+++ b/common/src/main/scala/org/neo4j/spark/service/Neo4jQueryService.scala
@@ -107,7 +107,7 @@ class Neo4jQueryWriteStrategy(private val neo4j: Neo4j, private val saveMode: Sa
     val relKeys = if (options.relationshipMetadata.relationshipKeys.nonEmpty) {
       options.relationshipMetadata.relationshipKeys
         .map(t =>
-          s"${t._2}: ${Neo4jQueryStrategy.VARIABLE_EVENT}.${Neo4jUtil.RELATIONSHIP_ALIAS}.${Neo4jWriteMappingStrategy.KEYS}.${t._1}"
+          s"${t._2.quote()}: ${Neo4jQueryStrategy.VARIABLE_EVENT}.${Neo4jUtil.RELATIONSHIP_ALIAS}.${Neo4jWriteMappingStrategy.KEYS}.${t._1.quote()}"
         )
         .mkString("{", ", ", "}")
     } else {

--- a/common/src/main/scala/org/neo4j/spark/service/SchemaService.scala
+++ b/common/src/main/scala/org/neo4j/spark/service/SchemaService.scala
@@ -766,20 +766,21 @@ class SchemaService(
             (t._2, sparkToCypherTypeConverter.convert(field.dataType), field.nullable)
           })
           .foreach(t => {
-            val prop = t._1.quote()
+            val prop = t._1
+            val propQuoted = prop.quote()
             val cypherType = t._2
             val isNullable = t._3
             if (constraints.contains(SchemaConstraintsOptimizationType.TYPE)) {
               val typeConstraintName = s"spark_$entityType-TYPE-CONSTRAINT-$entityIdentifier-$prop".quote()
               tx.run(
-                s"CREATE CONSTRAINT $typeConstraintName IF NOT EXISTS FOR $asciiRepresentation REQUIRE e.$prop IS :: $cypherType"
+                s"CREATE CONSTRAINT $typeConstraintName IF NOT EXISTS FOR $asciiRepresentation REQUIRE e.$propQuoted IS :: $cypherType"
               ).consume()
             }
             if (constraints.contains(SchemaConstraintsOptimizationType.EXISTS)) {
               if (!isNullable) {
                 val notNullConstraintName = s"spark_$entityType-NOT_NULL-CONSTRAINT-$entityIdentifier-$prop".quote()
                 tx.run(
-                  s"CREATE CONSTRAINT $notNullConstraintName IF NOT EXISTS FOR $asciiRepresentation REQUIRE e.$prop IS NOT NULL"
+                  s"CREATE CONSTRAINT $notNullConstraintName IF NOT EXISTS FOR $asciiRepresentation REQUIRE e.$propQuoted IS NOT NULL"
                 ).consume()
               }
             }

--- a/common/src/test/scala/org/neo4j/spark/service/Neo4jQueryServiceTest.scala
+++ b/common/src/test/scala/org/neo4j/spark/service/Neo4jQueryServiceTest.scala
@@ -655,6 +655,39 @@ class Neo4jQueryServiceTest {
 
   @Test
   @Parameters(method = "versions_and_prefixes")
+  def testRelationshipWithKeySaveStrategy(neo4j: Neo4j, prefix: String): Unit = {
+    val options: java.util.Map[String, String] = new java.util.HashMap[String, String]()
+    options.put(Neo4jOptions.URL, "bolt://localhost")
+    options.put("relationship", "DID BUY")
+    options.put("relationship.save.strategy", "keys")
+    options.put("relationship.source.labels", "Person")
+    options.put("relationship.source.save.mode", "Overwrite")
+    options.put("relationship.source.node.keys", "first name,last name")
+    options.put("relationship.target.labels", "Product")
+    options.put("relationship.target.save.mode", "Match")
+    options.put("relationship.target.node.keys", "article number")
+    options.put("relationship.properties", "number of items")
+    options.put("relationship.keys", "transactionId:transaction identifier")
+
+    val neo4jOptions: Neo4jOptions = new Neo4jOptions(options)
+
+    val query: String =
+      new Neo4jQueryService(neo4jOptions, new Neo4jQueryWriteStrategy(neo4j, SaveMode.Overwrite)).createQuery()
+
+    assertEquals(
+      s"""|${prefix}UNWIND $$events AS event
+          |MERGE (source:Person {`first name`: event.source.keys.`first name`, `last name`: event.source.keys.`last name`}) SET source += event.source.properties
+          |WITH source, event
+          |MATCH (target:Product {`article number`: event.target.keys.`article number`})
+          |MERGE (source)-[rel:`DID BUY`{`transaction identifier`: event.rel.keys.transactionId}]->(target)
+          |SET rel += event.rel.properties
+          |""".stripMargin,
+      query
+    )
+  }
+
+  @Test
+  @Parameters(method = "versions_and_prefixes")
   def testShouldDoSumAggregationOnLabels(neo4j: Neo4j, prefix: String): Unit = {
     val options: java.util.Map[String, String] = new java.util.HashMap[String, String]()
     options.put(Neo4jOptions.URL, "bolt://localhost")

--- a/spark-3/src/test/scala/org/neo4j/spark/DataSourceSchemaWriterTSE.scala
+++ b/spark-3/src/test/scala/org/neo4j/spark/DataSourceSchemaWriterTSE.scala
@@ -34,6 +34,7 @@ import org.junit.Test
 import org.neo4j.driver.types.IsoDuration
 import org.neo4j.spark.util.ConstraintsOptimizationType
 import org.neo4j.spark.util.Neo4jOptions
+import org.neo4j.spark.util.RelationshipSaveStrategy
 import org.neo4j.spark.util.SchemaConstraintsOptimizationType
 
 import java.sql.Date
@@ -656,6 +657,79 @@ class DataSourceSchemaWriterTSE extends SparkConnectorScalaBaseTSE {
       .toMap
 
     assertEquals(expectedMap, actualMap)
+  }
+
+  @Test
+  def shouldApplySchemaForRelationshipsAndNodesWhenKeysHaveSpaces(): Unit = {
+    val nodeData = Seq("first id", "second id").toDF("identification property")
+    val nodeDf = ss.createDataFrame(nodeData.rdd, nodeData.schema)
+
+    val relData = Seq(
+      ("first id", "second id", "a rel key", "this is an example property with spaces")
+    ).toDF(
+      "relationship id source",
+      "relationship id target",
+      "relationship key property",
+      "relationship random information property"
+    )
+    val relDf = ss.createDataFrame(relData.rdd, relData.schema)
+
+    try {
+      nodeDf
+        .write
+        .mode(SaveMode.Overwrite)
+        .format(classOf[DataSource].getName)
+        .option("url", SparkConnectorScalaSuiteIT.server.getBoltUrl)
+        .option("labels", ":Node With Spaces")
+        .option(Neo4jOptions.SCHEMA_OPTIMIZATION, schemaOptimization)
+        .option(Neo4jOptions.SCHEMA_OPTIMIZATION_NODE_KEY, ConstraintsOptimizationType.KEY.toString)
+        .option(Neo4jOptions.NODE_KEYS, "identification property")
+        .save()
+    } catch {
+      case e: Exception =>
+        fail("Creating node schema with spaces in identifiers should be fine, but threw:\n" + e)
+    }
+
+    try {
+      relDf
+        .write
+        .mode(SaveMode.Overwrite)
+        .format(classOf[DataSource].getName)
+        .option("url", SparkConnectorScalaSuiteIT.server.getBoltUrl)
+        .option("relationship", "RELATIONSHIP WITH SPACES")
+        .option(Neo4jOptions.SCHEMA_OPTIMIZATION, schemaOptimization)
+        .option(Neo4jOptions.SCHEMA_OPTIMIZATION_RELATIONSHIP_KEY, ConstraintsOptimizationType.KEY.toString)
+        .option(Neo4jOptions.RELATIONSHIP_SAVE_STRATEGY, RelationshipSaveStrategy.KEYS.toString.toLowerCase)
+        .option(Neo4jOptions.RELATIONSHIP_SOURCE_LABELS, ":Node With Spaces")
+        .option(Neo4jOptions.RELATIONSHIP_SOURCE_SAVE_MODE, SaveMode.Overwrite.toString)
+        .option(Neo4jOptions.RELATIONSHIP_SOURCE_NODE_KEYS, "relationship id source:identification property")
+        .option(Neo4jOptions.RELATIONSHIP_TARGET_LABELS, ":Node With Spaces")
+        .option(Neo4jOptions.RELATIONSHIP_TARGET_SAVE_MODE, SaveMode.Overwrite.toString)
+        .option(Neo4jOptions.RELATIONSHIP_TARGET_NODE_KEYS, "relationship id target:identification property")
+        .option(Neo4jOptions.RELATIONSHIP_PROPERTIES, "relationship random information property")
+        .option(Neo4jOptions.RELATIONSHIP_KEYS, "relationship key property")
+        .save()
+    } catch {
+      case e: Exception =>
+        fail("Creating relationship schema with spaces in identifiers should be fine, but threw:\n" + e)
+    }
+
+    val createdConstraints = SparkConnectorScalaSuiteIT.session()
+      .run("SHOW CONSTRAINTS YIELD name ORDER BY name ASC")
+      .list()
+      .asScala
+      .map(_.get("name").asString())
+      .toSeq
+
+    val wantConstraints = Seq(
+      "spark_NODE-TYPE-CONSTRAINT-Node With Spaces-identification property",
+      "spark_NODE_KEY-CONSTRAINT_Node With Spaces_identification property",
+      "spark_RELATIONSHIP-TYPE-CONSTRAINT-RELATIONSHIP WITH SPACES-relationship key property",
+      "spark_RELATIONSHIP-TYPE-CONSTRAINT-RELATIONSHIP WITH SPACES-relationship random information property",
+      "spark_RELATIONSHIP_KEY-CONSTRAINT_RELATIONSHIP WITH SPACES_relationship key property"
+    )
+
+    assertEquals(wantConstraints, createdConstraints)
   }
 
   @Test


### PR DESCRIPTION
If the user created constraints covering a property via the connector
and if that property has a space in its name, we accidentally double
escaped the name. Causing invalid cypher queries.

In order to fix the above, another bug was also fixed:

When writing using save strategy keys the actual keys were not escaped
properly causing invalid queries.

fixes CONN-966