### PR TITLE
feat: introduce byte, short, decimal, timestampNTZ types

### DIFF
--- a/scripts/python/test_spark.py
+++ b/scripts/python/test_spark.py
@@ -1,16 +1,19 @@
-from pyspark.sql import SparkSession
-import datetime
-from testcontainers.neo4j import Neo4jContainer
-from tzlocal import get_localzone
+#!/usr/bin/env python3
 
 import unittest
 import sys
+import datetime
+
+from tzlocal import get_localzone
+from testcontainers.neo4j import Neo4jContainer
+from pyspark.sql import SparkSession
+from neo4j import Driver
 
 
 class SparkTest(unittest.TestCase):
-    neo4j_driver = None
-    neo4j_container = None
-    spark = None
+    neo4j_driver: Driver = None
+    neo4j_container: Neo4jContainer = None
+    spark: SparkSession = None
 
     def tearDown(self):
         with self.neo4j_driver.session(database="system") as session:
@@ -20,32 +23,31 @@ class SparkTest(unittest.TestCase):
         with self.neo4j_driver.session() as session:
             session.run(query, parameters).consume()
 
-        return self.spark.read.format("org.neo4j.spark.DataSource") \
-            .option("url", self.neo4j_container.get_connection_url()) \
-            .option("authentication.type", "basic") \
-            .option("authentication.basic.username", "neo4j") \
-            .option("authentication.basic.password", "password") \
-            .option("labels", "Person") \
+        return (
+            self.spark.read.format("org.neo4j.spark.DataSource")
+            .option("url", self.neo4j_container.get_connection_url())
+            .option("authentication.type", "basic")
+            .option("authentication.basic.username", "neo4j")
+            .option("authentication.basic.password", "password")
+            .option("labels", "Person")
             .load()
+        )
 
     def test_string(self):
         name = "Foobar"
-        df = self.init_test(
-            "CREATE (p:Person {name: '" + name + "'})")
+        df = self.init_test("CREATE (p:Person {name: '" + name + "'})")
 
         assert name == df.select("name").collect()[0].name
 
     def test_int(self):
         age = 32
-        df = self.init_test(
-            "CREATE (p:Person {age: " + str(age) + "})")
+        df = self.init_test("CREATE (p:Person {age: " + str(age) + "})")
 
         assert age == df.select("age").collect()[0].age
 
     def test_double(self):
         score = 32.3
-        df = self.init_test(
-            "CREATE (p:Person {score: " + str(score) + "})")
+        df = self.init_test("CREATE (p:Person {score: " + str(score) + "})")
 
         assert score == df.select("score").collect()[0].score
 
@@ -64,13 +66,13 @@ class SparkTest(unittest.TestCase):
 
         assert "offset-time" == timeResult.type
         # .replace used in case of UTC timezone because of https://stackoverflow.com/a/42777551/1409772
-        assert str(time).replace("+00:00", "Z") \
-               == timeResult.value.split("+")[0]
+        assert str(time).replace("+00:00", "Z") == timeResult.value.split("+")[0]
 
     def test_datetime(self):
         dtString = "2015-06-24T12:50:35"
         df = self.init_test(
-            "CREATE (p:Person {datetime: datetime('" + dtString + "')})")
+            "CREATE (p:Person {datetime: datetime('" + dtString + "')})"
+        )
 
         dt = datetime.datetime(2015, 6, 24, 12, 50, 35, 0)
         dtResult = df.select("datetime").collect()[0].datetime
@@ -78,8 +80,7 @@ class SparkTest(unittest.TestCase):
         assert dt == dtResult
 
     def test_date(self):
-        df = self.init_test(
-            "CREATE (p:Person {born: date('2009-10-10')})")
+        df = self.init_test("CREATE (p:Person {born: date('2009-10-10')})")
 
         dt = datetime.date(2009, 10, 10)
         dtResult = df.select("born").collect()[0].born
@@ -87,9 +88,7 @@ class SparkTest(unittest.TestCase):
         assert dt == dtResult
 
     def test_point(self):
-        df = self.init_test(
-            "CREATE (p:Person {location: point({x: 12.12, y: 13.13})})"
-        )
+        df = self.init_test("CREATE (p:Person {location: point({x: 12.12, y: 13.13})})")
 
         pointResult = df.select("location").collect()[0].location
         assert "point-2d" == pointResult[0]
@@ -132,9 +131,14 @@ class SparkTest(unittest.TestCase):
         assert 58320 == durationResult[3]
         assert 0 == durationResult[4]
 
+    def test_binary(self):
+        byte_array = b"binaries are byte arrays"
+        df = self.init_test("CREATE (p:Person {bin: $bytes})", {"bytes": byte_array})
+
+        assert byte_array == df.select("bin").collect()[0].bin
+
     def test_string_array(self):
-        df = self.init_test(
-            "CREATE (p:Person {names: ['John', 'Doe']})")
+        df = self.init_test("CREATE (p:Person {names: ['John', 'Doe']})")
 
         result = df.select("names").collect()[0].names
         assert "John" == result[0]
@@ -148,16 +152,14 @@ class SparkTest(unittest.TestCase):
         assert 56 == result[1]
 
     def test_double_array(self):
-        df = self.init_test(
-            "CREATE (p:Person {scores: [24.11, 56.11]})")
+        df = self.init_test("CREATE (p:Person {scores: [24.11, 56.11]})")
 
         result = df.select("scores").collect()[0].scores
         assert 24.11 == result[0]
         assert 56.11 == result[1]
 
     def test_boolean_array(self):
-        df = self.init_test(
-            "CREATE (p:Person {field: [true, false]})")
+        df = self.init_test("CREATE (p:Person {field: [true, false]})")
 
         result = df.select("field").collect()[0].field
         assert True == result[0]
@@ -172,23 +174,25 @@ class SparkTest(unittest.TestCase):
 
         # .replace used in case of UTC timezone because of https://stackoverflow.com/a/42777551/1409772
         assert "offset-time" == timeResult[0].type
-        assert str(datetime.time(11, 23, 0, 0, get_localzone())).replace("+00:00", "Z") \
-               == timeResult[0].value.split("+")[0]
+        assert (
+            str(datetime.time(11, 23, 0, 0, get_localzone())).replace("+00:00", "Z")
+            == timeResult[0].value.split("+")[0]
+        )
 
         # .replace used in case of UTC timezone because of https://stackoverflow.com/a/42777551/1409772
         assert "offset-time" == timeResult[1].type
-        assert str(datetime.time(12, 23, 0, 0, get_localzone())).replace("+00:00", "Z") \
-               == timeResult[1].value.split("+")[0]
+        assert (
+            str(datetime.time(12, 23, 0, 0, get_localzone())).replace("+00:00", "Z")
+            == timeResult[1].value.split("+")[0]
+        )
 
     def test_datetime_array(self):
         df = self.init_test(
             "CREATE (p:Person {result: [datetime('2007-12-03T10:15:30'), datetime('2008-12-03T10:15:30')]})"
         )
 
-        dt1 = datetime.datetime(
-            2007, 12, 3, 10, 15, 30, 0)
-        dt2 = datetime.datetime(
-            2008, 12, 3, 10, 15, 30, 0)
+        dt1 = datetime.datetime(2007, 12, 3, 10, 15, 30, 0)
+        dt2 = datetime.datetime(2008, 12, 3, 10, 15, 30, 0)
         dtResult = df.select("result").collect()[0].result
 
         assert dt1 == dtResult[0]
@@ -275,21 +279,24 @@ class SparkTest(unittest.TestCase):
         assert 0 == durationResult[1][4]
 
     def test_unexisting_property(self):
-        self.spark.read.format("org.neo4j.spark.DataSource") \
-            .option("url", self.neo4j_container.get_connection_url()) \
-            .option("authentication.type", "basic") \
-            .option("authentication.basic.username", "neo4j") \
-            .option("authentication.basic.password", "password") \
-            .option("relationship.properties", None) \
-            .option("relationship", "FOO") \
-            .option("relationship.source.labels", ":Foo") \
-            .option("relationship.target.labels", ":Bar") \
+        (
+            self.spark.read.format("org.neo4j.spark.DataSource")
+            .option("url", self.neo4j_container.get_connection_url())
+            .option("authentication.type", "basic")
+            .option("authentication.basic.username", "neo4j")
+            .option("authentication.basic.password", "password")
+            .option("relationship.properties", None)
+            .option("relationship", "FOO")
+            .option("relationship.source.labels", ":Foo")
+            .option("relationship.target.labels", ":Bar")
             .load()
+        )
         # In this case we just test that the job has been executed without any exception
 
     def test_gds(self):
         with self.neo4j_driver.session() as session:
