### PR TITLE
fix: apoc byte array type is byte[]

### DIFF
--- a/common/src/main/scala/org/neo4j/spark/converter/TypeConverter.scala
+++ b/common/src/main/scala/org/neo4j/spark/converter/TypeConverter.scala
@@ -127,6 +127,7 @@ class CypherToSparkTypeConverter(options: Neo4jOptions) extends TypeConverter[St
       case "TimeArray" | "LocalTimeArray"         => DataTypes.createArrayType(timeType)
       case "DateArray" | "LocalDateArray"         => DataTypes.createArrayType(DataTypes.DateType)
       case "DurationArray"                        => DataTypes.createArrayType(durationType)
+      case "byte[]"                               => DataTypes.BinaryType
       // Default is String
       case _ => DataTypes.StringType
     }

--- a/spark-3/src/test/scala/org/neo4j/spark/DataSourceReaderNeo4jWithApocTSE.scala
+++ b/spark-3/src/test/scala/org/neo4j/spark/DataSourceReaderNeo4jWithApocTSE.scala
@@ -17,8 +17,6 @@
 package org.neo4j.spark
 
 import org.junit.Assert.assertEquals
-import org.junit.Assume
-import org.junit.BeforeClass
 import org.junit.Test
 import org.neo4j.driver.SessionConfig
 import org.neo4j.driver.Transaction
@@ -89,4 +87,26 @@ class DataSourceReaderNeo4jWithApocTSE extends SparkConnectorScalaBaseWithApocTS
     assertEquals(1, df.count())
   }
 
+  @Test
+  def testApocByteArrayRead(): Unit = {
+    val bytes = "hello, world!".map(_.toByte).toArray
+    val parameters = new java.util.HashMap[String, Object]()
+    parameters.put("bytes", bytes)
+
+    SparkConnectorScalaSuiteWithApocIT.session()
+      .writeTransaction((tx: Transaction) => tx.run("CREATE (h:Hello {b: $bytes})", parameters).consume())
+
+    val df = ss.read.format(classOf[DataSource].getName)
+      .option("url", SparkConnectorScalaSuiteWithApocIT.server.getBoltUrl)
+      .option("labels", "Hello")
+      .load()
+
+    val res = df.select("b").collect()
+    assertEquals(1, res.length)
+    val gotBytes = res.head.getAs[Array[Byte]](0)
+
+    for (i <- bytes.indices) {
+      assertEquals(bytes(i), gotBytes(i))
+    }
+  }
 }


### PR DESCRIPTION
apoc exposes byte arrays as "byte[]" which was missing from our cases
in the TypeConverter.scala.

this PR adds a test case for it and fixes the case.

Note: this is backported from https://github.com/neo4j/neo4j-spark-connector/pull/934