### PR TITLE
fix: neo4j options should always validate

### DIFF
--- a/src/main/scala/org/neo4j/spark/DataSource.scala
+++ b/src/main/scala/org/neo4j/spark/DataSource.scala
@@ -79,6 +79,7 @@ class DataSource extends TableProvider
         Neo4jOptions.fromSession(SparkSession.getActiveSession, caseInsensitiveStringMap.asCaseSensitiveMap())
     }
 
+    ValidateNeo4jOptionsConsistency(neo4jOptions).validate()
     neo4jOptions
   }
 

--- a/src/main/scala/org/neo4j/spark/util/Validations.scala
+++ b/src/main/scala/org/neo4j/spark/util/Validations.scala
@@ -219,7 +219,6 @@ case class ValidateWrite(
     val schemaService = new SchemaService(neo4j, neo4jOptions, cache)
     try {
       ValidateConnection(neo4jOptions, jobId).validate()
-      ValidateNeo4jOptionsConsistency(neo4jOptions).validate()
       ValidateSchemaMetadataWrite(neo4jOptions, saveMode).validate()
 
       neo4jOptions.query.queryType match {
@@ -275,7 +274,6 @@ case class ValidateRead(neo4j: Neo4j, neo4jOptions: Neo4jOptions, jobId: String)
     val schemaService = new SchemaService(neo4j, neo4jOptions, cache)
     try {
       ValidateConnection(neo4jOptions, jobId).validate()
-      ValidateNeo4jOptionsConsistency(neo4jOptions).validate()
 
       neo4jOptions.query.queryType match {
         case QueryType.LABELS => {


### PR DESCRIPTION
Spark itself can actually call `DataSource#inferSchema()`. Therefore it
is not enough to validate Neo4jOptions during reads and writes only.
In the case where Spark requests a schema inference, before reads or
writes take place, we must remember to validate the options.

Before this commit, we only validated options on read and writes.
This commit updates so that we always validate options right as we
create the Neo4jOptions object.