### PR TITLE
fix: constraints inner escaping of names

### DIFF
--- a/src/main/scala/org/neo4j/spark/service/Neo4jQueryService.scala
+++ b/src/main/scala/org/neo4j/spark/service/Neo4jQueryService.scala
@@ -114,7 +114,7 @@ class Neo4jQueryWriteStrategy(
     val relKeys = if (options.relationshipMetadata.relationshipKeys.nonEmpty) {
       options.relationshipMetadata.relationshipKeys
         .map(t =>
-          s"${t._2}: ${Neo4jQueryStrategy.VARIABLE_EVENT}.${Neo4jUtil.RELATIONSHIP_ALIAS}.${Neo4jWriteMappingStrategy.KEYS}.${t._1}"
+          s"${t._2.quote()}: ${Neo4jQueryStrategy.VARIABLE_EVENT}.${Neo4jUtil.RELATIONSHIP_ALIAS}.${Neo4jWriteMappingStrategy.KEYS}.${t._1.quote()}"
         )
         .mkString("{", ", ", "}")
     } else {

--- a/src/main/scala/org/neo4j/spark/service/SchemaService.scala
+++ b/src/main/scala/org/neo4j/spark/service/SchemaService.scala
@@ -710,20 +710,21 @@ class SchemaService(
             (t._2, sparkToCypherTypeConverter.convert(field.dataType), field.nullable)
           })
           .foreach(t => {
-            val prop = t._1.quote()
+            val prop = t._1
+            val propQuoted = prop.quote()
             val cypherType = t._2
             val isNullable = t._3
             if (constraints.contains(SchemaConstraintsOptimizationType.TYPE)) {
               val typeConstraintName = s"spark_$entityType-TYPE-CONSTRAINT-$entityIdentifier-$prop".quote()
               tx.run(
-                s"CREATE CONSTRAINT $typeConstraintName IF NOT EXISTS FOR $asciiRepresentation REQUIRE e.$prop IS :: $cypherType"
+                s"CREATE CONSTRAINT $typeConstraintName IF NOT EXISTS FOR $asciiRepresentation REQUIRE e.$propQuoted IS :: $cypherType"
               ).consume()
             }
             if (constraints.contains(SchemaConstraintsOptimizationType.EXISTS)) {
               if (!isNullable) {
                 val notNullConstraintName = s"spark_$entityType-NOT_NULL-CONSTRAINT-$entityIdentifier-$prop".quote()
                 tx.run(
-                  s"CREATE CONSTRAINT $notNullConstraintName IF NOT EXISTS FOR $asciiRepresentation REQUIRE e.$prop IS NOT NULL"
+                  s"CREATE CONSTRAINT $notNullConstraintName IF NOT EXISTS FOR $asciiRepresentation REQUIRE e.$propQuoted IS NOT NULL"
                 ).consume()
               }
             }

--- a/src/test/scala/org/neo4j/spark/service/Neo4jQueryServiceTest.scala
+++ b/src/test/scala/org/neo4j/spark/service/Neo4jQueryServiceTest.scala
@@ -684,6 +684,39 @@ class Neo4jQueryServiceTest {
 
   @ParameterizedTest
   @MethodSource(Array("versions_and_prefixes"))
+  def testRelationshipWithKeySaveStrategy(neo4j: Neo4j, prefix: String): Unit = {
+    val options: java.util.Map[String, String] = new java.util.HashMap[String, String]()
+    options.put(Neo4jOptions.URL, "bolt://localhost")
+    options.put("relationship", "DID BUY")
+    options.put("relationship.save.strategy", "keys")
+    options.put("relationship.source.labels", "Person")
+    options.put("relationship.source.save.mode", "Overwrite")
+    options.put("relationship.source.node.keys", "first name,last name")
+    options.put("relationship.target.labels", "Product")
+    options.put("relationship.target.save.mode", "Match")
+    options.put("relationship.target.node.keys", "article number")
+    options.put("relationship.properties", "number of items")
+    options.put("relationship.keys", "transactionId:transaction identifier")
+
+    val neo4jOptions: Neo4jOptions = new Neo4jOptions(options)
+
+    val query: String =
+      new Neo4jQueryService(neo4jOptions, new Neo4jQueryWriteStrategy(neo4j, SaveMode.Overwrite)).createQuery()
+
+    assertEquals(
+      s"""|${prefix}UNWIND $$events AS event
+          |MERGE (source:Person {`first name`: event.source.keys.`first name`, `last name`: event.source.keys.`last name`}) SET source += event.source.properties
+          |WITH source, event
+          |MATCH (target:Product {`article number`: event.target.keys.`article number`})
+          |MERGE (source)-[rel:`DID BUY`{`transaction identifier`: event.rel.keys.transactionId}]->(target)
+          |SET rel += event.rel.properties
+          |""".stripMargin,
+      query
+    )
+  }
+
+  @ParameterizedTest
+  @MethodSource(Array("versions_and_prefixes"))
   def testShouldDoSumAggregationOnLabels(neo4j: Neo4j, prefix: String): Unit = {
     val options: java.util.Map[String, String] = new java.util.HashMap[String, String]()
     options.put(Neo4jOptions.URL, "bolt://localhost")


### PR DESCRIPTION
If the user created constraints covering a property via the connector
and if that property has a space in its name, we accidentally double
escaped the name. Causing invalid cypher queries.

In order to fix the above, another bug was also fixed:

When writing using save strategy keys the actual keys were not escaped
properly causing invalid queries.

Cherry picked from (#936)