### PR TITLE
fix: return `null` when no last offset is available

### DIFF
--- a/src/main/scala/org/neo4j/spark/service/SchemaService.scala
+++ b/src/main/scala/org/neo4j/spark/service/SchemaService.scala
@@ -37,6 +37,7 @@ import org.neo4j.spark.cypher.CypherPreamble.fullPreamble
 import org.neo4j.spark.service.SchemaService.normalizedClassName
 import org.neo4j.spark.service.SchemaService.normalizedClassNameFromGraphEntity
 import org.neo4j.spark.util.Neo4jImplicits.CypherImplicits
+import org.neo4j.spark.util.Neo4jImplicits.ValueImplicits
 import org.neo4j.spark.util._
 
 import java.util
@@ -879,7 +880,13 @@ class SchemaService(
     }
   }
 
-  private def lastOffsetForNode(): Long = {
+  def lastOffset(): Option[Long] = options.query.queryType match {
+    case QueryType.LABELS       => lastOffsetForNode()
+    case QueryType.RELATIONSHIP => lastOffsetForRelationship()
+    case QueryType.QUERY        => lastOffsetForQuery()
+  }
+
+  private def lastOffsetForNode(): Option[Long] = {
     val label = options.nodeMetadata.labels.head
     session.executeRead(
       tx =>
@@ -890,10 +897,10 @@ class SchemaService(
       sessionTransactionConfig
     )
       .get(options.streamingOptions.propertyName)
-      .asLong(-1)
+      .asOptionalLong()
   }
 
-  private def lastOffsetForRelationship(): Long = {
+  private def lastOffsetForRelationship(): Option[Long] = {
     val sourceLabel = options.relationshipMetadata.source.labels.head.quote()
     val targetLabel = options.relationshipMetadata.target.labels.head.quote()
     val relType = options.relationshipMetadata.relationshipType.quote()
@@ -907,18 +914,13 @@ class SchemaService(
       sessionTransactionConfig
     )
       .get(options.streamingOptions.propertyName)
-      .asLong(-1)
+      .asOptionalLong()
   }
 
-  private def lastOffsetForQuery(): Long =
+  private def lastOffsetForQuery(): Option[Long] = {
     session.executeRead(tx => tx.run(options.streamingOptions.queryOffset).single(), sessionTransactionConfig)
       .get(0)
-      .asLong(-1)
-
-  def lastOffset(): Long = options.query.queryType match {
-    case QueryType.LABELS       => lastOffsetForNode()
-    case QueryType.RELATIONSHIP => lastOffsetForRelationship()
-    case QueryType.QUERY        => lastOffsetForQuery()
+      .asOptionalLong()
   }
 
   private def logResolutionChange(message: String, e: ClientException): Unit = {

--- a/src/main/scala/org/neo4j/spark/streaming/Neo4jMicroBatchReader.scala
+++ b/src/main/scala/org/neo4j/spark/streaming/Neo4jMicroBatchReader.scala
@@ -83,7 +83,7 @@ class Neo4jMicroBatchReader(
   }
 
   override def latestOffset(): Offset = {
-    val offset = Neo4jOffset(Neo4jUtil.callSchemaService[Long](
+    val offsetValue = Neo4jUtil.callSchemaService[Option[Long]](
       neo4j,
       neo4jOptions,
       jobId,
@@ -93,12 +93,11 @@ class Neo4jMicroBatchReader(
           try {
             schemaService.lastOffset()
           } catch {
-            case _: Throwable => -1L
+            case _: Throwable => null
           }
       }
-    ))
-
-    offset
+    )
+    offsetValue.map(value => Neo4jOffset(value)).orNull
   }
 
   override def initialOffset(): Offset = Neo4jOffset(neo4jOptions.streamingOptions.from.value())

--- a/src/main/scala/org/neo4j/spark/util/Neo4jImplicits.scala
+++ b/src/main/scala/org/neo4j/spark/util/Neo4jImplicits.scala
@@ -371,4 +371,14 @@ object Neo4jImplicits {
     def toNestedJavaMap: java.util.Map[String, Any] = nestingMap(map)
   }
 
+  implicit class ValueImplicits(value: Value) {
+
+    def asOptionalLong(): Option[Long] = {
+      if (value.isNull) {
+        Option.empty
+      } else {
+        Option(value.asLong())
+      }
+    }
+  }
 }

--- a/src/test/scala/org/neo4j/spark/DataSourceStreamingReaderTSE.scala
+++ b/src/test/scala/org/neo4j/spark/DataSourceStreamingReaderTSE.scala
@@ -27,6 +27,7 @@ import org.neo4j.spark.testsupport.Assert
 import org.neo4j.spark.testsupport.Closeables.use
 import org.neo4j.spark.testsupport.SparkConnectorScalaBaseTSE
 import org.neo4j.spark.testsupport.SparkConnectorScalaSuiteIT
+import org.neo4j.spark.testsupport.SparkConnectorScalaSuiteIT.session
 
 import java.nio.file.Files
 import java.nio.file.Path
@@ -575,20 +576,66 @@ class DataSourceStreamingReaderTSE extends SparkConnectorScalaBaseTSE {
     )
   }
 
-  private def createPersonNodes(from: Int, count: Int, delayMs: Int = 0, intervalMs: Int = 0): Unit = {
-    use(SparkConnectorScalaSuiteIT.session()) { session =>
+  @Test
+  def testStreamDoesNotReadAnyDataIfStreamingQueryReturnsNothing(): Unit = {
+    createPersonNodes(0, 50)
+    use(session()) { session =>
+      session.run("MATCH (p:Person) SET p:Human").consume()
+    }
+    val stream = ss.readStream.format(classOf[DataSource].getName)
+      .option("url", SparkConnectorScalaSuiteIT.server.getBoltUrl)
+      .option("streaming.property.name", "timestamp")
+      .option("streaming.from", "ALL")
+      .option(
+        "query",
+        """
+          |MATCH (p:Person)
+          |WHERE p.timestamp > $stream.from AND p.timestamp <= $stream.to
+          |RETURN p.age AS age, p.timestamp AS timestamp
+          |""".stripMargin
+      )
+      .option("streaming.query.offset", "MATCH (p:Human) RETURN max(p.timestamp)")
+      .load()
+
+    val checkpoint = Files.createTempDirectory(folder, "checkpoint")
+    // 1st trigger: every node was processed
+    var streamTable = stream.writeStream
+      .trigger(Trigger.AvailableNow())
+      .option("checkpointLocation", checkpoint.toAbsolutePath.toString)
+      .toTable("testStreamDoesNotReadAnyDataIfStreamingQueryReturnsNothing")
+    streamTable.awaitTermination()
+    val firstSource = streamTable.lastProgress.sources.head
+    assertEquals(50, firstSource.numInputRows)
+    val endOffset1 = firstSource.endOffset
+    use(session()) { session =>
+      session.run("MATCH (p:Human) REMOVE p:Human").consume()
+    }
+    // 2nd trigger: previous offset is kept intact
+    streamTable = stream.writeStream
+      .trigger(Trigger.AvailableNow())
+      .option("checkpointLocation", checkpoint.toAbsolutePath.toString)
+      .toTable("testStreamDoesNotReadAnyDataIfStreamingQueryReturnsNothing")
+    streamTable.awaitTermination()
+    val source = streamTable.lastProgress.sources.head
+    assertEquals(endOffset1, source.startOffset)
+    assertEquals(endOffset1, source.endOffset)
+    assertEquals(0L, source.numInputRows)
+  }
+
+  private def createPersonNodes(minAge: Int, maxAge: Int, delayMs: Int = 0, intervalMs: Int = 0): Unit = {
+    use(session()) { session =>
       Thread.sleep(delayMs)
-      (from until from + count).foreach(index => {
+      (minAge until minAge + maxAge).foreach(age => {
         Thread.sleep(intervalMs)
         session.run(
-          s"CREATE (p:Person {age: '$index', timestamp: timestamp()})"
+          s"CREATE (p:Person {age: '$age', timestamp: timestamp()})"
         ).consume()
       })
     }
   }
 
   private def createMovieNodes(from: Int, count: Int, delayMs: Int = 0, intervalMs: Int = 0): Unit = {
-    use(SparkConnectorScalaSuiteIT.session()) { session =>
+    use(session()) { session =>
       Thread.sleep(delayMs)
       (from until from + count).foreach(index => {
         Thread.sleep(intervalMs)
@@ -600,7 +647,7 @@ class DataSourceStreamingReaderTSE extends SparkConnectorScalaBaseTSE {
   }
 
   private def createLikesRelationships(from: Int, count: Int, delayMs: Int = 0, intervalMs: Int = 0): Unit = {
-    use(SparkConnectorScalaSuiteIT.session()) { session =>
+    use(session()) { session =>
       Thread.sleep(delayMs)
       (from until from + count).foreach(index => {
         Thread.sleep(intervalMs)


### PR DESCRIPTION
This means user-defined stream offset queries that return no results
will keep the previous offset instead of overwriting with -1.

In some edge scenarios where the user-defined query is ill-defined,
this could lead to the whole data being reprocessed again.

Cherry picked from pull request (#824)