### PR TITLE
fix: neo4j options should always validate

### DIFF
--- a/common/src/main/scala/org/neo4j/spark/util/Validations.scala
+++ b/common/src/main/scala/org/neo4j/spark/util/Validations.scala
@@ -267,7 +267,6 @@ case class ValidateWrite(
     val schemaService = new SchemaService(neo4j, neo4jOptions, cache)
     try {
       ValidateConnection(neo4jOptions, jobId).validate()
-      ValidateNeo4jOptionsConsistency(neo4jOptions).validate()
       ValidateSchemaMetadataWrite(neo4jOptions, saveMode).validate()
 
       neo4jOptions.query.queryType match {
@@ -334,7 +333,6 @@ case class ValidateRead(neo4j: Neo4j, neo4jOptions: Neo4jOptions, jobId: String)
     val schemaService = new SchemaService(neo4j, neo4jOptions, cache)
     try {
       ValidateConnection(neo4jOptions, jobId).validate()
-      ValidateNeo4jOptionsConsistency(neo4jOptions).validate()
 
       neo4jOptions.query.queryType match {
         case QueryType.LABELS => {

--- a/spark-3/src/main/scala/org/neo4j/spark/DataSource.scala
+++ b/spark-3/src/main/scala/org/neo4j/spark/DataSource.scala
@@ -31,6 +31,7 @@ import org.neo4j.spark.util.Neo4jDriverOptions
 import org.neo4j.spark.util.Neo4jOptions
 import org.neo4j.spark.util.Neo4jUtil
 import org.neo4j.spark.util.ValidateConnection
+import org.neo4j.spark.util.ValidateNeo4jOptionsConsistency
 import org.neo4j.spark.util.ValidateSparkMinVersion
 import org.neo4j.spark.util.Validations
 
@@ -85,6 +86,7 @@ class DataSource extends TableProvider
         Neo4jOptions.fromSession(SparkSession.getActiveSession, caseInsensitiveStringMap.asCaseSensitiveMap())
     }
 
+    ValidateNeo4jOptionsConsistency(neo4jOptions).validate()
     neo4jOptions
   }
 


### PR DESCRIPTION
Spark itself can actually call `DataSource#inferSchema()`. Therefore it
is not enough to validate Neo4jOptions during reads and writes only.
In the case where Spark requests a schema inference, before reads or
writes take place, we must remember to validate the options.

Before this commit, we only validated options on read and writes.
This commit updates so that we always validate options right as we
create the Neo4jOptions object.

Back port of PR #961