-            session.run("""
+            session.run(
+                """
                 CREATE
                   (home:Page {name:'Home'}),
                   (about:Page {name:'About'}),
@@ -314,30 +321,35 @@ class SparkTest(unittest.TestCase):
                   (links)-[:LINKS {weight: 0.05}]->(b),
                   (links)-[:LINKS {weight: 0.05}]->(c),
                   (links)-[:LINKS {weight: 0.05}]->(d);
-            """)
+            """
+            )
 
-        self.spark.read.format("org.neo4j.spark.DataSource") \
-            .option("url", self.neo4j_container.get_connection_url()) \
-            .option("authentication.type", "basic") \
-            .option("authentication.basic.username", "neo4j") \
-            .option("authentication.basic.password", "password") \
-            .option("gds", "gds.graph.project") \
-            .option("gds.graphName", "myGraph") \
-            .option("gds.nodeProjection", "Page") \
-            .option("gds.relationshipProjection", "LINKS") \
-            .option("gds.configuration.relationshipProperties", "weight") \
-            .load() \
-            .show(truncate=False)
-
-        df = self.spark.read.format("org.neo4j.spark.DataSource") \
-            .option("url", self.neo4j_container.get_connection_url()) \
-            .option("authentication.type", "basic") \
-            .option("authentication.basic.username", "neo4j") \
-            .option("authentication.basic.password", "password") \
-            .option("gds", "gds.pageRank.stream") \
-            .option("gds.graphName", "myGraph") \
-            .option("gds.configuration.concurrency", "2") \
+        (
+            self.spark.read.format("org.neo4j.spark.DataSource")
+            .option("url", self.neo4j_container.get_connection_url())
+            .option("authentication.type", "basic")
+            .option("authentication.basic.username", "neo4j")
+            .option("authentication.basic.password", "password")
+            .option("gds", "gds.graph.project")
+            .option("gds.graphName", "myGraph")
+            .option("gds.nodeProjection", "Page")
+            .option("gds.relationshipProjection", "LINKS")
+            .option("gds.configuration.relationshipProperties", "weight")
             .load()
+            .show(truncate=False)
+        )
+
+        df = (
+            self.spark.read.format("org.neo4j.spark.DataSource")
+            .option("url", self.neo4j_container.get_connection_url())
+            .option("authentication.type", "basic")
+            .option("authentication.basic.username", "neo4j")
+            .option("authentication.basic.password", "password")
+            .option("gds", "gds.pageRank.stream")
+            .option("gds.graphName", "myGraph")
+            .option("gds.configuration.concurrency", "2")
+            .load()
+        )
 
         assert 8 == df.count()
 
@@ -352,20 +364,20 @@ connector_jar = str(sys.argv.pop())
 current_time_zone = get_localzone().zone
 
 if __name__ == "__main__":
-    with (Neo4jContainer(neo4j_image)
-            .with_env("NEO4J_ACCEPT_LICENSE_AGREEMENT", "yes")
-            .with_env("NEO4J_db_temporal_timezone", current_time_zone)
-            .with_env("NEO4JLABS_PLUGINS", "[\"graph-data-science\"]")) as neo4j_container:
+    with (
+        Neo4jContainer(neo4j_image)
+        .with_env("NEO4J_ACCEPT_LICENSE_AGREEMENT", "yes")
+        .with_env("NEO4J_db_temporal_timezone", current_time_zone)
+        .with_env("NEO4JLABS_PLUGINS", '["graph-data-science"]')
+    ) as neo4j_container:
         with neo4j_container.get_driver() as neo4j_driver:
-            SparkTest.spark = SparkSession.builder \
-                .appName("Neo4jConnectorTests") \
-                .master('local[*]') \
-                .config(
-                "spark.jars",
-                connector_jar
-            ) \
-                .config("spark.driver.host", "127.0.0.1") \
+            SparkTest.spark = (
+                SparkSession.builder.appName("Neo4jConnectorTests")
+                .master("local[*]")
+                .config("spark.jars", connector_jar)
+                .config("spark.driver.host", "127.0.0.1")
                 .getOrCreate()
+            )
             SparkTest.neo4j_driver = neo4j_driver
             SparkTest.neo4j_container = neo4j_container
             unittest.main()

