### PR TITLE
fix: omit scriptResult clause when script is not provided

### DIFF
--- a/src/main/scala/org/neo4j/spark/service/Neo4jQueryService.scala
+++ b/src/main/scala/org/neo4j/spark/service/Neo4jQueryService.scala
@@ -46,9 +46,9 @@ class Neo4jQueryWriteStrategy(
 ) extends Neo4jQueryStrategy {
 
   override def createStatementForQuery(options: Neo4jOptions): String = {
+    val scriptResult = Neo4jQueryStrategy.scriptResultClause(options)
     val preamble = if (withPreamble) fullPreamble(neo4j, options.tuning) else ""
-    s"""${preamble}WITH $$scriptResult AS ${Neo4jQueryStrategy.VARIABLE_SCRIPT_RESULT}
-       |UNWIND ${"$"}events AS ${Neo4jQueryStrategy.VARIABLE_EVENT}
+    s"""$preamble${scriptResult}UNWIND ${"$"}events AS ${Neo4jQueryStrategy.VARIABLE_EVENT}
        |${options.query.value}
        |""".stripMargin
   }
@@ -179,8 +179,9 @@ class Neo4jQueryReadStrategy(
       s"${options.query.value}"
     }
 
+    val scriptResult = Neo4jQueryStrategy.scriptResultClause(options)
     val preamble = if (withPreamble) fullPreamble(neo4j, options.tuning) else ""
-    s"${preamble}WITH $$scriptResult AS ${Neo4jQueryStrategy.VARIABLE_SCRIPT_RESULT} $limitedQuery"
+    s"$preamble$scriptResult$limitedQuery"
   }
 
   override def createStatementForRelationships(options: Neo4jOptions): String = {
@@ -549,6 +550,12 @@ object Neo4jQueryStrategy {
   val VARIABLE_EVENTS = "events"
   val VARIABLE_SCRIPT_RESULT = "scriptResult"
   val VARIABLE_STREAM = "stream"
+
+  def scriptResultClause(options: Neo4jOptions): String =
+    if (options.script != null && options.script.nonEmpty)
+      s"WITH $$scriptResult AS $VARIABLE_SCRIPT_RESULT "
+    else
+      ""
 }
 
 abstract class Neo4jQueryStrategy {

--- a/src/main/scala/org/neo4j/spark/service/SchemaService.scala
+++ b/src/main/scala/org/neo4j/spark/service/SchemaService.scala
@@ -845,7 +845,7 @@ class SchemaService(
         (session.executeRead(tx => tx.run(s"EXPLAIN $query").consume(), sessionTransactionConfig).queryType(), query)
       })
       .groupBy(_._1)
-      .mapValues(_.map(_._2))
+      .view.mapValues(_.map(_._2))
     val schemaQueries = queryMap.getOrElse(org.neo4j.driver.summary.QueryType.SCHEMA_WRITE, Seq.empty[String])
     schemaQueries.foreach(q => session.executeWrite(tx => tx.run(q).consume(), sessionTransactionConfig))
     val others = queryMap

--- a/src/main/scala/org/neo4j/spark/streaming/BaseStreamingPartitionReader.scala
+++ b/src/main/scala/org/neo4j/spark/streaming/BaseStreamingPartitionReader.scala
@@ -32,7 +32,6 @@ import org.neo4j.spark.service.PartitionPagination
 import org.neo4j.spark.streaming.BaseStreamingPartitionReader.offsetUsagePatterns
 import org.neo4j.spark.util.Neo4jImplicits._
 import org.neo4j.spark.util.Neo4jOptions
-import org.neo4j.spark.util.Neo4jTuningOptions
 import org.neo4j.spark.util.Neo4jUtil
 import org.neo4j.spark.util.QueryType._
 import org.neo4j.spark.util.StreamingFrom

--- a/src/test/scala/org/neo4j/spark/service/Neo4jQueryServiceTest.scala
+++ b/src/test/scala/org/neo4j/spark/service/Neo4jQueryServiceTest.scala
@@ -1169,7 +1169,7 @@ class Neo4jQueryServiceTest {
   }
 
   @Test
-  def testTuningWithVersion(): Unit = {
+  def testTuningAndVersionInclusionInCustomReadQuery(): Unit = {
     val options: java.util.Map[String, String] = new java.util.HashMap[String, String]()
     options.put(Neo4jOptions.URL, "bolt://localhost")
     options.put(QueryType.QUERY.toString.toLowerCase, "MATCH (o:Object) RETURN o")
@@ -1177,29 +1177,39 @@ class Neo4jQueryServiceTest {
     val tuningOptions = Neo4jTuningOptions.empty.copy(replan = "force", operatorEngine = "compiled")
     val neo4jOptions: Neo4jOptions = new Neo4jOptions(withTuning(options, tuningOptions))
 
-    val readActual = new Neo4jQueryService(
+    val actual = new Neo4jQueryService(
       neo4jOptions,
       new Neo4jQueryReadStrategy(neo4j(version(2025, 1), ENTERPRISE))
     ).createQuery().trim
 
     assertEquals(
       "CYPHER replan=force operatorEngine=compiled\nCYPHER 5 MATCH (o:Object) RETURN o",
-      readActual
+      actual
     )
+  }
 
-    val writeActual = new Neo4jQueryService(
+  @Test
+  def testTuningAndVersionInclusionInCustomWriteQuery(): Unit = {
+    val options: java.util.Map[String, String] = new java.util.HashMap[String, String]()
+    options.put(Neo4jOptions.URL, "bolt://localhost")
+    options.put(QueryType.QUERY.toString.toLowerCase, "MATCH (o:Object) RETURN o")
+
+    val tuningOptions = Neo4jTuningOptions.empty.copy(replan = "force", operatorEngine = "compiled")
+    val neo4jOptions: Neo4jOptions = new Neo4jOptions(withTuning(options, tuningOptions))
+
+    val actual = new Neo4jQueryService(
       neo4jOptions,
       new Neo4jQueryWriteStrategy(neo4j(version(2025, 1), ENTERPRISE), SaveMode.Overwrite)
     ).createQuery().trim
 
     assertEquals(
       "CYPHER replan=force operatorEngine=compiled\nCYPHER 5 UNWIND $events AS event\nMATCH (o:Object) RETURN o",
-      writeActual
+      actual
     )
   }
 
   @Test
-  def testScriptResultInclusionInCustomQuery(): Unit = {
+  def testScriptResultInclusionInCustomReadQuery(): Unit = {
     val options: java.util.Map[String, String] = new java.util.HashMap[String, String]()
     options.put(Neo4jOptions.URL, "bolt://localhost")
     options.put(QueryType.QUERY.toString.toLowerCase, "MATCH (o:Object) RETURN o")
@@ -1207,24 +1217,34 @@ class Neo4jQueryServiceTest {
 
     val neo4jOptions: Neo4jOptions = new Neo4jOptions(options)
 
-    val readActual = new Neo4jQueryService(
+    val actual = new Neo4jQueryService(
       neo4jOptions,
       new Neo4jQueryReadStrategy(neo4j(version(5, 0), COMMUNITY))
     ).createQuery().trim
 
     assertEquals(
       "WITH $scriptResult AS scriptResult MATCH (o:Object) RETURN o",
-      readActual
+      actual
     )
+  }
 
-    val writeActual = new Neo4jQueryService(
+  @Test
+  def testScriptResultInclusionInCustomWriteQuery(): Unit = {
+    val options: java.util.Map[String, String] = new java.util.HashMap[String, String]()
+    options.put(Neo4jOptions.URL, "bolt://localhost")
+    options.put(QueryType.QUERY.toString.toLowerCase, "MATCH (o:Object) RETURN o")
+    options.put("script", "return 'foo'")
+
+    val neo4jOptions: Neo4jOptions = new Neo4jOptions(options)
+
+    val actual = new Neo4jQueryService(
       neo4jOptions,
       new Neo4jQueryWriteStrategy(neo4j(version(5, 0), COMMUNITY), SaveMode.Overwrite)
     ).createQuery().trim
 
     assertEquals(
       "WITH $scriptResult AS scriptResult UNWIND $events AS event\nMATCH (o:Object) RETURN o",
-      writeActual
+      actual
     )
   }
 

--- a/src/test/scala/org/neo4j/spark/service/Neo4jQueryServiceTest.scala
+++ b/src/test/scala/org/neo4j/spark/service/Neo4jQueryServiceTest.scala
@@ -1199,7 +1199,7 @@ class Neo4jQueryServiceTest {
   }
 
   @Test
-  def testScriptResult(): Unit = {
+  def testScriptResultInclusionInCustomQuery(): Unit = {
     val options: java.util.Map[String, String] = new java.util.HashMap[String, String]()
     options.put(Neo4jOptions.URL, "bolt://localhost")
     options.put(QueryType.QUERY.toString.toLowerCase, "MATCH (o:Object) RETURN o")

--- a/src/test/scala/org/neo4j/spark/service/Neo4jQueryServiceTest.scala
+++ b/src/test/scala/org/neo4j/spark/service/Neo4jQueryServiceTest.scala
@@ -1050,7 +1050,7 @@ class Neo4jQueryServiceTest {
       )
     ).createQuery()
 
-    assertEquals(s"${prefix}WITH $$scriptResult AS scriptResult MATCH (p:Person) RETURN p SKIP 0 LIMIT 24", query)
+    assertEquals(s"${prefix}MATCH (p:Person) RETURN p SKIP 0 LIMIT 24", query)
   }
 
   @ParameterizedTest
@@ -1128,14 +1128,14 @@ class Neo4jQueryServiceTest {
           new Neo4jQueryReadStrategy(
             neo4j(version(5, 0), COMMUNITY)
           ),
-          "WITH $scriptResult AS scriptResult MATCH (o:Object) RETURN o"
+          "MATCH (o:Object) RETURN o"
         )
       case "WRITE" => (
           new Neo4jQueryWriteStrategy(
             neo4j(version(5, 0), COMMUNITY),
             SaveMode.Overwrite
           ),
-          "WITH $scriptResult AS scriptResult\nUNWIND $events AS event\nMATCH (o:Object) RETURN o"
+          "UNWIND $events AS event\nMATCH (o:Object) RETURN o"
         )
     }
 
@@ -1155,11 +1155,11 @@ class Neo4jQueryServiceTest {
     val (strategy, wantQuery) = mode match {
       case "READ" => (
           new Neo4jQueryReadStrategy(neo4j(version(5, 0), COMMUNITY), withPreamble = false),
-          "WITH $scriptResult AS scriptResult MATCH (o:Object) RETURN o"
+          "MATCH (o:Object) RETURN o"
         )
       case "WRITE" => (
           new Neo4jQueryWriteStrategy(neo4j(version(5, 0), COMMUNITY), SaveMode.Overwrite, withPreamble = false),
-          "WITH $scriptResult AS scriptResult\nUNWIND $events AS event\nMATCH (o:Object) RETURN o"
+          "UNWIND $events AS event\nMATCH (o:Object) RETURN o"
         )
     }
 
@@ -1183,7 +1183,7 @@ class Neo4jQueryServiceTest {
     ).createQuery().trim
 
     assertEquals(
-      "CYPHER replan=force operatorEngine=compiled\nCYPHER 5 WITH $scriptResult AS scriptResult MATCH (o:Object) RETURN o",
+      "CYPHER replan=force operatorEngine=compiled\nCYPHER 5 MATCH (o:Object) RETURN o",
       readActual
     )
 
@@ -1193,7 +1193,37 @@ class Neo4jQueryServiceTest {
     ).createQuery().trim
 
     assertEquals(
-      "CYPHER replan=force operatorEngine=compiled\nCYPHER 5 WITH $scriptResult AS scriptResult\nUNWIND $events AS event\nMATCH (o:Object) RETURN o",
+      "CYPHER replan=force operatorEngine=compiled\nCYPHER 5 UNWIND $events AS event\nMATCH (o:Object) RETURN o",
+      writeActual
+    )
+  }
+
+  @Test
+  def testScriptResult(): Unit = {
+    val options: java.util.Map[String, String] = new java.util.HashMap[String, String]()
+    options.put(Neo4jOptions.URL, "bolt://localhost")
+    options.put(QueryType.QUERY.toString.toLowerCase, "MATCH (o:Object) RETURN o")
+    options.put("script", "return 'foo'")
+
+    val neo4jOptions: Neo4jOptions = new Neo4jOptions(options)
+
+    val readActual = new Neo4jQueryService(
+      neo4jOptions,
+      new Neo4jQueryReadStrategy(neo4j(version(5, 0), COMMUNITY))
+    ).createQuery().trim
+
+    assertEquals(
+      "WITH $scriptResult AS scriptResult MATCH (o:Object) RETURN o",
+      readActual
+    )
+
+    val writeActual = new Neo4jQueryService(
+      neo4jOptions,
+      new Neo4jQueryWriteStrategy(neo4j(version(5, 0), COMMUNITY), SaveMode.Overwrite)
+    ).createQuery().trim
+
+    assertEquals(
+      "WITH $scriptResult AS scriptResult UNWIND $events AS event\nMATCH (o:Object) RETURN o",
       writeActual
     )
   }


### PR DESCRIPTION
With this PR we no longer include scriptResult clause in custom query when script option isn't provided.