--- a/src/main/scala/org/neo4j/spark/converter/DataConverter.scala
+++ b/src/main/scala/org/neo4j/spark/converter/DataConverter.scala
@@ -56,20 +56,18 @@ trait DataConverter[T] {
 object SparkToNeo4jDataConverter {
   def apply(): SparkToNeo4jDataConverter = new SparkToNeo4jDataConverter()
 
-  def dayTimeIntervalToNeo4j(micros: Long): Value = {
+  def dayTimeMicrosToNeo4jDuration(micros: Long): Value = {
     val oneSecondInMicros = 1000000L
     val oneDayInMicros = 24 * 3600 * oneSecondInMicros
-
     val numberDays = Math.floorDiv(micros, oneDayInMicros)
     val remainderMicros = Math.floorMod(micros, oneDayInMicros)
     val numberSeconds = Math.floorDiv(remainderMicros, oneSecondInMicros)
     val numberNanos = Math.floorMod(remainderMicros, oneSecondInMicros) * 1000
-
     Values.isoDuration(0L, numberDays, numberSeconds, numberNanos.toInt)
   }
 
   // while Neo4j supports years, this driver version's API does not expose it.
-  def yearMonthIntervalToNeo4j(months: Int): Value = {
+  def yearMonthIntervalToNeo4jDuration(months: Int): Value = {
     Values.isoDuration(months.toLong, 0L, 0L, 0)
   }
 }
@@ -77,29 +75,23 @@ object SparkToNeo4jDataConverter {
 class SparkToNeo4jDataConverter extends DataConverter[Value] {
 
   override def convert(value: Any, dataType: DataType): Value = {
-    dataType match {
-      case _: DayTimeIntervalType if value != null =>
-        return SparkToNeo4jDataConverter.dayTimeIntervalToNeo4j(value.asInstanceOf[Long])
-      case _: YearMonthIntervalType if value != null =>
-        return SparkToNeo4jDataConverter.yearMonthIntervalToNeo4j(value.asInstanceOf[Int])
-      case _ => // do nothing
-    }
-
     value match {
       case date: java.sql.Date           => convert(date.toLocalDate, dataType)
-      case timestamp: java.sql.Timestamp => convert(timestamp.toLocalDateTime, dataType)
+      case timestamp: java.sql.Timestamp => convert(timestamp.toInstant.atZone(ZoneOffset.UTC), dataType)
       case intValue: Int if dataType == DataTypes.DateType =>
         convert(
           DateTimeUtils
             .toJavaDate(intValue),
           dataType
         )
+      case intValue: Int if dataType.isInstanceOf[YearMonthIntervalType] =>
+        SparkToNeo4jDataConverter.yearMonthIntervalToNeo4jDuration(intValue)
       case longValue: Long if dataType == DataTypes.TimestampType =>
-        convert(
-          DateTimeUtils
-            .toJavaTimestamp(longValue),
-          dataType
-        )
+        convert(DateTimeUtils.toJavaTimestamp(longValue), dataType)
+      case longValue: Long if dataType == DataTypes.TimestampNTZType =>
+        convert(DateTimeUtils.microsToLocalDateTime(longValue), dataType)
+      case longValue: Long if dataType.isInstanceOf[DayTimeIntervalType] =>
+        SparkToNeo4jDataConverter.dayTimeMicrosToNeo4jDuration(longValue)
       case unsafeRow: UnsafeRow =>
         val structType = extractStructType(dataType)
         val row = new GenericRowWithSchema(unsafeRow.toSeq(structType).toArray, structType)
@@ -144,10 +136,14 @@ class SparkToNeo4jDataConverter extends DataConverter[Value] {
           case arrayType: ArrayType => arrayType.elementType
           case _                    => dataType
         }
-        val javaList = unsafeArray.toSeq[AnyRef](sparkType)
-          .map(elem => convert(elem, sparkType))
-          .asJava
-        Values.value(javaList)
+        if (sparkType == DataTypes.ByteType) {
+          Values.value(unsafeArray.toByteArray)
+        } else {
+          val javaList = unsafeArray.toSeq[AnyRef](sparkType)
+            .map(elem => convert(elem, sparkType))
+            .asJava
+          Values.value(javaList)
+        }
       case unsafeMapData: MapData => // Neo4j only supports Map[String, AnyRef]
         val mapType = dataType.asInstanceOf[MapType]
         val map: Map[String, AnyRef] = (0 until unsafeMapData.numElements())
@@ -158,8 +154,9 @@ class SparkToNeo4jDataConverter extends DataConverter[Value] {
           .mapValues(innerValue => convert(innerValue, mapType.valueType))
           .toMap[String, AnyRef]
         Values.value(map.asJava)
-      case string: UTF8String => convert(string.toString)
-      case _                  => Values.value(value)
+      case string: UTF8String                                     => convert(string.toString)
+      case decimal: Decimal if dataType.isInstanceOf[DecimalType] => Values.value(decimal.toString)
+      case _                                                      => Values.value(value)
     }
   }
 }
@@ -213,7 +210,7 @@ class Neo4jToSparkDataConverter extends DataConverter[Any] {
             UTF8String.fromString(d.toString)
           ))
         case zt: ZonedDateTime => DateTimeUtils.instantToMicros(zt.toInstant)
-        case dt: LocalDateTime => DateTimeUtils.instantToMicros(dt.toInstant(ZoneOffset.UTC))
+        case dt: LocalDateTime => DateTimeUtils.localDateTimeToMicros(dt)
         case d: LocalDate      => d.toEpochDay.toInt
         case lt: LocalTime =>
           InternalRow.fromSeq(Seq(

--- a/src/main/scala/org/neo4j/spark/converter/TypeConverter.scala
+++ b/src/main/scala/org/neo4j/spark/converter/TypeConverter.scala
@@ -19,6 +19,7 @@ package org.neo4j.spark.converter
 import org.apache.spark.sql.types.DataType
 import org.apache.spark.sql.types.DataTypes
 import org.apache.spark.sql.types.DayTimeIntervalType
+import org.apache.spark.sql.types.DecimalType
 import org.apache.spark.sql.types.YearMonthIntervalType
 import org.neo4j.driver.types.Entity
 import org.neo4j.spark.converter.CypherToSparkTypeConverter.cleanTerms
@@ -40,7 +41,7 @@ trait TypeConverter[SOURCE_TYPE, DESTINATION_TYPE] {
 object CypherToSparkTypeConverter {
   def apply(): CypherToSparkTypeConverter = new CypherToSparkTypeConverter()
 
-  private val cleanTerms: String = "Unmodifiable|Internal|Iso|2D|3D|Offset|Local|Zoned"
+  private val cleanTerms: String = "Unmodifiable|Internal|Iso|2D|3D|Offset"
 
   val durationType: DataType = DataTypes.createStructType(Array(
     DataTypes.createStructField("type", DataTypes.StringType, false),
@@ -72,14 +73,16 @@ class CypherToSparkTypeConverter extends TypeConverter[String, DataType] {
     case "Node" | "Relationship" => if (value != null) value.asInstanceOf[Entity].toStruct else DataTypes.NullType
     case "NodeArray" | "RelationshipArray" =>
       if (value != null) DataTypes.createArrayType(value.asInstanceOf[Entity].toStruct) else DataTypes.NullType
-    case "Boolean"                                      => DataTypes.BooleanType
-    case "Long"                                         => DataTypes.LongType
-    case "Double"                                       => DataTypes.DoubleType
-    case "Point"                                        => pointType
-    case "DateTime" | "ZonedDateTime" | "LocalDateTime" => DataTypes.TimestampType
-    case "Time"                                         => timeType
-    case "Date"                                         => DataTypes.DateType
-    case "Duration"                                     => durationType
+    case "Boolean"                    => DataTypes.BooleanType
+    case "Long"                       => DataTypes.LongType
+    case "Double"                     => DataTypes.DoubleType
+    case "Point"                      => pointType
+    case "DateTime" | "ZonedDateTime" => DataTypes.TimestampType
+    case "LocalDateTime"              => DataTypes.TimestampNTZType
+    case "Time" | "LocalTime"         => timeType
+    case "Date" | "LocalDate"         => DataTypes.DateType
+    case "Duration"                   => durationType
+    case "ByteArray"                  => DataTypes.BinaryType
     case "Map" => {
       val valueType = if (value == null) {
         DataTypes.NullType
@@ -105,15 +108,15 @@ class CypherToSparkTypeConverter extends TypeConverter[String, DataType] {
       DataTypes.createArrayType(valueType)
     }
     // These are from APOC
-    case "StringArray"   => DataTypes.createArrayType(DataTypes.StringType)
-    case "LongArray"     => DataTypes.createArrayType(DataTypes.LongType)
-    case "DoubleArray"   => DataTypes.createArrayType(DataTypes.DoubleType)
-    case "BooleanArray"  => DataTypes.createArrayType(DataTypes.BooleanType)
-    case "PointArray"    => DataTypes.createArrayType(pointType)
-    case "DateTimeArray" => DataTypes.createArrayType(DataTypes.TimestampType)
-    case "TimeArray"     => DataTypes.createArrayType(timeType)
-    case "DateArray"     => DataTypes.createArrayType(DataTypes.DateType)
-    case "DurationArray" => DataTypes.createArrayType(durationType)
+    case "StringArray"                          => DataTypes.createArrayType(DataTypes.StringType)
+    case "LongArray"                            => DataTypes.createArrayType(DataTypes.LongType)
+    case "DoubleArray"                          => DataTypes.createArrayType(DataTypes.DoubleType)
+    case "BooleanArray"                         => DataTypes.createArrayType(DataTypes.BooleanType)
+    case "PointArray"                           => DataTypes.createArrayType(pointType)
+    case "DateTimeArray" | "ZonedDateTimeArray" => DataTypes.createArrayType(DataTypes.TimestampType)
+    case "TimeArray" | "LocalTimeArray"         => DataTypes.createArrayType(timeType)
+    case "DateArray" | "LocalDateArray"         => DataTypes.createArrayType(DataTypes.DateType)
+    case "DurationArray"                        => DataTypes.createArrayType(durationType)
     // Default is String
     case _ => DataTypes.StringType
   }
@@ -125,12 +128,16 @@ object SparkToCypherTypeConverter {
   private val mapping: Map[DataType, String] = Map(
     DataTypes.BooleanType -> "BOOLEAN",
     DataTypes.StringType -> "STRING",
+    DecimalType.SYSTEM_DEFAULT -> "STRING",
+    DataTypes.ByteType -> "INTEGER",
+    DataTypes.ShortType -> "INTEGER",
     DataTypes.IntegerType -> "INTEGER",
     DataTypes.LongType -> "INTEGER",
     DataTypes.FloatType -> "FLOAT",
     DataTypes.DoubleType -> "FLOAT",
     DataTypes.DateType -> "DATE",
-    DataTypes.TimestampType -> "LOCAL DATETIME",
+    DataTypes.TimestampType -> "ZONED DATETIME",
+    DataTypes.TimestampNTZType -> "LOCAL DATETIME",
     DayTimeIntervalType() -> "DURATION",
     YearMonthIntervalType() -> "DURATION",
     durationType -> "DURATION",
@@ -138,13 +145,16 @@ object SparkToCypherTypeConverter {
     // Cypher graph entities do not allow null values in arrays
     DataTypes.createArrayType(DataTypes.BooleanType, false) -> "LIST<BOOLEAN NOT NULL>",
     DataTypes.createArrayType(DataTypes.StringType, false) -> "LIST<STRING NOT NULL>",
+    DataTypes.createArrayType(DecimalType.SYSTEM_DEFAULT, false) -> "LIST<STRING NOT NULL>",
+    DataTypes.createArrayType(DataTypes.ByteType, false) -> "ByteArray",
+    DataTypes.createArrayType(DataTypes.ShortType, false) -> "LIST<INTEGER NOT NULL>",
     DataTypes.createArrayType(DataTypes.IntegerType, false) -> "LIST<INTEGER NOT NULL>",
     DataTypes.createArrayType(DataTypes.LongType, false) -> "LIST<INTEGER NOT NULL>",
     DataTypes.createArrayType(DataTypes.FloatType, false) -> "LIST<FLOAT NOT NULL>",
     DataTypes.createArrayType(DataTypes.DoubleType, false) -> "LIST<FLOAT NOT NULL>",
     DataTypes.createArrayType(DataTypes.DateType, false) -> "LIST<DATE NOT NULL>",
-    DataTypes.createArrayType(DataTypes.TimestampType, false) -> "LIST<LOCAL DATETIME NOT NULL>",
-    DataTypes.createArrayType(DataTypes.TimestampType, true) -> "LIST<LOCAL DATETIME NOT NULL>",
+    DataTypes.createArrayType(DataTypes.TimestampType, false) -> "LIST<ZONED DATETIME NOT NULL>",
+    DataTypes.createArrayType(DataTypes.TimestampNTZType, false) -> "LIST<LOCAL DATETIME NOT NULL>",
     DataTypes.createArrayType(DayTimeIntervalType(), false) -> "LIST<DURATION NOT NULL>",
     DataTypes.createArrayType(DayTimeIntervalType(), true) -> "LIST<DURATION NOT NULL>",
     DataTypes.createArrayType(YearMonthIntervalType(), false) -> "LIST<DURATION NOT NULL>",

--- a/src/main/scala/org/neo4j/spark/service/SchemaService.scala
+++ b/src/main/scala/org/neo4j/spark/service/SchemaService.scala
@@ -947,14 +947,17 @@ object SchemaService {
   val DURATION_TYPE = "duration"
 
   def normalizedClassName(value: AnyRef): String = value match {
+    case binary: Array[Byte]           => "ByteArray"
     case list: java.util.List[_]       => "Array"
     case map: java.util.Map[String, _] => "Map"
     case null                          => "String"
     case _                             => value.getClass.getSimpleName
   }
 
-  // from nodes and relationships we cannot have maps as properties and elements in collections are the same type
+  // from nodes and relationships we cannot have maps as properties and elements in lists are the same type
+  // special treatment for ByteArray required (pattern matching on Array != List)
   def normalizedClassNameFromGraphEntity(value: AnyRef): String = value match {
+    case binary: Array[Byte]     => "ByteArray"
     case list: java.util.List[_] => s"${list.get(0).getClass.getSimpleName}Array"
     case null                    => "String"
     case _                       => value.getClass.getSimpleName

--- a/src/test/java/org/neo4j/spark/DataSourceReaderTypesTSE.java
+++ b/src/test/java/org/neo4j/spark/DataSourceReaderTypesTSE.java
@@ -89,8 +89,9 @@ public class DataSourceReaderTypesTSE extends SparkConnectorScalaBaseTSE {
         String localDateTime = "2007-12-03T10:15:30";
         Dataset<Row> df = initTest("CREATE (p:Person {aTime: localdatetime('" + localDateTime + "')})");
 
-        Timestamp result = df.select("aTime").collectAsList().get(0).getTimestamp(0);
-        assertEquals(Timestamp.from(LocalDateTime.parse(localDateTime).toInstant(ZoneOffset.UTC)), result);
+        Row row = df.select("aTime").collectAsList().get(0);
+        LocalDateTime result = row.getAs(0);
+        assertEquals(LocalDateTime.parse(localDateTime), result);
     }
 
     @Test

--- a/src/test/scala/org/neo4j/spark/DataSourceReaderTSE.scala
+++ b/src/test/scala/org/neo4j/spark/DataSourceReaderTSE.scala
@@ -165,7 +165,6 @@ class DataSourceReaderTSE extends SparkConnectorScalaBaseTSE {
       initTest(s"CREATE (p:Person {aTime: localtime({hour:12, minute: 23, second: 0, millisecond: 294})})")
 
     val result = df.select("aTime").collectAsList().get(0).getAs[GenericRowWithSchema](0)
-
     assertEquals("local-time", result.get(0))
     assertEquals("12:23:00.294", result.get(1))
   }
@@ -178,7 +177,7 @@ class DataSourceReaderTSE extends SparkConnectorScalaBaseTSE {
     val result = df.select("aTime").collectAsList().get(0).getAs[GenericRowWithSchema](0)
 
     val localTime = LocalTime.of(12, 23, 0, 294000000)
-    val expectedTime = OffsetTime.of(localTime, timezone.toZoneId.getRules.getOffset(Instant.now()))
+    val expectedTime = OffsetTime.of(localTime, timezone.toZoneId.getRules.getOffset(Instant.now))
 
     assertEquals("offset-time", result.get(0))
     assertEquals(expectedTime.toString, result.get(1))
@@ -188,10 +187,8 @@ class DataSourceReaderTSE extends SparkConnectorScalaBaseTSE {
   def testReadNodeWithLocalDateTime(): Unit = {
     val localDateTime = "2007-12-03T10:15:30"
     val df: DataFrame = initTest(s"CREATE (p:Person {aTime: localdatetime('$localDateTime')})")
-
-    val result = df.select("aTime").collectAsList().get(0).getTimestamp(0)
-
-    assertEquals(Timestamp.from(LocalDateTime.parse(localDateTime).toInstant(ZoneOffset.UTC)), result)
+    val result = df.select("aTime").collectAsList().get(0).getAs[LocalDateTime](0)
+    assertEquals(LocalDateTime.parse(localDateTime), result)
   }
 
   @Test
@@ -297,12 +294,23 @@ class DataSourceReaderTSE extends SparkConnectorScalaBaseTSE {
   }
 
   @Test
+  def testReadNodeWithTimestampArray(): Unit = {
+    val df: DataFrame =
+      initTest(
+        s"CREATE (p:Person {someTimes: [datetime('2010-10-10T11:13:37+01:00'), datetime('2011-11-11T10:13:37Z')]})"
+      )
+
+    val res = df.select("someTimes").collectAsList().get(0).getAs[Seq[Timestamp]](0)
+    assertEquals("2010-10-10T10:13:37Z", res.head.toInstant.atZone(ZoneOffset.UTC).toString)
+    assertEquals("2011-11-11T10:13:37Z", res(1).toInstant.atZone(ZoneOffset.UTC).toString)
+  }
+
+  @Test
   def testReadNodeWithLocalTimeArray(): Unit = {
     val df: DataFrame =
       initTest(s"CREATE (p:Person {someTimes: [localtime({hour:12}), localtime({hour:1, minute: 3})]})")
 
     val res = df.select("someTimes").collectAsList().get(0).getAs[Seq[GenericRowWithSchema]](0)
-
     assertEquals("local-time", res.head.get(0))
     assertEquals("12:00:00", res.head.get(1))
     assertEquals("local-time", res(1).get(0))
@@ -424,6 +432,29 @@ class DataSourceReaderTSE extends SparkConnectorScalaBaseTSE {
     assertEquals(43200L, res(1).get(3))
     assertEquals(0, res(1).get(4))
     assertEquals("P0M17DT43200S", res(1).get(5))
+  }
+
+  @Test
+  def testReadNodeWithBinary(): Unit = {
+    val bytes = "hello, world!".map(_.toByte).toArray
+    val parameters = new java.util.HashMap[String, Object]()
+    parameters.put("bytes", bytes)
+
+    SparkConnectorScalaSuiteIT.session()
+      .executeWrite((tx: TransactionContext) => tx.run("CREATE (h:Hello {b: $bytes})", parameters).consume())
+
+    val df = ss.read.format(classOf[DataSource].getName)
+      .option("url", SparkConnectorScalaSuiteIT.server.getBoltUrl)
+      .option("labels", "Hello")
+      .load()
+
+    val res = df.select("b").collect()
+    assertEquals(1, res.length)
+    val gotBytes = res.head.getAs[Array[Byte]](0)
+
+    for (i <- bytes.indices) {
+      assertEquals(bytes(i), gotBytes(i))
+    }
   }
 
   @Test

--- a/src/test/scala/org/neo4j/spark/DataSourceReaderWithApocTSE.scala
+++ b/src/test/scala/org/neo4j/spark/DataSourceReaderWithApocTSE.scala
@@ -128,9 +128,8 @@ class DataSourceReaderWithApocTSE extends SparkConnectorScalaBaseWithApocTSE {
     val localDateTime = "2007-12-03T10:15:30"
     val df: DataFrame = initTest(s"CREATE (p:Person {aTime: localdatetime('$localDateTime')})")
 
-    val result = df.select("aTime").collectAsList().get(0).getTimestamp(0)
-
-    assertEquals(Timestamp.from(LocalDateTime.parse(localDateTime).toInstant(ZoneOffset.UTC)), result)
+    val result = df.select("aTime").collectAsList().get(0).getAs[LocalDateTime](0)
+    assertEquals(LocalDateTime.parse(localDateTime), result)
   }
 
   @Test

--- a/src/test/scala/org/neo4j/spark/DataSourceSchemaWriterTSE.scala
+++ b/src/test/scala/org/neo4j/spark/DataSourceSchemaWriterTSE.scala
@@ -39,6 +39,8 @@ import java.sql.Date
 import java.sql.Timestamp
 import java.time.LocalDate
 import java.time.LocalDateTime
+import java.time.ZonedDateTime
+import java.util.TimeZone
 
 import scala.collection.JavaConverters.iterableAsScalaIterableConverter
 import scala.collection.JavaConverters.mapAsScalaMapConverter
@@ -53,7 +55,13 @@ object DataSourceSchemaWriterTSE {
 }
 
 class DataSourceSchemaWriterTSE extends SparkConnectorScalaBaseTSE {
-  val sparkSession = SparkSession.builder().getOrCreate()
+  val timeZoneLock = "UTC" // to make TIMESTAMP_NTZ tests deterministic
+
+  val sparkSession = SparkSession.builder()
+    .master("local[*]")
+    .appName("DataSourceWriterTSE")
+    .config("spark.sql.session.timeZone", timeZoneLock) // to make TIMESTAMP_NTZ tests deterministic
+    .getOrCreate()
 
   final private val SHOW_CONSTRAINTS_QUERY =
     """|SHOW CONSTRAINTS
@@ -79,12 +87,12 @@ class DataSourceSchemaWriterTSE extends SparkConnectorScalaBaseTSE {
 
   import sparkSession.implicits._
 
-  private def mapData(x: Any): Any = x match {
+  private def mapData(data: Any): Any = data match {
     case null                 => null
     case a: Array[_]          => a.toSeq.map(mapData)
     case l: java.util.List[_] => l.asScala.toSeq.map(mapData)
     case d: LocalDate         => Date.valueOf(d)
-    case ldt: LocalDateTime   => Timestamp.valueOf(ldt)
+    case zdt: ZonedDateTime   => Timestamp.from(zdt.toInstant)
     case any: Any             => any
   }
 
@@ -95,6 +103,7 @@ class DataSourceSchemaWriterTSE extends SparkConnectorScalaBaseTSE {
   @Test
   def shouldApplySchemaForNodes(): Unit = {
     val (expectedNode: Map[_root_.java.lang.String, Any], df: DataFrame) = createNodesDataFrameWithNotNullColumns
+
     df
       .write
       .mode(SaveMode.Append)
@@ -112,6 +121,7 @@ class DataSourceSchemaWriterTSE extends SparkConnectorScalaBaseTSE {
       .single()
       .get(0)
       .asLong()
+
     assertEquals(1L, count)
 
     val expectedSchema = Seq(
@@ -212,6 +222,22 @@ class DataSourceSchemaWriterTSE extends SparkConnectorScalaBaseTSE {
         "propertyType" -> "LIST<INTEGER NOT NULL>"
       ),
       Map(
+        "name" -> "spark_NODE-TYPE-CONSTRAINT-NodeWithSchema-localDateTime",
+        "type" -> "NODE_PROPERTY_TYPE",
+        "entityType" -> "NODE",
+        "labelsOrTypes" -> Seq("NodeWithSchema"),
+        "properties" -> Seq("localDateTime"),
+        "propertyType" -> "LOCAL DATETIME"
+      ),
+      Map(
+        "name" -> "spark_NODE-TYPE-CONSTRAINT-NodeWithSchema-localDateTimeArray",
+        "type" -> "NODE_PROPERTY_TYPE",
+        "entityType" -> "NODE",
+        "labelsOrTypes" -> Seq("NodeWithSchema"),
+        "properties" -> Seq("localDateTimeArray"),
+        "propertyType" -> "LIST<LOCAL DATETIME NOT NULL>"
+      ),
+      Map(
         "name" -> "spark_NODE-TYPE-CONSTRAINT-NodeWithSchema-string",
         "type" -> "NODE_PROPERTY_TYPE",
         "entityType" -> "NODE",
@@ -228,20 +254,20 @@ class DataSourceSchemaWriterTSE extends SparkConnectorScalaBaseTSE {
         "propertyType" -> "LIST<STRING NOT NULL>"
       ),
       Map(
-        "name" -> "spark_NODE-TYPE-CONSTRAINT-NodeWithSchema-timestamp",
+        "name" -> "spark_NODE-TYPE-CONSTRAINT-NodeWithSchema-zonedDateTime",
         "type" -> "NODE_PROPERTY_TYPE",
         "entityType" -> "NODE",
         "labelsOrTypes" -> Seq("NodeWithSchema"),
-        "properties" -> Seq("timestamp"),
-        "propertyType" -> "LOCAL DATETIME"
+        "properties" -> Seq("zonedDateTime"),
+        "propertyType" -> "ZONED DATETIME"
       ),
       Map(
-        "name" -> "spark_NODE-TYPE-CONSTRAINT-NodeWithSchema-timestampArray",
+        "name" -> "spark_NODE-TYPE-CONSTRAINT-NodeWithSchema-zonedDateTimeArray",
         "type" -> "NODE_PROPERTY_TYPE",
         "entityType" -> "NODE",
         "labelsOrTypes" -> Seq("NodeWithSchema"),
-        "properties" -> Seq("timestampArray"),
-        "propertyType" -> "LIST<LOCAL DATETIME NOT NULL>"
+        "properties" -> Seq("zonedDateTimeArray"),
+        "propertyType" -> "LIST<ZONED DATETIME NOT NULL>"
       )
     )
 
@@ -391,6 +417,22 @@ class DataSourceSchemaWriterTSE extends SparkConnectorScalaBaseTSE {
         "propertyType" -> "LIST<INTEGER NOT NULL>"
       ),
       Map(
+        "name" -> "spark_NODE-TYPE-CONSTRAINT-NodeWithSchema-localDateTime",
+        "type" -> "NODE_PROPERTY_TYPE",
+        "entityType" -> "NODE",
+        "labelsOrTypes" -> Seq("NodeWithSchema"),
+        "properties" -> Seq("localDateTime"),
+        "propertyType" -> "LOCAL DATETIME"
+      ),
+      Map(
+        "name" -> "spark_NODE-TYPE-CONSTRAINT-NodeWithSchema-localDateTimeArray",
+        "type" -> "NODE_PROPERTY_TYPE",
+        "entityType" -> "NODE",
+        "labelsOrTypes" -> Seq("NodeWithSchema"),
+        "properties" -> Seq("localDateTimeArray"),
+        "propertyType" -> "LIST<LOCAL DATETIME NOT NULL>"
+      ),
+      Map(
         "name" -> "spark_NODE-TYPE-CONSTRAINT-NodeWithSchema-string",
         "type" -> "NODE_PROPERTY_TYPE",
         "entityType" -> "NODE",
@@ -407,20 +449,20 @@ class DataSourceSchemaWriterTSE extends SparkConnectorScalaBaseTSE {
         "propertyType" -> "LIST<STRING NOT NULL>"
       ),
       Map(
-        "name" -> "spark_NODE-TYPE-CONSTRAINT-NodeWithSchema-timestamp",
+        "name" -> "spark_NODE-TYPE-CONSTRAINT-NodeWithSchema-zonedDateTime",
         "type" -> "NODE_PROPERTY_TYPE",
         "entityType" -> "NODE",
         "labelsOrTypes" -> Seq("NodeWithSchema"),
-        "properties" -> Seq("timestamp"),
-        "propertyType" -> "LOCAL DATETIME"
+        "properties" -> Seq("zonedDateTime"),
+        "propertyType" -> "ZONED DATETIME"
       ),
       Map(
-        "name" -> "spark_NODE-TYPE-CONSTRAINT-NodeWithSchema-timestampArray",
+        "name" -> "spark_NODE-TYPE-CONSTRAINT-NodeWithSchema-zonedDateTimeArray",
         "type" -> "NODE_PROPERTY_TYPE",
         "entityType" -> "NODE",
         "labelsOrTypes" -> Seq("NodeWithSchema"),
-        "properties" -> Seq("timestampArray"),
-        "propertyType" -> "LIST<LOCAL DATETIME NOT NULL>"
+        "properties" -> Seq("zonedDateTimeArray"),
+        "propertyType" -> "LIST<ZONED DATETIME NOT NULL>"
       ),
       Map(
         "name" -> "spark_NODE_KEY-CONSTRAINT_NodeWithSchema_int-string",
@@ -458,19 +500,23 @@ class DataSourceSchemaWriterTSE extends SparkConnectorScalaBaseTSE {
   }
 
   private def createNodesDataFrameWithNotNullColumns: (Map[String, Any], DataFrame) = {
+    TimeZone.setDefault(TimeZone.getTimeZone(timeZoneLock))
+
     val colNames = Array(
       "string",
       "int",
       "boolean",
       "float",
       "date",
-      "timestamp",
+      "localDateTime",
+      "zonedDateTime",
       "stringArray",
       "intArray",
       "booleanArray",
       "floatArray",
       "dateArray",
-      "timestampArray"
+      "localDateTimeArray",
+      "zonedDateTimeArray"
     )
     val row = (
       "Foo",
@@ -478,21 +524,25 @@ class DataSourceSchemaWriterTSE extends SparkConnectorScalaBaseTSE {
       false,
       1.1,
       Date.valueOf("2023-11-22"),
+      LocalDateTime.of(2023, 11, 22, 12, 12, 12),
       Timestamp.valueOf(s"2020-11-22 11:11:11.11"),
       Seq("Foo1", "Foo2"),
       Seq(1, 2),
       Seq(true, false),
       Seq(1.1, 2.2),
       Seq(Date.valueOf("2023-11-22"), Date.valueOf("2023-11-23")),
+      Seq(LocalDateTime.of(2023, 11, 22, 11, 11, 11), LocalDateTime.of(2023, 11, 23, 12, 12, 12)),
       Seq(Timestamp.valueOf("2023-11-22 11:11:11.11"), Timestamp.valueOf("2023-11-23 12:12:12.12"))
     )
-    val data = Seq(row).toDF(colNames: _*)
 
+    val data = Seq(row).toDF(colNames: _*)
     val expectedNode = colNames.zip(row.productIterator.toSeq).toMap
 
     val schema = StructType(data.schema.map { sf =>
       sf.name match {
-        case "timestampArray" =>
+        case "localDateTimeArray" =>
+          StructField(sf.name, DataTypes.createArrayType(DataTypes.TimestampNTZType, false), sf.nullable)
+        case "zonedDateTimeArray" =>
           StructField(sf.name, DataTypes.createArrayType(DataTypes.TimestampType, false), sf.nullable)
         case "stringArray" => StructField(sf.name, DataTypes.createArrayType(DataTypes.StringType, false), sf.nullable)
         case "dateArray"   => StructField(sf.name, DataTypes.createArrayType(DataTypes.DateType, false), sf.nullable)
@@ -500,6 +550,7 @@ class DataSourceSchemaWriterTSE extends SparkConnectorScalaBaseTSE {
         case _             => sf
       }
     })
+
     val df = ss.createDataFrame(data.rdd, schema)
     (expectedNode, df)
   }
@@ -645,6 +696,22 @@ class DataSourceSchemaWriterTSE extends SparkConnectorScalaBaseTSE {
         "propertyType" -> "LIST<INTEGER NOT NULL>"
       ),
       Map(
+        "name" -> "spark_RELATIONSHIP-TYPE-CONSTRAINT-MY_REL-localDateTime",
+        "type" -> "RELATIONSHIP_PROPERTY_TYPE",
+        "entityType" -> "RELATIONSHIP",
+        "labelsOrTypes" -> Seq("MY_REL"),
+        "properties" -> Seq("localDateTime"),
+        "propertyType" -> "LOCAL DATETIME"
+      ),
+      Map(
+        "name" -> "spark_RELATIONSHIP-TYPE-CONSTRAINT-MY_REL-localDateTimeArray",
+        "type" -> "RELATIONSHIP_PROPERTY_TYPE",
+        "entityType" -> "RELATIONSHIP",
+        "labelsOrTypes" -> Seq("MY_REL"),
+        "properties" -> Seq("localDateTimeArray"),
+        "propertyType" -> "LIST<LOCAL DATETIME NOT NULL>"
+      ),
+      Map(
         "name" -> "spark_RELATIONSHIP-TYPE-CONSTRAINT-MY_REL-string",
         "type" -> "RELATIONSHIP_PROPERTY_TYPE",
         "entityType" -> "RELATIONSHIP",
@@ -661,20 +728,20 @@ class DataSourceSchemaWriterTSE extends SparkConnectorScalaBaseTSE {
         "propertyType" -> "LIST<STRING NOT NULL>"
       ),
       Map(
-        "name" -> "spark_RELATIONSHIP-TYPE-CONSTRAINT-MY_REL-timestamp",
+        "name" -> "spark_RELATIONSHIP-TYPE-CONSTRAINT-MY_REL-zonedDateTime",
         "type" -> "RELATIONSHIP_PROPERTY_TYPE",
         "entityType" -> "RELATIONSHIP",
         "labelsOrTypes" -> Seq("MY_REL"),
-        "properties" -> Seq("timestamp"),
-        "propertyType" -> "LOCAL DATETIME"
+        "properties" -> Seq("zonedDateTime"),
+        "propertyType" -> "ZONED DATETIME"
       ),
       Map(
-        "name" -> "spark_RELATIONSHIP-TYPE-CONSTRAINT-MY_REL-timestampArray",
+        "name" -> "spark_RELATIONSHIP-TYPE-CONSTRAINT-MY_REL-zonedDateTimeArray",
         "type" -> "RELATIONSHIP_PROPERTY_TYPE",
         "entityType" -> "RELATIONSHIP",
         "labelsOrTypes" -> Seq("MY_REL"),
-        "properties" -> Seq("timestampArray"),
-        "propertyType" -> "LIST<LOCAL DATETIME NOT NULL>"
+        "properties" -> Seq("zonedDateTimeArray"),
+        "propertyType" -> "LIST<ZONED DATETIME NOT NULL>"
       )
     )
 
@@ -720,13 +787,15 @@ class DataSourceSchemaWriterTSE extends SparkConnectorScalaBaseTSE {
       "boolean",
       "float",
       "date",
-      "timestamp",
+      "localDateTime",
+      "zonedDateTime",
       "stringArray",
       "intArray",
       "booleanArray",
       "floatArray",
       "dateArray",
-      "timestampArray"
+      "localDateTimeArray",
+      "zonedDateTimeArray"
     )
     val row = (
       "a",
@@ -736,19 +805,23 @@ class DataSourceSchemaWriterTSE extends SparkConnectorScalaBaseTSE {
       false,
       1.1,
       Date.valueOf("2023-11-22"),
+      LocalDateTime.of(2023, 11, 22, 12, 12, 12),
       Timestamp.valueOf(s"2020-11-22 11:11:11.11"),
       Seq("Foo1", "Foo2"),
       Seq(1, 2),
       Seq(true, false),
       Seq(1.1, 2.2),
       Seq(Date.valueOf("2023-11-22"), Date.valueOf("2023-11-23")),
+      Seq(LocalDateTime.of(2023, 11, 22, 11, 11, 11), LocalDateTime.of(2023, 11, 23, 12, 12, 12)),
       Seq(Timestamp.valueOf("2023-11-22 11:11:11.11"), Timestamp.valueOf("2023-11-23 12:12:12.12"))
     )
     val data = Seq(row).toDF(colNames: _*)
 
     val schema = StructType(data.schema.map { sf =>
       sf.name match {
-        case "timestampArray" =>
+        case "localDateTimeArray" =>
+          StructField(sf.name, DataTypes.createArrayType(DataTypes.TimestampNTZType, false), sf.nullable)
+        case "zonedDateTimeArray" =>
           StructField(sf.name, DataTypes.createArrayType(DataTypes.TimestampType, false), sf.nullable)
         case "stringArray" => StructField(sf.name, DataTypes.createArrayType(DataTypes.StringType, false), sf.nullable)
         case "dateArray"   => StructField(sf.name, DataTypes.createArrayType(DataTypes.DateType, false), sf.nullable)
@@ -891,6 +964,7 @@ class DataSourceSchemaWriterTSE extends SparkConnectorScalaBaseTSE {
       .head
       .mapValues(mapData)
       .toMap
+
     assertEquals(expectedMap, actualMap)
 
     val actualConstraint = SparkConnectorScalaSuiteIT.session().run(RELATIONSHIP_UNIQUENESS_SHOW_CONSTRAINTS_QUERY)
@@ -934,6 +1008,7 @@ class DataSourceSchemaWriterTSE extends SparkConnectorScalaBaseTSE {
       .head
       .mapValues(mapData)
       .toMap
+
     assertEquals(expectedMap, actualMap)
 
     val actualConstraint = SparkConnectorScalaSuiteIT.session().run(SHOW_CONSTRAINTS_QUERY)
@@ -949,6 +1024,7 @@ class DataSourceSchemaWriterTSE extends SparkConnectorScalaBaseTSE {
       "properties" -> Seq("string", "int"),
       "ownedIndex" -> "spark_RELATIONSHIP_KEY-CONSTRAINT_MY_REL_string-int"
     )
+
     assertEquals(expectedConstraint, actualConstraint)
   }
 }

--- a/src/test/scala/org/neo4j/spark/DataSourceWriterTSE.scala
+++ b/src/test/scala/org/neo4j/spark/DataSourceWriterTSE.scala
@@ -22,8 +22,11 @@ import org.apache.spark.sql.DataFrame
 import org.apache.spark.sql.SaveMode
 import org.apache.spark.sql.SparkSession
 import org.apache.spark.sql.types.ArrayType
+import org.apache.spark.sql.types.ByteType
 import org.apache.spark.sql.types.DataType
+import org.apache.spark.sql.types.DataTypes
 import org.apache.spark.sql.types.DayTimeIntervalType
+import org.apache.spark.sql.types.DecimalType
 import org.apache.spark.sql.types.YearMonthIntervalType
 import org.junit.jupiter.api.Assertions._
 import org.junit.jupiter.api.Disabled
@@ -49,6 +52,9 @@ import org.neo4j.spark.util.Neo4jOptions
 
 import java.time.LocalTime
 import java.time.OffsetTime
+import java.time.ZoneId
+import java.time.ZoneOffset
+import java.util.TimeZone
 
 import scala.collection.JavaConverters._
 import scala.collection.immutable.ListMap
@@ -92,7 +98,11 @@ case class DurationCase(
 }
 
 class DataSourceWriterTSE extends SparkConnectorScalaBaseTSE {
-  val sparkSession = SparkSession.builder().master("local[*]").getOrCreate()
+
+  val sparkSession = SparkSession.builder()
+    .master("local[*]")
+    .appName("DataSourceWriterTSE")
+    .getOrCreate()
 
   import sparkSession.implicits._
 
@@ -112,19 +122,20 @@ class DataSourceWriterTSE extends SparkConnectorScalaBaseTSE {
       .filter(r => r.get("foo").hasType(neo4jType))
       .map(r => r.asMap().asScala)
       .toSet
+
     val expected = ds.collect()
       .map(row =>
         Map("foo" -> {
           val foo = row.getAs[T]("foo")
           foo match {
-            case sqlDate: java.sql.Date => sqlDate
-                .toLocalDate
-            case sqlTimestamp: java.sql.Timestamp => sqlTimestamp.toLocalDateTime
+            case sqlDate: java.sql.Date           => sqlDate.toLocalDate
+            case sqlTimestamp: java.sql.Timestamp => sqlTimestamp.toInstant.atZone(ZoneOffset.UTC)
             case _                                => foo
           }
         })
       )
       .toSet
+
     assertEquals(expected, records)
   }
 
@@ -147,6 +158,28 @@ class DataSourceWriterTSE extends SparkConnectorScalaBaseTSE {
     val expected = ds.collect()
       .map(row => row.getList[T](0))
       .toSet
+
+    assertEquals(expected, records)
+  }
+
+  private def testDurationType(ds: DataFrame, expected: Set[Duration]): Unit = {
+    ds.write
+      .format(classOf[DataSource].getName)
+      .mode(SaveMode.Append)
+      .option("url", SparkConnectorScalaSuiteIT.server.getBoltUrl)
+      .option("labels", ":Duration")
+      .save()
+
+    val records = SparkConnectorScalaSuiteIT.session().run(
+      """MATCH (d:Duration)
+        |RETURN d.duration AS duration
+        |""".stripMargin
+    ).list().asScala
+      .filter(r => r.get("duration").hasType(InternalTypeSystem.TYPE_SYSTEM.DURATION()))
+      .map(r => r.get("duration").asIsoDuration())
+      .map(data => Duration(data.months, data.days, data.seconds, data.nanoseconds))
+      .toSet
+
     assertEquals(expected, records)
   }
 
@@ -203,8 +236,7 @@ class DataSourceWriterTSE extends SparkConnectorScalaBaseTSE {
 
   @Test
   def `should write nodes with string values into Neo4j`(): Unit = {
-    val total = 10
-    val ds = (1 to total)
+    val ds = (1 to 10)
       .map(i => i.toString)
       .toDF("foo")
 
@@ -213,8 +245,7 @@ class DataSourceWriterTSE extends SparkConnectorScalaBaseTSE {
 
   @Test
   def `should write nodes with string array values into Neo4j`(): Unit = {
-    val total = 10
-    val ds = (1 to total)
+    val ds = (1 to 10)
       .map(i => i.toString)
       .map(i => Array(i, i))
       .toDF("foo")
@@ -224,8 +255,7 @@ class DataSourceWriterTSE extends SparkConnectorScalaBaseTSE {
 
   @Test
   def `should write nodes with int values into Neo4j`(): Unit = {
-    val total = 10
-    val ds = (1 to total)
+    val ds = (1 to 10)
       .map(i => i)
       .toDF("foo")
 
@@ -233,9 +263,26 @@ class DataSourceWriterTSE extends SparkConnectorScalaBaseTSE {
   }
 
   @Test
+  def `should write nodes with byte values into Neo4j`(): Unit = {
+    val ds = (1 to 10)
+      .map(_.toByte)
+      .toDF("foo")
+
+    testType[Byte](ds, InternalTypeSystem.TYPE_SYSTEM.INTEGER())
+  }
+
+  @Test
+  def `should write nodes with short values into Neo4j`(): Unit = {
+    val ds = (1 to 10)
+      .map(_.toShort)
+      .toDF("foo")
+
+    testType[Short](ds, InternalTypeSystem.TYPE_SYSTEM.INTEGER())
+  }
+
+  @Test
   def `should write nodes with date values into Neo4j`(): Unit = {
-    val total = 5
-    val ds = (1 to total)
+    val ds = (1 to 5)
       .map(i => java.sql.Date.valueOf("2020-01-0" + i))
       .toDF("foo")
 
@@ -244,18 +291,25 @@ class DataSourceWriterTSE extends SparkConnectorScalaBaseTSE {
 
   @Test
   def `should write nodes with timestamp values into Neo4j`(): Unit = {
-    val total = 5
-    val ds = (1 to total)
+    val ds = (1 to 5)
       .map(i => java.sql.Timestamp.valueOf(s"2020-01-0$i 11:11:11.11"))
       .toDF("foo")
 
-    testType[java.sql.Timestamp](ds, InternalTypeSystem.TYPE_SYSTEM.LOCAL_DATE_TIME())
+    testType[java.sql.Timestamp](ds, InternalTypeSystem.TYPE_SYSTEM.DATE_TIME())
+  }
+
+  @Test
+  def `should write nodes with timestampNTZ values into Neo4j`(): Unit = {
+    val ds = (1 to 5)
+      .map(i => java.time.LocalDateTime.of(2020, 1, i, 11, 11, 11, 111000000))
+      .toDF("foo")
+
+    testType[java.time.LocalDateTime](ds, InternalTypeSystem.TYPE_SYSTEM.LOCAL_DATE_TIME())
   }
 
   @Test
   def `should write nodes with int array values into Neo4j`(): Unit = {
-    val total = 10
-    val ds = (1 to total)
+    val ds = (1 to 10)
       .map(i => i.toLong)
       .map(i => Array(i, i))
       .toDF("foo")
@@ -265,8 +319,7 @@ class DataSourceWriterTSE extends SparkConnectorScalaBaseTSE {
 
   @Test
   def `should write nodes with point-2d values into Neo4j`(): Unit = {
-    val total = 10
-    val ds = (1 to total)
+    val ds = (1 to 10)
       .map(i => EmptyRow(Point2d(srid = 4326, x = Random.nextDouble(), y = Random.nextDouble())))
       .toDS()
 
@@ -296,8 +349,7 @@ class DataSourceWriterTSE extends SparkConnectorScalaBaseTSE {
 
   @Test
   def `should write nodes with point-2d array values into Neo4j`(): Unit = {
-    val total = 10
-    val ds = (1 to total)
+    val ds = (1 to 10)
       .map(i =>
         EmptyRow(Seq(
           Point2d(srid = 4326, x = Random.nextDouble(), y = Random.nextDouble()),
@@ -334,8 +386,7 @@ class DataSourceWriterTSE extends SparkConnectorScalaBaseTSE {
 
   @Test
   def `should write nodes with point-3d values into Neo4j`(): Unit = {
-    val total = 10
-    val ds = (1 to total)
+    val ds = (1 to 10)
       .map(i =>
         EmptyRow(Point3d(srid = 4979, x = Random.nextDouble(), y = Random.nextDouble(), z = Random.nextDouble()))
       )
@@ -367,8 +418,7 @@ class DataSourceWriterTSE extends SparkConnectorScalaBaseTSE {
 
   @Test
   def `should write nodes with point-3d array values into Neo4j`(): Unit = {
-    val total = 10
-    val ds = (1 to total)
+    val ds = (1 to 10)
       .map(i =>
         EmptyRow(Seq(
           Point3d(srid = 4979, x = Random.nextDouble(), y = Random.nextDouble(), z = Random.nextDouble()),
@@ -405,8 +455,7 @@ class DataSourceWriterTSE extends SparkConnectorScalaBaseTSE {
 
   @Test
   def `should write nodes with map values into Neo4j`(): Unit = {
-    val total = 10
-    val ds = (1 to total)
+    val ds = (1 to 10)
       .map(i => Map("field" + i -> i))
       .toDF("foo")
 
@@ -432,40 +481,51 @@ class DataSourceWriterTSE extends SparkConnectorScalaBaseTSE {
   }
 
   @Test
+  def `should write nodes with duration values into Neo4j from java period`(): Unit = {
+    val range = 1 to 10
+    val ds = range
+      .map(i => java.time.Period.ofMonths(i))
+      .toDF("duration")
+
+    val expected = range
+      .map(i => Duration(i, 0, 0, 0))
+      .toSet
+
+    testDurationType(ds, expected)
+  }
+
+  @Test
+  def `should write nodes with duration values into Neo4j from java duration`(): Unit = {
+    val range = 1 to 10
+    val ds = range
+      .map(i => java.time.Duration.ofDays(i.toLong))
+      .toDF("duration")
+
+    val expected = range
+      .map(i => Duration(0, i, 0, 0))
+      .toSet
+
+    testDurationType(ds, expected)
+  }
+
+  @Test
   def `should write nodes with duration values into Neo4j from struct`(): Unit = {
-    val total = 10
-    val ds = (1 to total)
+    val range = 1 to 10
+    val ds = range
       .map(i => i.toLong)
       .map(i => EmptyRow(Duration(i, i, i, i)))
-      .toDS()
+      .toDF("duration")
 
-    ds.write
-      .format(classOf[DataSource].getName)
-      .mode(SaveMode.Append)
-      .option("url", SparkConnectorScalaSuiteIT.server.getBoltUrl)
-      .option("labels", "BeanWithDuration")
-      .save()
-
-    val records = SparkConnectorScalaSuiteIT.session().run(
-      """MATCH (p:BeanWithDuration)
-        |RETURN p.data AS duration
-        |""".stripMargin
-    ).list().asScala
-      .map(r => r.get("duration").asIsoDuration())
-      .map(data => (data.months, data.days, data.seconds, data.nanoseconds))
+    val expected = range
+      .map(i => Duration(i, i, i, i))
       .toSet
 
-    val expected = ds.collect()
-      .map(row => (row.data.months, row.data.days, row.data.seconds, row.data.nanoseconds))
-      .toSet
-
-    assertEquals(expected, records)
+    testDurationType(ds, expected)
   }
 
   @Test
   def `should write nodes with duration array values into Neo4j from struct`(): Unit = {
-    val total = 10
-    val ds = (1 to total)
+    val ds = (1 to 10)
       .map(i => i.toLong)
       .map(i =>
         EmptyRow(Seq(
@@ -504,7 +564,7 @@ class DataSourceWriterTSE extends SparkConnectorScalaBaseTSE {
 
   @ParameterizedTest
   @MethodSource(Array("org.neo4j.spark.DataSourceWriterTSE#sqlDurationCases"))
-  def `interval literals map to native neo4j durations`(testCase: DurationCase): Unit = {
+  def `interval SQL literals map to native neo4j durations`(testCase: DurationCase): Unit = {
     val id = java.util.UUID.randomUUID().toString
     val df = sparkSession.sql(s"SELECT '$id' AS id, ${testCase.sql} AS duration")
 
@@ -537,7 +597,7 @@ class DataSourceWriterTSE extends SparkConnectorScalaBaseTSE {
 
   @ParameterizedTest
   @MethodSource(Array("org.neo4j.spark.DataSourceWriterTSE#sqlDurationArrayCases"))
-  def `should write interval arrays as native neo4j durations`(testCase: Seq[DurationCase]): Unit = {
+  def `interval SQL arrays map to native neo4j durations arrays`(testCase: Seq[DurationCase]): Unit = {
     val id = java.util.UUID.randomUUID().toString
     val expectedDt = testCase.head.expectedDt
     val sqlArray = testCase.map(_.sql).mkString("array(", ", ", ")")
@@ -576,6 +636,119 @@ class DataSourceWriterTSE extends SparkConnectorScalaBaseTSE {
       },
       s"expected successful conversion to IsoDuration array, but it failed: $result"
     )
+  }
+
+  @Test
+  def `should write TINYINT as neo4j integer`(): Unit = {
+    val id = java.util.UUID.randomUUID().toString
+    val df = sparkSession.sql(s"SELECT '$id' AS id, CAST(5 AS TINYINT) AS byte")
+
+    df.write
+      .format(classOf[DataSource].getName)
+      .mode(SaveMode.Append)
+      .option("url", SparkConnectorScalaSuiteIT.server.getBoltUrl)
+      .option("labels", "Byte")
+      .save()
+
+    val wantType = DataTypes.ByteType
+    val gotType = df.schema("byte").dataType
+    assertTrue(wantType == gotType, s"expected Spark to pick ${wantType.simpleString} but it was $gotType")
+
+    val gotByte = SparkConnectorScalaSuiteIT.session().run(
+      s"""MATCH (b:Byte {id: '$id'})
+         |RETURN b.byte AS byte
+         |""".stripMargin
+    ).single().get("byte").asInt()
+
+    assertEquals(5, gotByte)
+  }
+
+  @Test
+  def `should write BINARY (byte array) as neo4j ByteArray`(): Unit = {
+    val id = java.util.UUID.randomUUID().toString
+    val sqlArray = (1 to 10).map(i => s"CAST($i AS TINYINT)").mkString("array(", ", ", ")")
+    val df = sparkSession.sql(s"SELECT '$id' AS id, $sqlArray AS binary")
+
+    df.write
+      .format(classOf[DataSource].getName)
+      .mode(SaveMode.Append)
+      .option("url", SparkConnectorScalaSuiteIT.server.getBoltUrl)
+      .option("labels", "Binary")
+      .save()
+
+    val wantType: DataType = DataTypes.ByteType
+    val gotType = df.schema("binary").dataType
+
+    assertTrue(
+      gotType match {
+        case ArrayType(_: ByteType, _) => true
+        case _                         => false
+      },
+      s"expected Spark to infer ArrayType(${wantType.simpleString}) but it was $gotType"
+    )
+
+    val gotByteArray = SparkConnectorScalaSuiteIT.session().run(
+      s"""MATCH (b:Binary {id: '$id'})
+         |RETURN b.binary AS binary
+         |""".stripMargin
+    ).single().get("binary").asByteArray()
+
+    assertEquals(10, gotByteArray.length)
+
+    for (b <- gotByteArray.indices) {
+      val expectedValue = (b + 1).toByte
+      assertEquals(expectedValue, gotByteArray(b))
+    }
+  }
+
+  @Test
+  def `should write SMALLINT as neo4j integer`(): Unit = {
+    val id = java.util.UUID.randomUUID().toString
+    val df = sparkSession.sql(s"SELECT '$id' AS id, CAST(5 AS SMALLINT) AS short")
+
+    df.write
+      .format(classOf[DataSource].getName)
+      .mode(SaveMode.Append)
+      .option("url", SparkConnectorScalaSuiteIT.server.getBoltUrl)
+      .option("labels", "Short")
+      .save()
+
+    val wantType = DataTypes.ShortType
+    val gotType = df.schema("short").dataType
+    assertTrue(wantType == gotType, s"expected Spark to pick ${wantType.simpleString} but it was $gotType")
+
+    val gotByte = SparkConnectorScalaSuiteIT.session().run(
+      s"""MATCH (b:Short {id: '$id'})
+         |RETURN b.short AS short
+         |""".stripMargin
+    ).single().get("short").asInt()
+
+    assertEquals(5, gotByte)
+  }
+
+  @Test
+  def `should write DECIMAL as neo4j string`(): Unit = {
+    val id = java.util.UUID.randomUUID().toString
+    val df = sparkSession.sql(s"SELECT '$id' AS id, CAST(5.42 AS DECIMAL(10, 2)) AS decimal")
+
+    df.write
+      .format(classOf[DataSource].getName)
+      .mode(SaveMode.Append)
+      .option("url", SparkConnectorScalaSuiteIT.server.getBoltUrl)
+      .option("labels", "Decimal")
+      .save()
+
+    val wantType = DecimalType(10, 2)
+    val gotType = df.schema("decimal").dataType
+    assertTrue(wantType.typeName == gotType.simpleString, s"expected Spark to pick $wantType but it was $gotType")
+
+    val gotDecimal = SparkConnectorScalaSuiteIT.session().run(
+      s"""MATCH (b:Decimal {id: '$id'})
+         |RETURN b.decimal AS decimal
+         |""".stripMargin
+    ).single().get("decimal").asString
+
+    assertEquals("5.42", gotDecimal)
   }
 
   @Test

--- a/src/test/scala/org/neo4j/spark/testsupport/SparkConnectorScalaBaseTSE.scala
+++ b/src/test/scala/org/neo4j/spark/testsupport/SparkConnectorScalaBaseTSE.scala
@@ -43,7 +43,6 @@ object SparkConnectorScalaBaseTSE {
 }
 
 class SparkConnectorScalaBaseTSE {
-
   val conf: SparkConf = SparkConnectorScalaSuiteIT.conf
   val ss: SparkSession = SparkConnectorScalaSuiteIT.ss
 


### PR DESCRIPTION
adds support to natively write these spark types to neo4j:

- Byte: will convert to Integer, therefore cannot read-back as Byte
- Short: will convert to Integer, therefore cannot read-back as Short
- Decimal: will convert to String, therefore cannot read-back as Decimal
- Binary: will convert to ByteArray and will be read-back as ByteArray
- TimestampNTZType: will convert to LocalDateTime

BREAKING CHANGE:

- already existing Timestamp now converts to ZonedDateTime, not LocalDateTime.

Before, writing a Timestamp would remove the timezone information. Now it will be normalized to UTC-time instead. If you want to retain old behaviour, please use TimestampNTZType or be mindful when you read the stamp.

Assuming you interpret time zone when reading and writing, you should not notice. But if you indeed intend to use LocalDateTime, this is moved and maps to TimestampNTZType

Cherry picked from (#816)