### PR TITLE
refactor: use cypher dsl on read/write queries we generate

### DIFF
--- a/src/main/scala/org/neo4j/spark/service/Neo4jQueryService.scala
+++ b/src/main/scala/org/neo4j/spark/service/Neo4jQueryService.scala
@@ -29,10 +29,12 @@ import org.neo4j.caniuse.Neo4j
 import org.neo4j.cypherdsl.core._
 import org.neo4j.spark.cypher.CypherPreamble.fullPreamble
 import org.neo4j.spark.cypher.CypherRenderer
-import org.neo4j.spark.service.Neo4jQueryStrategy.unwindEventsClause
+import org.neo4j.spark.service.Neo4jQueryStrategy.VARIABLE_EVENT
+import org.neo4j.spark.service.Neo4jQueryStrategy.unwindEventsAsEvent
 import org.neo4j.spark.util.Neo4jImplicits._
 import org.neo4j.spark.util.Neo4jNodeMetadata
 import org.neo4j.spark.util.Neo4jOptions
+import org.neo4j.spark.util.Neo4jRelationshipMetadata
 import org.neo4j.spark.util.Neo4jTuningOptions
 import org.neo4j.spark.util.Neo4jUtil
 import org.neo4j.spark.util.NodeSaveMode
@@ -50,26 +52,7 @@ class Neo4jQueryWriteStrategy(
   override def createStatementForQuery(options: Neo4jOptions): String = {
     val preamble = if (withPreamble) fullPreamble(neo4j, options) else ""
     val scriptResult = Neo4jQueryStrategy.scriptResultClause(options)
-    val prefixedUnwind = preamble + scriptResult + unwindEventsClause
-    prefixedUnwind + options.query.value
-  }
-
-  private def cypherNode(nodeData: Neo4jNodeMetadata, alias: String): Node = {
-    val n = Cypher.node(nodeData.labels.head, nodeData.labels.tail: _*).named(alias)
-
-    val keyProperties =
-      nodeData.nodeKeys.toSeq.flatMap { case (_, keyName) =>
-        Seq(
-          keyName,
-          Cypher.property(Cypher.name(Neo4jQueryStrategy.VARIABLE_EVENT), Neo4jWriteMappingStrategy.KEYS, keyName)
-        )
-      }
-
-    if (keyProperties.nonEmpty) {
-      n.withProperties(keyProperties: _*)
-    } else {
-      n
-    }
+    preamble + scriptResult + unwindEventsAsEvent + options.query.value
   }
 
   private def createPropsList(props: Map[String, String], prefix: String): String = {
@@ -99,66 +82,145 @@ class Neo4jQueryWriteStrategy(
   }
 
   override def createStatementForRelationships(options: Neo4jOptions): String = {
-    val relationshipKeyword = keywordFromSaveMode(saveMode)
-    val sourceKeyword = keywordFromSaveMode(options.relationshipMetadata.sourceSaveMode)
-    val targetKeyword = keywordFromSaveMode(options.relationshipMetadata.targetSaveMode)
+    val sourceNode = cypherNode(options.relationshipMetadata.source, Neo4jUtil.RELATIONSHIP_SOURCE_ALIAS, "source")
+    val targetNode = cypherNode(options.relationshipMetadata.target, Neo4jUtil.RELATIONSHIP_TARGET_ALIAS, "target")
 
-    val relationship = options.relationshipMetadata.relationshipType.quote()
+    val relationshipRel =
+      cypherRelationship(sourceNode, targetNode, options.relationshipMetadata, Neo4jUtil.RELATIONSHIP_ALIAS)
 
-    val sourceLabels = options.relationshipMetadata.source.labels
-      .map(_.quote())
-      .mkString(":")
-
-    val targetLabels = options.relationshipMetadata.target.labels
-      .map(_.quote())
-      .mkString(":")
-
-    val sourceKeys = createPropsList(
-      options.relationshipMetadata.source.nodeKeys,
-      s"source.${Neo4jWriteMappingStrategy.KEYS}"
-    )
-    val targetKeys = createPropsList(
-      options.relationshipMetadata.target.nodeKeys,
-      s"target.${Neo4jWriteMappingStrategy.KEYS}"
-    )
-    val sourceQueryPart = createQueryPart(sourceKeyword, sourceLabels, sourceKeys, Neo4jUtil.RELATIONSHIP_SOURCE_ALIAS)
-    val targetQueryPart = createQueryPart(targetKeyword, targetLabels, targetKeys, Neo4jUtil.RELATIONSHIP_TARGET_ALIAS)
-
-    val withQueryPart = if (sourceKeyword != "MATCH" && targetKeyword == "MATCH")
-      "\nWITH source, event"
-    else {
-      ""
-    }
-
-    val relKeys = if (options.relationshipMetadata.relationshipKeys.nonEmpty) {
-      options.relationshipMetadata.relationshipKeys
-        .map(t =>
-          s"${t._2.quote()}: ${Neo4jQueryStrategy.VARIABLE_EVENT}.${Neo4jUtil.RELATIONSHIP_ALIAS}.${Neo4jWriteMappingStrategy.KEYS}.${t._1.quote()}"
+    val sourceNodeClause = options.relationshipMetadata.sourceSaveMode match {
+      case NodeSaveMode.Overwrite => Cypher.merge(sourceNode).mutate(
+          sourceNode,
+          Cypher.property(Cypher.name(VARIABLE_EVENT), "source", "properties")
         )
-        .mkString("{", ", ", "}")
-    } else {
-      ""
+      case NodeSaveMode.Append => Cypher.create(sourceNode).mutate(
+          sourceNode,
+          Cypher.property(Cypher.name(VARIABLE_EVENT), "source", "properties")
+        )
+      case NodeSaveMode.Match => Cypher.`match`(sourceNode)
     }
 
-    s"""${fullPreamble(neo4j, options)}UNWIND ${"$"}events AS ${Neo4jQueryStrategy.VARIABLE_EVENT}
-       |$sourceQueryPart$withQueryPart
-       |$targetQueryPart
-       |$relationshipKeyword (${Neo4jUtil.RELATIONSHIP_SOURCE_ALIAS})-[${Neo4jUtil.RELATIONSHIP_ALIAS}:$relationship$relKeys]->(${Neo4jUtil.RELATIONSHIP_TARGET_ALIAS})
-       |SET ${Neo4jUtil.RELATIONSHIP_ALIAS} += ${Neo4jQueryStrategy.VARIABLE_EVENT}.${Neo4jUtil.RELATIONSHIP_ALIAS}.${Neo4jWriteMappingStrategy.PROPERTIES}
-       |""".stripMargin
+    val bothNodesClause =
+      if (
+        options.relationshipMetadata.sourceSaveMode != NodeSaveMode.Match && options.relationshipMetadata.targetSaveMode == NodeSaveMode.Match
+      ) {
+        val withClause = sourceNodeClause.`with`(Cypher.name("source"), Cypher.name("event"))
+
+        options.relationshipMetadata.targetSaveMode match {
+          case NodeSaveMode.Overwrite => withClause.merge(targetNode).mutate(
+              targetNode,
+              Cypher.property(Cypher.name(VARIABLE_EVENT), "target", "properties")
+            )
+          case NodeSaveMode.Append => withClause.create(sourceNode).mutate(
+              sourceNode,
+              Cypher.property(Cypher.name(VARIABLE_EVENT), "target", "properties")
+            )
+          case NodeSaveMode.Match => withClause.`match`(targetNode)
+        }
+      } else {
+        options.relationshipMetadata.targetSaveMode match {
+          case NodeSaveMode.Overwrite => sourceNodeClause.merge(sourceNode).mutate(
+              sourceNode,
+              Cypher.property(Cypher.name(VARIABLE_EVENT), "source", "properties")
+            )
+          case NodeSaveMode.Append => sourceNodeClause.create(sourceNode).mutate(
+              sourceNode,
+              Cypher.property(Cypher.name(VARIABLE_EVENT), "source", "properties")
+            )
+          case NodeSaveMode.Match if options.relationshipMetadata.sourceSaveMode == NodeSaveMode.Match =>
+            Cypher.`match`(sourceNode, targetNode)
+          case _ => throw new IllegalStateException(
+              "Impossible state due to the way we build the internal query. Please report this bug."
+            )
+        }
+      }
+
+    val preamble = if (withPreamble) fullPreamble(neo4j, options) else ""
+
+    val test = bothNodesClause
+      .merge(relationshipRel)
+      .mutate(relationshipRel, Cypher.property(Cypher.name(VARIABLE_EVENT), "rel", "properties"))
+      .build()
+
+    preamble + unwindEventsAsEvent + renderer.render(test)
   }
 
   override def createStatementForNodes(options: Neo4jOptions): String = {
     val node = cypherNode(options.nodeMetadata, "node")
+    val nodeMatcher = matcher(node, saveMode)
+    val preamble = if (withPreamble) fullPreamble(neo4j, options) else ""
+    val query = renderer.render(nodeMatcher.mutate(node, Neo4jQueryStrategy.eventProperties).build())
+    preamble + unwindEventsAsEvent + query
+  }
 
-    val clause = saveMode match {
-      case SaveMode.Overwrite                       => Cypher.merge(node)
-      case SaveMode.Append | SaveMode.ErrorIfExists => Cypher.create(node)
+  private def cypherNode(nodeData: Neo4jNodeMetadata, alias: String, propertyPrefix: String = ""): Node = {
+    val n = Cypher.node(nodeData.labels.head, nodeData.labels.tail: _*).named(alias)
+
+    val keyProperties = cypherNodeKeys(nodeData.nodeKeys.toSeq, propertyPrefix)
+
+    if (keyProperties.nonEmpty) {
+      n.withProperties(keyProperties: _*)
+    } else {
+      n
+    }
+  }
+
+  private def cypherRelationship(
+    source: Node,
+    target: Node,
+    relationshipData: Neo4jRelationshipMetadata,
+    alias: String
+  ): Relationship = {
+    val r = source.relationshipTo(target, relationshipData.relationshipType).named(Cypher.name(alias))
+    val keyProperties = cypherRelationshipKeys(relationshipData.relationshipKeys.toSeq)
+
+    if (keyProperties.nonEmpty) {
+      r.withProperties(keyProperties: _*)
+    } else {
+      r
+    }
+  }
+
+  private def cypherNodeKeys(mappings: Seq[(String, String)], propertyPrefix: String): Seq[Object] = {
+    mappings.flatMap { case (to, from) =>
+      Seq(
+        from,
+        if (propertyPrefix.isBlank) {
+          Cypher.property(Cypher.name(Neo4jQueryStrategy.VARIABLE_EVENT), Neo4jWriteMappingStrategy.KEYS, from)
+        } else {
+          Cypher.property(
+            Cypher.name(Neo4jQueryStrategy.VARIABLE_EVENT),
+            propertyPrefix,
+            Neo4jWriteMappingStrategy.KEYS,
+            from
+          )
+        }
+      )
+    }
+  }
+
+  // NOTE: I think this might be a bug because why would we map rel keys but not map node keys?
+  // NOTE: But we still need to keep this becasue we need to refactor, that means bringing with all the bugs
+  private def cypherRelationshipKeys(mappings: Seq[(String, String)]): Seq[Object] = {
+    mappings.flatMap { case (to, from) =>
+      Seq(
+        from,
+        Cypher.property(
+          Cypher.name(Neo4jQueryStrategy.VARIABLE_EVENT),
+          "rel",
+          Neo4jWriteMappingStrategy.KEYS,
+          to
+        )
+      )
+    }
+  }
+
+  private def matcher(entity: PatternElement, saveMode: SaveMode): StatementBuilder.OngoingUpdate = {
+    saveMode match {
+      case SaveMode.Overwrite                       => Cypher.merge(entity)
+      case SaveMode.Append | SaveMode.ErrorIfExists => Cypher.create(entity)
       case _ => throw new UnsupportedOperationException(s"SaveMode $saveMode not supported")
     }
-
-    val preamble = if (withPreamble) fullPreamble(neo4j, options) else ""
-    preamble + unwindEventsClause + renderer.render(clause.mutate(node, Neo4jQueryStrategy.eventProperties).build())
   }
 
   override def createStatementForGDS(options: Neo4jOptions): String =
@@ -571,9 +633,9 @@ object Neo4jQueryStrategy {
     else
       ""
 
-  val unwindEventsClause: String = s"UNWIND $$$VARIABLE_EVENTS AS $VARIABLE_EVENT "
+  val unwindEventsAsEvent: String = s"UNWIND $$$VARIABLE_EVENTS AS $VARIABLE_EVENT "
 
-  val eventProperties = Cypher.property(Cypher.name(VARIABLE_EVENT), Neo4jWriteMappingStrategy.PROPERTIES)
+  val eventProperties: Property = Cypher.property(Cypher.name(VARIABLE_EVENT), Neo4jWriteMappingStrategy.PROPERTIES)
 }
 
 abstract class Neo4jQueryStrategy {

--- a/src/main/scala/org/neo4j/spark/service/Neo4jQueryService.scala
+++ b/src/main/scala/org/neo4j/spark/service/Neo4jQueryService.scala
@@ -94,7 +94,7 @@ class Neo4jQueryWriteStrategy(
         case NodeSaveMode.Overwrite              => sourceMatcher.merge(targetNode).mutate(targetNode, targetPropsName)
         case NodeSaveMode.Append                 => sourceMatcher.create(targetNode).mutate(targetNode, targetPropsName)
         case NodeSaveMode.Match if isSourceMatch => Cypher.`match`(sourceNode).`match`(targetNode)
-        case _ => throw new IllegalStateException("Impossible state reached. Please report this as a bug.")
+        case _ => throw new IllegalStateException("Impossible query state reached. Please report this as a bug.")
       }
     }
 
@@ -122,7 +122,7 @@ class Neo4jQueryWriteStrategy(
     val preamble = if (withPreamble) fullPreamble(neo4j, options) else ""
     val query = renderer.render(nodeMatcher.mutate(node, eventProperties).build())
 
-    preamble + Neo4jQueryStrategy.unwindEventsAsEvent + query
+    preamble + unwindEventsAsEvent + query
   }
 
   private def cypherNode(nodeData: Neo4jNodeMetadata, alias: String, prefix: Boolean = false): Node = {
@@ -158,10 +158,10 @@ class Neo4jQueryWriteStrategy(
       Seq(
         from,
         if (propertyPrefix.isBlank) {
-          Cypher.property(Cypher.name(Neo4jQueryStrategy.VARIABLE_EVENT), Neo4jWriteMappingStrategy.KEYS, from)
+          Cypher.property(Cypher.name(VARIABLE_EVENT), Neo4jWriteMappingStrategy.KEYS, from)
         } else {
           Cypher.property(
-            Cypher.name(Neo4jQueryStrategy.VARIABLE_EVENT),
+            Cypher.name(VARIABLE_EVENT),
             propertyPrefix,
             Neo4jWriteMappingStrategy.KEYS,
             from
@@ -176,7 +176,7 @@ class Neo4jQueryWriteStrategy(
       Seq(
         from,
         Cypher.property(
-          Cypher.name(Neo4jQueryStrategy.VARIABLE_EVENT),
+          Cypher.name(VARIABLE_EVENT),
           "rel",
           Neo4jWriteMappingStrategy.KEYS,
           to
@@ -217,7 +217,7 @@ class Neo4jQueryReadStrategy(
       s"${options.query.value}"
     }
 
-    val scriptResult = Neo4jQueryStrategy.scriptResultClause(options)
+    val scriptResult = scriptResultClause(options)
     val preamble = if (withPreamble) fullPreamble(neo4j, options) else ""
     s"$preamble$scriptResult$limitedQuery"
   }

--- a/src/main/scala/org/neo4j/spark/service/Neo4jQueryService.scala
+++ b/src/main/scala/org/neo4j/spark/service/Neo4jQueryService.scala
@@ -55,32 +55,6 @@ class Neo4jQueryWriteStrategy(
     preamble + scriptResult + unwindEventsAsEvent + options.query.value
   }
 
-  private def createPropsList(props: Map[String, String], prefix: String): String = {
-    props
-      .map(key => {
-        s"${key._2.quote()}: ${Neo4jQueryStrategy.VARIABLE_EVENT}.$prefix.${key._2.quote()}"
-      }).mkString(", ")
-  }
-
-  private def keywordFromSaveMode(saveMode: Any): String = {
-    saveMode match {
-      case NodeSaveMode.Overwrite | SaveMode.Overwrite                                                 => "MERGE"
-      case NodeSaveMode.ErrorIfExists | SaveMode.ErrorIfExists | SaveMode.Append | NodeSaveMode.Append => "CREATE"
-      case NodeSaveMode.Match                                                                          => "MATCH"
-      case _ => throw new UnsupportedOperationException(s"SaveMode $saveMode not supported")
-    }
-  }
-
-  private def createQueryPart(keyword: String, labels: String, keys: String, alias: String): String = {
-    val setStatement = if (!keyword.equals("MATCH"))
-      s" SET $alias += ${Neo4jQueryStrategy.VARIABLE_EVENT}.$alias.${Neo4jWriteMappingStrategy.PROPERTIES}"
-    else ""
-    s"""$keyword ($alias${if (labels.isEmpty) "" else s":$labels"} ${
-        if (keys.isEmpty) ""
-        else s"{$keys}"
-      })$setStatement""".stripMargin
-  }
-
   override def createStatementForRelationships(options: Neo4jOptions): String = {
     val sourceNode = cypherNode(options.relationshipMetadata.source, Neo4jUtil.RELATIONSHIP_SOURCE_ALIAS, "source")
     val targetNode = cypherNode(options.relationshipMetadata.target, Neo4jUtil.RELATIONSHIP_TARGET_ALIAS, "target")
@@ -100,40 +74,40 @@ class Neo4jQueryWriteStrategy(
       case NodeSaveMode.Match => Cypher.`match`(sourceNode)
     }
 
-    val bothNodesClause =
-      if (
-        options.relationshipMetadata.sourceSaveMode != NodeSaveMode.Match && options.relationshipMetadata.targetSaveMode == NodeSaveMode.Match
-      ) {
-        val withClause = sourceNodeClause.`with`(Cypher.name("source"), Cypher.name("event"))
+    val isSourceMatch = options.relationshipMetadata.sourceSaveMode == NodeSaveMode.Match
+    val isTargetMatch = options.relationshipMetadata.targetSaveMode == NodeSaveMode.Match
 
-        options.relationshipMetadata.targetSaveMode match {
-          case NodeSaveMode.Overwrite => withClause.merge(targetNode).mutate(
-              targetNode,
-              Cypher.property(Cypher.name(VARIABLE_EVENT), "target", "properties")
-            )
-          case NodeSaveMode.Append => withClause.create(sourceNode).mutate(
-              sourceNode,
-              Cypher.property(Cypher.name(VARIABLE_EVENT), "target", "properties")
-            )
-          case NodeSaveMode.Match => withClause.`match`(targetNode)
-        }
-      } else {
-        options.relationshipMetadata.targetSaveMode match {
-          case NodeSaveMode.Overwrite => sourceNodeClause.merge(sourceNode).mutate(
-              sourceNode,
-              Cypher.property(Cypher.name(VARIABLE_EVENT), "source", "properties")
-            )
-          case NodeSaveMode.Append => sourceNodeClause.create(sourceNode).mutate(
-              sourceNode,
-              Cypher.property(Cypher.name(VARIABLE_EVENT), "source", "properties")
-            )
-          case NodeSaveMode.Match if options.relationshipMetadata.sourceSaveMode == NodeSaveMode.Match =>
-            Cypher.`match`(sourceNode, targetNode)
-          case _ => throw new IllegalStateException(
-              "Impossible state due to the way we build the internal query. Please report this bug."
-            )
-        }
+    val bothNodesClause = if (!isSourceMatch && isTargetMatch) {
+      val withClause = sourceNodeClause.`with`(Cypher.name("source"), Cypher.name("event"))
+
+      options.relationshipMetadata.targetSaveMode match {
+        case NodeSaveMode.Overwrite => withClause.merge(targetNode).mutate(
+            targetNode,
+            Cypher.property(Cypher.name(VARIABLE_EVENT), "target", "properties")
+          )
+        case NodeSaveMode.Append => withClause.create(sourceNode).mutate(
+            sourceNode,
+            Cypher.property(Cypher.name(VARIABLE_EVENT), "target", "properties")
+          )
+        case NodeSaveMode.Match => withClause.`match`(targetNode)
       }
+    } else {
+      options.relationshipMetadata.targetSaveMode match {
+        case NodeSaveMode.Overwrite => sourceNodeClause.merge(targetNode).mutate(
+            targetNode,
+            Cypher.property(Cypher.name(VARIABLE_EVENT), "target", "properties")
+          )
+        case NodeSaveMode.Append => sourceNodeClause.create(targetNode).mutate(
+            targetNode,
+            Cypher.property(Cypher.name(VARIABLE_EVENT), "target", "properties")
+          )
+        case NodeSaveMode.Match if options.relationshipMetadata.sourceSaveMode == NodeSaveMode.Match =>
+          Cypher.`match`(sourceNode, targetNode)
+        case _ => throw new IllegalStateException(
+            "Impossible state due to the way we build the internal query. Please report this bug."
+          )
+      }
+    }
 
     val preamble = if (withPreamble) fullPreamble(neo4j, options) else ""
 

--- a/src/main/scala/org/neo4j/spark/service/Neo4jQueryService.scala
+++ b/src/main/scala/org/neo4j/spark/service/Neo4jQueryService.scala
@@ -29,7 +29,9 @@ import org.neo4j.caniuse.Neo4j
 import org.neo4j.cypherdsl.core._
 import org.neo4j.spark.cypher.CypherPreamble.fullPreamble
 import org.neo4j.spark.cypher.CypherRenderer
+import org.neo4j.spark.service.Neo4jQueryStrategy.unwindEventsClause
 import org.neo4j.spark.util.Neo4jImplicits._
+import org.neo4j.spark.util.Neo4jNodeMetadata
 import org.neo4j.spark.util.Neo4jOptions
 import org.neo4j.spark.util.Neo4jTuningOptions
 import org.neo4j.spark.util.Neo4jUtil
@@ -40,16 +42,34 @@ import scala.jdk.CollectionConverters.SeqHasAsJava
 
 class Neo4jQueryWriteStrategy(
   private val neo4j: Neo4j,
+  private val renderer: CypherRenderer,
   private val saveMode: SaveMode,
   private val withPreamble: Boolean = true
 ) extends Neo4jQueryStrategy {
 
   override def createStatementForQuery(options: Neo4jOptions): String = {
-    val scriptResult = Neo4jQueryStrategy.scriptResultClause(options)
     val preamble = if (withPreamble) fullPreamble(neo4j, options) else ""
-    s"""$preamble${scriptResult}UNWIND ${"$"}events AS ${Neo4jQueryStrategy.VARIABLE_EVENT}
-       |${options.query.value}
-       |""".stripMargin
+    val scriptResult = Neo4jQueryStrategy.scriptResultClause(options)
+    val prefixedUnwind = preamble + scriptResult + unwindEventsClause
+    prefixedUnwind + options.query.value
+  }
+
+  private def cypherNode(nodeData: Neo4jNodeMetadata, alias: String): Node = {
+    val n = Cypher.node(nodeData.labels.head, nodeData.labels.tail: _*).named(alias)
+
+    val keyProperties =
+      nodeData.nodeKeys.toSeq.flatMap { case (_, keyName) =>
+        Seq(
+          keyName,
+          Cypher.property(Cypher.name(Neo4jQueryStrategy.VARIABLE_EVENT), Neo4jWriteMappingStrategy.KEYS, keyName)
+        )
+      }
+
+    if (keyProperties.nonEmpty) {
+      n.withProperties(keyProperties: _*)
+    } else {
+      n
+    }
   }
 
   private def createPropsList(props: Map[String, String], prefix: String): String = {
@@ -129,21 +149,16 @@ class Neo4jQueryWriteStrategy(
   }
 
   override def createStatementForNodes(options: Neo4jOptions): String = {
-    val keyword = keywordFromSaveMode(saveMode)
+    val node = cypherNode(options.nodeMetadata, "node")
 
-    val labels = options.nodeMetadata.labels
-      .map(_.quote())
-      .mkString(":")
+    val clause = saveMode match {
+      case SaveMode.Overwrite                       => Cypher.merge(node)
+      case SaveMode.Append | SaveMode.ErrorIfExists => Cypher.create(node)
+      case _ => throw new UnsupportedOperationException(s"SaveMode $saveMode not supported")
+    }
 
-    val keys = createPropsList(
-      options.nodeMetadata.nodeKeys,
-      Neo4jWriteMappingStrategy.KEYS
-    )
-
-    s"""${fullPreamble(neo4j, options)}UNWIND ${"$"}events AS ${Neo4jQueryStrategy.VARIABLE_EVENT}
-       |$keyword (node${if (labels.isEmpty) "" else s":$labels"} ${if (keys.isEmpty) "" else s"{$keys}"})
-       |SET node += ${Neo4jQueryStrategy.VARIABLE_EVENT}.${Neo4jWriteMappingStrategy.PROPERTIES}
-       |""".stripMargin
+    val preamble = if (withPreamble) fullPreamble(neo4j, options) else ""
+    preamble + unwindEventsClause + renderer.render(clause.mutate(node, Neo4jQueryStrategy.eventProperties).build())
   }
 
   override def createStatementForGDS(options: Neo4jOptions): String =
@@ -555,6 +570,10 @@ object Neo4jQueryStrategy {
       s"WITH $$scriptResult AS $VARIABLE_SCRIPT_RESULT "
     else
       ""
+
+  val unwindEventsClause: String = s"UNWIND $$$VARIABLE_EVENTS AS $VARIABLE_EVENT "
+
+  val eventProperties = Cypher.property(Cypher.name(VARIABLE_EVENT), Neo4jWriteMappingStrategy.PROPERTIES)
 }
 
 abstract class Neo4jQueryStrategy {

--- a/src/main/scala/org/neo4j/spark/service/Neo4jQueryService.scala
+++ b/src/main/scala/org/neo4j/spark/service/Neo4jQueryService.scala
@@ -93,7 +93,7 @@ class Neo4jQueryWriteStrategy(
       options.relationshipMetadata.targetSaveMode match {
         case NodeSaveMode.Overwrite              => sourceMatcher.merge(targetNode).mutate(targetNode, targetPropsName)
         case NodeSaveMode.Append                 => sourceMatcher.create(targetNode).mutate(targetNode, targetPropsName)
-        case NodeSaveMode.Match if isSourceMatch => Cypher.`match`(sourceNode, targetNode)
+        case NodeSaveMode.Match if isSourceMatch => Cypher.`match`(sourceNode).`match`(targetNode)
         case _ => throw new IllegalStateException("Impossible state reached. Please report this as a bug.")
       }
     }

--- a/src/main/scala/org/neo4j/spark/service/Neo4jQueryService.scala
+++ b/src/main/scala/org/neo4j/spark/service/Neo4jQueryService.scala
@@ -30,13 +30,20 @@ import org.neo4j.cypherdsl.core._
 import org.neo4j.spark.cypher.CypherPreamble.fullPreamble
 import org.neo4j.spark.cypher.CypherRenderer
 import org.neo4j.spark.service.Neo4jQueryStrategy.VARIABLE_EVENT
+import org.neo4j.spark.service.Neo4jQueryStrategy.eventProperties
+import org.neo4j.spark.service.Neo4jQueryStrategy.relEventProperties
+import org.neo4j.spark.service.Neo4jQueryStrategy.scriptResultClause
 import org.neo4j.spark.service.Neo4jQueryStrategy.unwindEventsAsEvent
+import org.neo4j.spark.service.Neo4jWriteMappingStrategy.PROPERTIES
 import org.neo4j.spark.util.Neo4jImplicits._
 import org.neo4j.spark.util.Neo4jNodeMetadata
 import org.neo4j.spark.util.Neo4jOptions
 import org.neo4j.spark.util.Neo4jRelationshipMetadata
 import org.neo4j.spark.util.Neo4jTuningOptions
 import org.neo4j.spark.util.Neo4jUtil
+import org.neo4j.spark.util.Neo4jUtil.RELATIONSHIP_ALIAS
+import org.neo4j.spark.util.Neo4jUtil.RELATIONSHIP_SOURCE_ALIAS
+import org.neo4j.spark.util.Neo4jUtil.RELATIONSHIP_TARGET_ALIAS
 import org.neo4j.spark.util.NodeSaveMode
 import org.neo4j.spark.util.QueryType
 
@@ -51,91 +58,81 @@ class Neo4jQueryWriteStrategy(
 
   override def createStatementForQuery(options: Neo4jOptions): String = {
     val preamble = if (withPreamble) fullPreamble(neo4j, options) else ""
-    val scriptResult = Neo4jQueryStrategy.scriptResultClause(options)
+    val scriptResult = scriptResultClause(options)
+
     preamble + scriptResult + unwindEventsAsEvent + options.query.value
   }
 
   override def createStatementForRelationships(options: Neo4jOptions): String = {
-    val sourceNode = cypherNode(options.relationshipMetadata.source, Neo4jUtil.RELATIONSHIP_SOURCE_ALIAS, "source")
-    val targetNode = cypherNode(options.relationshipMetadata.target, Neo4jUtil.RELATIONSHIP_TARGET_ALIAS, "target")
+    val sourceNode = cypherNode(options.relationshipMetadata.source, RELATIONSHIP_SOURCE_ALIAS, prefix = true)
+    val sourcePropsName = Cypher.property(Cypher.name(VARIABLE_EVENT), RELATIONSHIP_SOURCE_ALIAS, PROPERTIES)
 
-    val relationshipRel =
-      cypherRelationship(sourceNode, targetNode, options.relationshipMetadata, Neo4jUtil.RELATIONSHIP_ALIAS)
+    val targetNode = cypherNode(options.relationshipMetadata.target, RELATIONSHIP_TARGET_ALIAS, prefix = true)
+    val targetPropsName = Cypher.property(Cypher.name(VARIABLE_EVENT), RELATIONSHIP_TARGET_ALIAS, PROPERTIES)
 
-    val sourceNodeClause = options.relationshipMetadata.sourceSaveMode match {
-      case NodeSaveMode.Overwrite => Cypher.merge(sourceNode).mutate(
-          sourceNode,
-          Cypher.property(Cypher.name(VARIABLE_EVENT), "source", "properties")
-        )
-      case NodeSaveMode.Append => Cypher.create(sourceNode).mutate(
-          sourceNode,
-          Cypher.property(Cypher.name(VARIABLE_EVENT), "source", "properties")
-        )
-      case NodeSaveMode.Match => Cypher.`match`(sourceNode)
-    }
+    val rel = cypherRelationship(sourceNode, targetNode, options.relationshipMetadata, RELATIONSHIP_ALIAS)
 
     val isSourceMatch = options.relationshipMetadata.sourceSaveMode == NodeSaveMode.Match
     val isTargetMatch = options.relationshipMetadata.targetSaveMode == NodeSaveMode.Match
 
-    val bothNodesClause = if (!isSourceMatch && isTargetMatch) {
-      val withClause = sourceNodeClause.`with`(Cypher.name("source"), Cypher.name("event"))
+    val sourceMatcher = options.relationshipMetadata.sourceSaveMode match {
+      case NodeSaveMode.Overwrite => Cypher.merge(sourceNode).mutate(sourceNode, sourcePropsName)
+      case NodeSaveMode.Append    => Cypher.create(sourceNode).mutate(sourceNode, sourcePropsName)
+      case NodeSaveMode.Match     => Cypher.`match`(sourceNode)
+    }
+
+    val nodesMatcher = if (!isSourceMatch && isTargetMatch) {
+      // inject a with statement
+      val sourceWith = sourceMatcher.`with`(Cypher.name(RELATIONSHIP_SOURCE_ALIAS), Cypher.name(VARIABLE_EVENT))
 
       options.relationshipMetadata.targetSaveMode match {
-        case NodeSaveMode.Overwrite => withClause.merge(targetNode).mutate(
-            targetNode,
-            Cypher.property(Cypher.name(VARIABLE_EVENT), "target", "properties")
-          )
-        case NodeSaveMode.Append => withClause.create(sourceNode).mutate(
-            sourceNode,
-            Cypher.property(Cypher.name(VARIABLE_EVENT), "target", "properties")
-          )
-        case NodeSaveMode.Match => withClause.`match`(targetNode)
+        case NodeSaveMode.Overwrite => sourceWith.merge(targetNode).mutate(targetNode, targetPropsName)
+        case NodeSaveMode.Append    => sourceWith.create(targetNode).mutate(targetNode, targetPropsName)
+        case NodeSaveMode.Match     => sourceWith.`match`(targetNode)
       }
     } else {
       options.relationshipMetadata.targetSaveMode match {
-        case NodeSaveMode.Overwrite => sourceNodeClause.merge(targetNode).mutate(
-            targetNode,
-            Cypher.property(Cypher.name(VARIABLE_EVENT), "target", "properties")
-          )
-        case NodeSaveMode.Append => sourceNodeClause.create(targetNode).mutate(
-            targetNode,
-            Cypher.property(Cypher.name(VARIABLE_EVENT), "target", "properties")
-          )
-        case NodeSaveMode.Match if options.relationshipMetadata.sourceSaveMode == NodeSaveMode.Match =>
-          Cypher.`match`(sourceNode, targetNode)
-        case _ => throw new IllegalStateException(
-            "Impossible state due to the way we build the internal query. Please report this bug."
-          )
+        case NodeSaveMode.Overwrite              => sourceMatcher.merge(targetNode).mutate(targetNode, targetPropsName)
+        case NodeSaveMode.Append                 => sourceMatcher.create(targetNode).mutate(targetNode, targetPropsName)
+        case NodeSaveMode.Match if isSourceMatch => Cypher.`match`(sourceNode, targetNode)
+        case _ => throw new IllegalStateException("Impossible state reached. Please report this as a bug.")
       }
     }
 
     val preamble = if (withPreamble) fullPreamble(neo4j, options) else ""
 
-    val test = bothNodesClause
-      .merge(relationshipRel)
-      .mutate(relationshipRel, Cypher.property(Cypher.name(VARIABLE_EVENT), "rel", "properties"))
+    val finalStatement = nodesMatcher
+      .merge(rel)
+      .mutate(rel, relEventProperties)
       .build()
 
-    preamble + unwindEventsAsEvent + renderer.render(test)
+    preamble + unwindEventsAsEvent + renderer.render(finalStatement)
   }
 
   override def createStatementForNodes(options: Neo4jOptions): String = {
     val node = cypherNode(options.nodeMetadata, "node")
-    val nodeMatcher = matcher(node, saveMode)
+
+    val nodeMatcher = saveMode match {
+      case SaveMode.Overwrite => Cypher.merge(node)
+      case SaveMode.Append    => Cypher.create(node)
+      case _                  => throw new UnsupportedOperationException(s"SaveMode $saveMode not supported")
+    }
+
     val preamble = if (withPreamble) fullPreamble(neo4j, options) else ""
-    val query = renderer.render(nodeMatcher.mutate(node, Neo4jQueryStrategy.eventProperties).build())
-    preamble + unwindEventsAsEvent + query
+    val query = renderer.render(nodeMatcher.mutate(node, eventProperties).build())
+
+    preamble + Neo4jQueryStrategy.unwindEventsAsEvent + query
   }
 
-  private def cypherNode(nodeData: Neo4jNodeMetadata, alias: String, propertyPrefix: String = ""): Node = {
-    val n = Cypher.node(nodeData.labels.head, nodeData.labels.tail: _*).named(alias)
-
+  private def cypherNode(nodeData: Neo4jNodeMetadata, alias: String, prefix: Boolean = false): Node = {
+    val propertyPrefix = if (prefix) alias else StringUtils.EMPTY
+    val node = Cypher.node(nodeData.labels.head, nodeData.labels.tail: _*).named(alias)
     val keyProperties = cypherNodeKeys(nodeData.nodeKeys.toSeq, propertyPrefix)
 
     if (keyProperties.nonEmpty) {
-      n.withProperties(keyProperties: _*)
+      node.withProperties(keyProperties: _*)
     } else {
-      n
+      node
     }
   }
 
@@ -145,18 +142,18 @@ class Neo4jQueryWriteStrategy(
     relationshipData: Neo4jRelationshipMetadata,
     alias: String
   ): Relationship = {
-    val r = source.relationshipTo(target, relationshipData.relationshipType).named(Cypher.name(alias))
+    val rel = source.relationshipTo(target, relationshipData.relationshipType).named(Cypher.name(alias))
     val keyProperties = cypherRelationshipKeys(relationshipData.relationshipKeys.toSeq)
 
     if (keyProperties.nonEmpty) {
-      r.withProperties(keyProperties: _*)
+      rel.withProperties(keyProperties: _*)
     } else {
-      r
+      rel
     }
   }
 
   private def cypherNodeKeys(mappings: Seq[(String, String)], propertyPrefix: String): Seq[Object] = {
-    mappings.flatMap { case (to, from) =>
+    mappings.flatMap { case (_, from) =>
       Seq(
         from,
         if (propertyPrefix.isBlank) {
@@ -173,8 +170,6 @@ class Neo4jQueryWriteStrategy(
     }
   }
 
-  // NOTE: I think this might be a bug because why would we map rel keys but not map node keys?
-  // NOTE: But we still need to keep this becasue we need to refactor, that means bringing with all the bugs
   private def cypherRelationshipKeys(mappings: Seq[(String, String)]): Seq[Object] = {
     mappings.flatMap { case (to, from) =>
       Seq(
@@ -186,14 +181,6 @@ class Neo4jQueryWriteStrategy(
           to
         )
       )
-    }
-  }
-
-  private def matcher(entity: PatternElement, saveMode: SaveMode): StatementBuilder.OngoingUpdate = {
-    saveMode match {
-      case SaveMode.Overwrite                       => Cypher.merge(entity)
-      case SaveMode.Append | SaveMode.ErrorIfExists => Cypher.create(entity)
-      case _ => throw new UnsupportedOperationException(s"SaveMode $saveMode not supported")
     }
   }
 
@@ -603,13 +590,15 @@ object Neo4jQueryStrategy {
 
   def scriptResultClause(options: Neo4jOptions): String =
     if (options.script != null && options.script.nonEmpty)
-      s"WITH $$scriptResult AS $VARIABLE_SCRIPT_RESULT "
+      s"WITH $$$VARIABLE_SCRIPT_RESULT AS $VARIABLE_SCRIPT_RESULT "
     else
       ""
 
   val unwindEventsAsEvent: String = s"UNWIND $$$VARIABLE_EVENTS AS $VARIABLE_EVENT "
 
-  val eventProperties: Property = Cypher.property(Cypher.name(VARIABLE_EVENT), Neo4jWriteMappingStrategy.PROPERTIES)
+  val eventProperties: Property = Cypher.property(Cypher.name(VARIABLE_EVENT), PROPERTIES)
+
+  val relEventProperties: Property = Cypher.property(Cypher.name(VARIABLE_EVENT), RELATIONSHIP_ALIAS, PROPERTIES)
 }
 
 abstract class Neo4jQueryStrategy {

--- a/src/main/scala/org/neo4j/spark/service/Neo4jQueryService.scala
+++ b/src/main/scala/org/neo4j/spark/service/Neo4jQueryService.scala
@@ -82,7 +82,6 @@ class Neo4jQueryWriteStrategy(
     }
 
     val nodesMatcher = if (!isSourceMatch && isTargetMatch) {
-      // inject a with statement
       val sourceWith = sourceMatcher.`with`(Cypher.name(RELATIONSHIP_SOURCE_ALIAS), Cypher.name(VARIABLE_EVENT))
 
       options.relationshipMetadata.targetSaveMode match {
@@ -99,13 +98,15 @@ class Neo4jQueryWriteStrategy(
       }
     }
 
-    val preamble = if (withPreamble) fullPreamble(neo4j, options) else ""
-
-    val finalStatement = nodesMatcher
-      .merge(rel)
+    val finalStatement = (saveMode match {
+      case SaveMode.Overwrite => nodesMatcher.merge(rel)
+      case SaveMode.Append    => nodesMatcher.create(rel)
+      case _                  => throw new UnsupportedOperationException(s"SaveMode $saveMode not supported")
+    })
       .mutate(rel, relEventProperties)
       .build()
 
+    val preamble = if (withPreamble) fullPreamble(neo4j, options) else ""
     preamble + unwindEventsAsEvent + renderer.render(finalStatement)
   }
 

--- a/src/main/scala/org/neo4j/spark/writer/BaseDataWriter.scala
+++ b/src/main/scala/org/neo4j/spark/writer/BaseDataWriter.scala
@@ -27,6 +27,7 @@ import org.neo4j.driver.Session
 import org.neo4j.driver.Transaction
 import org.neo4j.driver.Values
 import org.neo4j.driver.exceptions.ServiceUnavailableException
+import org.neo4j.spark.cypher.CypherRenderer
 import org.neo4j.spark.service._
 import org.neo4j.spark.util.DriverCache
 import org.neo4j.spark.util.Neo4jOptions
@@ -38,7 +39,6 @@ import java.time.Duration
 import java.util
 import java.util.concurrent.CountDownLatch
 import java.util.concurrent.locks.LockSupport
-
 import scala.annotation.tailrec
 import scala.jdk.CollectionConverters.MapHasAsJava
 
@@ -67,7 +67,7 @@ abstract class BaseDataWriter(
   private val retries = new CountDownLatch(options.transactionSettings.retries)
 
   private val query: String =
-    new Neo4jQueryService(options, new Neo4jQueryWriteStrategy(neo4j, saveMode)).createQuery()
+    new Neo4jQueryService(options, new Neo4jQueryWriteStrategy(neo4j, new CypherRenderer(neo4j, options), saveMode)).createQuery()
 
   private val metrics = DataWriterMetrics()
 

--- a/src/main/scala/org/neo4j/spark/writer/BaseDataWriter.scala
+++ b/src/main/scala/org/neo4j/spark/writer/BaseDataWriter.scala
@@ -39,6 +39,7 @@ import java.time.Duration
 import java.util
 import java.util.concurrent.CountDownLatch
 import java.util.concurrent.locks.LockSupport
+
 import scala.annotation.tailrec
 import scala.jdk.CollectionConverters.MapHasAsJava
 
@@ -67,7 +68,10 @@ abstract class BaseDataWriter(
   private val retries = new CountDownLatch(options.transactionSettings.retries)
 
   private val query: String =
-    new Neo4jQueryService(options, new Neo4jQueryWriteStrategy(neo4j, new CypherRenderer(neo4j, options), saveMode)).createQuery()
+    new Neo4jQueryService(
+      options,
+      new Neo4jQueryWriteStrategy(neo4j, new CypherRenderer(neo4j, options), saveMode)
+    ).createQuery()
 
   private val metrics = DataWriterMetrics()
 

--- a/src/test/scala/org/neo4j/spark/service/Neo4jQueryServiceTest.scala
+++ b/src/test/scala/org/neo4j/spark/service/Neo4jQueryServiceTest.scala
@@ -112,7 +112,7 @@ class Neo4jQueryServiceTest {
       neo4jOptions,
       new Neo4jQueryReadStrategy(
         neo4j,
-        CypherRenderer(neo4j, neo4jOptions),
+        new CypherRenderer(neo4j, neo4jOptions),
         partitionPagination = PartitionPagination(0, 0, TopN(100))
       )
     ).createQuery()
@@ -133,7 +133,7 @@ class Neo4jQueryServiceTest {
       neo4jOptions,
       new Neo4jQueryReadStrategy(
         neo4j,
-        CypherRenderer(neo4j, neo4jOptions),
+        new CypherRenderer(neo4j, neo4jOptions),
         Array.empty[Filter],
         PartitionPagination.EMPTY,
         Seq("name")
@@ -156,7 +156,7 @@ class Neo4jQueryServiceTest {
       neo4jOptions,
       new Neo4jQueryReadStrategy(
         neo4j,
-        CypherRenderer(neo4j, neo4jOptions),
+        new CypherRenderer(neo4j, neo4jOptions),
         Array.empty[Filter],
         PartitionPagination.EMPTY,
         List("name", "bornDate")
@@ -179,7 +179,7 @@ class Neo4jQueryServiceTest {
       neo4jOptions,
       new Neo4jQueryReadStrategy(
         neo4j,
-        CypherRenderer(neo4j, neo4jOptions),
+        new CypherRenderer(neo4j, neo4jOptions),
         Array.empty[Filter],
         PartitionPagination.EMPTY,
         List("<elementId>")
@@ -205,7 +205,7 @@ class Neo4jQueryServiceTest {
     val query: String =
       new Neo4jQueryService(
         neo4jOptions,
-        new Neo4jQueryReadStrategy(neo4j, CypherRenderer(neo4j, neo4jOptions), filters)
+        new Neo4jQueryReadStrategy(neo4j, new CypherRenderer(neo4j, neo4jOptions), filters)
       ).createQuery()
 
     val paramName = "$" + "name".toParameterName("John Doe")
@@ -230,7 +230,7 @@ class Neo4jQueryServiceTest {
     val query: String =
       new Neo4jQueryService(
         neo4jOptions,
-        new Neo4jQueryReadStrategy(neo4j, CypherRenderer(neo4j, neo4jOptions), filters)
+        new Neo4jQueryReadStrategy(neo4j, new CypherRenderer(neo4j, neo4jOptions), filters)
       ).createQuery()
 
     val nameParameterName = "$" + "name".toParameterName("John Doe")
@@ -262,7 +262,7 @@ class Neo4jQueryServiceTest {
     val query: String =
       new Neo4jQueryService(
         neo4jOptions,
-        new Neo4jQueryReadStrategy(neo4j, CypherRenderer(neo4j, neo4jOptions), filters)
+        new Neo4jQueryReadStrategy(neo4j, new CypherRenderer(neo4j, neo4jOptions), filters)
       ).createQuery()
 
     val nameParameterName = "$" + "name".toParameterName(null)
@@ -291,7 +291,7 @@ class Neo4jQueryServiceTest {
     val query: String =
       new Neo4jQueryService(
         neo4jOptions,
-        new Neo4jQueryReadStrategy(neo4j, CypherRenderer(neo4j, neo4jOptions), filters)
+        new Neo4jQueryReadStrategy(neo4j, new CypherRenderer(neo4j, neo4jOptions), filters)
       ).createQuery()
 
     val nameOneParameterName = "$" + "name".toParameterName("Person Name")
@@ -322,7 +322,7 @@ class Neo4jQueryServiceTest {
       neo4jOptions,
       new Neo4jQueryReadStrategy(
         neo4j,
-        CypherRenderer(neo4j, neo4jOptions),
+        new CypherRenderer(neo4j, neo4jOptions),
         Array.empty[Filter],
         PartitionPagination.EMPTY,
         List("source.name")
@@ -353,7 +353,7 @@ class Neo4jQueryServiceTest {
       neo4jOptions,
       new Neo4jQueryReadStrategy(
         neo4j,
-        CypherRenderer(neo4j, neo4jOptions),
+        new CypherRenderer(neo4j, neo4jOptions),
         Array.empty[Filter],
         PartitionPagination.EMPTY,
         List("source.name", "<source.elementId>")
@@ -388,7 +388,7 @@ class Neo4jQueryServiceTest {
       neo4jOptions,
       new Neo4jQueryReadStrategy(
         neo4j,
-        CypherRenderer(neo4j, neo4jOptions),
+        new CypherRenderer(neo4j, neo4jOptions),
         Array.empty[Filter],
         PartitionPagination(0, 0, TopN(limit = 100)),
         List("source.name", "<source.elementId>")
@@ -423,7 +423,7 @@ class Neo4jQueryServiceTest {
       neo4jOptions,
       new Neo4jQueryReadStrategy(
         neo4j,
-        CypherRenderer(neo4j, neo4jOptions),
+        new CypherRenderer(neo4j, neo4jOptions),
         Array.empty[Filter],
         PartitionPagination.EMPTY,
         List("source.name", "source.id", "rel.someprops", "target.date")
@@ -457,7 +457,7 @@ class Neo4jQueryServiceTest {
     val query: String =
       new Neo4jQueryService(
         neo4jOptions,
-        new Neo4jQueryReadStrategy(neo4j, CypherRenderer(neo4j, neo4jOptions), filters)
+        new Neo4jQueryReadStrategy(neo4j, new CypherRenderer(neo4j, neo4jOptions), filters)
       ).createQuery()
 
     val parameterName = "$" + "source.name".toParameterName("John Doe")
@@ -489,7 +489,7 @@ class Neo4jQueryServiceTest {
     val query: String =
       new Neo4jQueryService(
         neo4jOptions,
-        new Neo4jQueryReadStrategy(neo4j, CypherRenderer(neo4j, neo4jOptions), filters)
+        new Neo4jQueryReadStrategy(neo4j, new CypherRenderer(neo4j, neo4jOptions), filters)
       ).createQuery()
 
     val paramOneName = "$" + "source.name".toParameterName("John Doe")
@@ -523,7 +523,7 @@ class Neo4jQueryServiceTest {
     val query: String =
       new Neo4jQueryService(
         neo4jOptions,
-        new Neo4jQueryReadStrategy(neo4j, CypherRenderer(neo4j, neo4jOptions), filters)
+        new Neo4jQueryReadStrategy(neo4j, new CypherRenderer(neo4j, neo4jOptions), filters)
       ).createQuery()
 
     val sourceIdParameterName = "$" + "source.id".toParameterName(14)
@@ -558,7 +558,7 @@ class Neo4jQueryServiceTest {
     val query: String =
       new Neo4jQueryService(
         neo4jOptions,
-        new Neo4jQueryReadStrategy(neo4j, CypherRenderer(neo4j, neo4jOptions), filters)
+        new Neo4jQueryReadStrategy(neo4j, new CypherRenderer(neo4j, neo4jOptions), filters)
       ).createQuery()
 
     val parameterNames: Map[String, String] = HashMap(
@@ -604,7 +604,7 @@ class Neo4jQueryServiceTest {
     val query: String =
       new Neo4jQueryService(
         neo4jOptions,
-        new Neo4jQueryReadStrategy(neo4j, CypherRenderer(neo4j, neo4jOptions), filters)
+        new Neo4jQueryReadStrategy(neo4j, new CypherRenderer(neo4j, neo4jOptions), filters)
       ).createQuery()
 
     val parameterNames = Map(
@@ -660,7 +660,7 @@ class Neo4jQueryServiceTest {
     val query: String =
       new Neo4jQueryService(
         neo4jOptions,
-        new Neo4jQueryReadStrategy(neo4j, CypherRenderer(neo4j, neo4jOptions), filters)
+        new Neo4jQueryReadStrategy(neo4j, new CypherRenderer(neo4j, neo4jOptions), filters)
       ).createQuery()
 
     val parameterNames = Map(
@@ -717,9 +717,9 @@ class Neo4jQueryServiceTest {
     val options: java.util.Map[String, String] = new java.util.HashMap[String, String]()
     options.put(Neo4jOptions.URL, "bolt://localhost")
     options.put("relationship", "BOUGHT")
-    options.put("relationship.source.labels", "Person")
+    options.put("relationship.source.labels", ":Person")
     options.put("relationship.source.node.keys", "FirstName:name,LastName:lastName")
-    options.put("relationship.target.labels", "Product")
+    options.put("relationship.target.labels", ":Product:Merch")
     options.put("relationship.target.node.keys", "ProductPrice:price,ProductId:id")
 
     options.put(Neo4jOptions.CYPHER_VERSION, customCypherVersion)
@@ -730,12 +730,12 @@ class Neo4jQueryServiceTest {
 
     assertEquals(
       s"""${prefix}UNWIND $$events AS event
-         |MATCH (source:Person {name: event.source.keys.name, lastName: event.source.keys.lastName})
-         |MATCH (target:Product {price: event.target.keys.price, id: event.target.keys.id})
-         |MERGE (source)-[rel:BOUGHT]->(target)
+         |MATCH (source:`Person` {name: event.source.keys.name, lastName: event.source.keys.lastName}),
+         |(target:`Product`:`Merch` {price: event.target.keys.price, id: event.target.keys.id})
+         |MERGE (source)-[rel:`BOUGHT`]->(target)
          |SET rel += event.rel.properties
-         |""".stripMargin,
-      query.stripMargin
+         |""".stripMargin.replaceAll("\n", " ").trim,
+      query.trim
     )
   }
 
@@ -760,13 +760,13 @@ class Neo4jQueryServiceTest {
 
     assertEquals(
       s"""${prefix}UNWIND $$events AS event
-         |MERGE (source:Person {name: event.source.keys.name, lastName: event.source.keys.lastName}) SET source += event.source.properties
+         |MERGE (source:`Person` {name: event.source.keys.name, lastName: event.source.keys.lastName}) SET source += event.source.properties
          |WITH source, event
-         |MATCH (target:Product {price: event.target.keys.price, id: event.target.keys.id})
-         |MERGE (source)-[rel:BOUGHT]->(target)
+         |MATCH (target:`Product` {price: event.target.keys.price, id: event.target.keys.id})
+         |MERGE (source)-[rel:`BOUGHT`]->(target)
          |SET rel += event.rel.properties
-         |""".stripMargin,
-      query.stripMargin
+         |""".stripMargin.replaceAll("\n", " ").trim,
+      query.trim
     )
   }
 
@@ -777,7 +777,7 @@ class Neo4jQueryServiceTest {
     options.put(Neo4jOptions.URL, "bolt://localhost")
     options.put("relationship", "DID BUY")
     options.put("relationship.save.strategy", "keys")
-    options.put("relationship.source.labels", "Person")
+    options.put("relationship.source.labels", ":Person:Customer")
     options.put("relationship.source.save.mode", "Overwrite")
     options.put("relationship.source.node.keys", "first name,last name")
     options.put("relationship.target.labels", "Product")
@@ -794,13 +794,13 @@ class Neo4jQueryServiceTest {
 
     assertEquals(
       s"""|${prefix}UNWIND $$events AS event
-          |MERGE (source:Person {`first name`: event.source.keys.`first name`, `last name`: event.source.keys.`last name`}) SET source += event.source.properties
+          |MERGE (source:`Person`:`Customer` {`first name`: event.source.keys.`first name`, `last name`: event.source.keys.`last name`}) SET source += event.source.properties
           |WITH source, event
-          |MATCH (target:Product {`article number`: event.target.keys.`article number`})
-          |MERGE (source)-[rel:`DID BUY`{`transaction identifier`: event.rel.keys.transactionId}]->(target)
+          |MATCH (target:`Product` {`article number`: event.target.keys.`article number`})
+          |MERGE (source)-[rel:`DID BUY` {`transaction identifier`: event.rel.keys.transactionId}]->(target)
           |SET rel += event.rel.properties
-          |""".stripMargin,
-      query
+          |""".stripMargin.replaceAll("\n", " ").trim,
+      query.trim
     )
   }
 
@@ -818,7 +818,7 @@ class Neo4jQueryServiceTest {
       neo4jOptions,
       new Neo4jQueryReadStrategy(
         neo4j,
-        CypherRenderer(neo4j, neo4jOptions),
+        new CypherRenderer(neo4j, neo4jOptions),
         Array.empty[Filter],
         PartitionPagination.EMPTY,
         Seq("name", "SUM(DISTINCT age)", "SUM(age)"),
@@ -839,7 +839,7 @@ class Neo4jQueryServiceTest {
       neo4jOptions,
       new Neo4jQueryReadStrategy(
         neo4j,
-        CypherRenderer(neo4j, neo4jOptions),
+        new CypherRenderer(neo4j, neo4jOptions),
         Array.empty[Filter],
         PartitionPagination.EMPTY,
         Seq("name", "COUNT(DISTINCT name)", "COUNT(name)"),
@@ -859,7 +859,7 @@ class Neo4jQueryServiceTest {
       neo4jOptions,
       new Neo4jQueryReadStrategy(
         neo4j,
-        CypherRenderer(neo4j, neo4jOptions),
+        new CypherRenderer(neo4j, neo4jOptions),
         Array.empty[Filter],
         PartitionPagination.EMPTY,
         Seq("name", "MAX(age)", "MIN(age)"),
@@ -893,7 +893,7 @@ class Neo4jQueryServiceTest {
       neo4jOptions,
       new Neo4jQueryReadStrategy(
         neo4j,
-        CypherRenderer(neo4j, neo4jOptions),
+        new CypherRenderer(neo4j, neo4jOptions),
         Array.empty,
         PartitionPagination.EMPTY,
         List("source.fullName", "SUM(DISTINCT `target.price`)", "SUM(`target.price`)"),
@@ -919,7 +919,7 @@ class Neo4jQueryServiceTest {
       neo4jOptions,
       new Neo4jQueryReadStrategy(
         neo4j,
-        CypherRenderer(neo4j, neo4jOptions),
+        new CypherRenderer(neo4j, neo4jOptions),
         Array.empty,
         PartitionPagination.EMPTY,
         List("source.fullName", "COUNT(DISTINCT `target.id`)", "COUNT(`target.id`)"),
@@ -943,7 +943,7 @@ class Neo4jQueryServiceTest {
       neo4jOptions,
       new Neo4jQueryReadStrategy(
         neo4j,
-        CypherRenderer(neo4j, neo4jOptions),
+        new CypherRenderer(neo4j, neo4jOptions),
         Array.empty,
         PartitionPagination.EMPTY,
         List("source.fullName", "MAX(`target.price`)", "MIN(`target.price`)"),
@@ -978,7 +978,7 @@ class Neo4jQueryServiceTest {
       neo4jOptions,
       new Neo4jQueryReadStrategy(
         neo4j,
-        CypherRenderer(neo4j, neo4jOptions),
+        new CypherRenderer(neo4j, neo4jOptions),
         partitionPagination = PartitionPagination(
           0,
           0,
@@ -1012,7 +1012,7 @@ class Neo4jQueryServiceTest {
       neo4jOptions,
       new Neo4jQueryReadStrategy(
         neo4j,
-        CypherRenderer(neo4j, neo4jOptions),
+        new CypherRenderer(neo4j, neo4jOptions),
         requiredColumns = Array("name").toIndexedSeq,
         partitionPagination = PartitionPagination(
           0,
@@ -1050,7 +1050,7 @@ class Neo4jQueryServiceTest {
       neo4jOptions,
       new Neo4jQueryReadStrategy(
         neo4j,
-        CypherRenderer(neo4j, neo4jOptions),
+        new CypherRenderer(neo4j, neo4jOptions),
         Array.empty[Filter],
         PartitionPagination(
           0,
@@ -1094,7 +1094,7 @@ class Neo4jQueryServiceTest {
       neo4jOptions,
       new Neo4jQueryReadStrategy(
         neo4j,
-        CypherRenderer(neo4j, neo4jOptions),
+        new CypherRenderer(neo4j, neo4jOptions),
         Array.empty[Filter],
         PartitionPagination(
           0,
@@ -1138,7 +1138,7 @@ class Neo4jQueryServiceTest {
       neo4jOptions,
       new Neo4jQueryReadStrategy(
         neo4j,
-        CypherRenderer(neo4j, neo4jOptions),
+        new CypherRenderer(neo4j, neo4jOptions),
         Array.empty[Filter],
         PartitionPagination(
           0,
@@ -1185,7 +1185,7 @@ class Neo4jQueryServiceTest {
 
     val writeService = new Neo4jQueryService(
       neo4jOptions,
-      new Neo4jQueryWriteStrategy(neo4jInfo, CypherRenderer(neo4jInfo, neo4jOptions), SaveMode.Overwrite)
+      new Neo4jQueryWriteStrategy(neo4jInfo, new CypherRenderer(neo4jInfo, neo4jOptions), SaveMode.Overwrite)
     )
 
     val wantQuery = "UNWIND $events AS event MERGE (node:`Person`) SET node += event.properties"
@@ -1225,11 +1225,13 @@ class Neo4jQueryServiceTest {
 
     val writeService = new Neo4jQueryService(
       neo4jOptions,
-      new Neo4jQueryWriteStrategy(neo4jInfo, CypherRenderer(neo4jInfo, neo4jOptions), SaveMode.Overwrite)
+      new Neo4jQueryWriteStrategy(neo4jInfo, new CypherRenderer(neo4jInfo, neo4jOptions), SaveMode.Overwrite)
     )
-
-    val wantQuery =
-      "UNWIND $events AS event\nMATCH (source:Person )\nMATCH (target:Person )\nMERGE (source)-[rel:KNOWS]->(target)\nSET rel += event.rel.properties"
+    val wantQuery = """UNWIND $events AS event
+                      |MATCH (source:`Person`),
+                      |(target:`Person`)
+                      |MERGE (source)-[rel:`KNOWS`]->(target)
+                      |SET rel += event.rel.properties""".stripMargin.replaceAll("\n", " ")
 
     assertEquals(s"$prefix\n$wantQuery".trim, writeService.createQuery().trim)
   }
@@ -1248,7 +1250,7 @@ class Neo4jQueryServiceTest {
         neo4jOptions,
         new Neo4jQueryReadStrategy(
           neo4jInfo,
-          CypherRenderer(neo4jInfo, neo4jOptions),
+          new CypherRenderer(neo4jInfo, neo4jOptions),
           withPreamble = false
         )
       )
@@ -1269,7 +1271,7 @@ class Neo4jQueryServiceTest {
     val noPreambleWriteService =
       new Neo4jQueryService(
         neo4jOptions,
-        new Neo4jQueryWriteStrategy(neo4jInfo, CypherRenderer(neo4jInfo, neo4jOptions), SaveMode.Overwrite, false)
+        new Neo4jQueryWriteStrategy(neo4jInfo, new CypherRenderer(neo4jInfo, neo4jOptions), SaveMode.Overwrite, false)
       )
 
     val wantQuery = "UNWIND $events AS event MATCH (o:Object) RETURN o"
@@ -1367,10 +1369,14 @@ class Neo4jQueryServiceTest {
   }
 
   def plainReadStrategy(neo4j: Neo4j, neo4jOptions: Neo4jOptions): Neo4jQueryReadStrategy =
-    new Neo4jQueryReadStrategy(neo4j, CypherRenderer(neo4j, neo4jOptions))
+    new Neo4jQueryReadStrategy(neo4j, new CypherRenderer(neo4j, neo4jOptions))
 
-  def plainWriteStrategy(neo4j: Neo4j, neo4jOptions: Neo4jOptions, saveMode: SaveMode = SaveMode.Overwrite): Neo4jQueryWriteStrategy =
-    new Neo4jQueryWriteStrategy(neo4j, CypherRenderer(neo4j, neo4jOptions), saveMode)
+  def plainWriteStrategy(
+    neo4j: Neo4j,
+    neo4jOptions: Neo4jOptions,
+    saveMode: SaveMode = SaveMode.Overwrite
+  ): Neo4jQueryWriteStrategy =
+    new Neo4jQueryWriteStrategy(neo4j, new CypherRenderer(neo4j, neo4jOptions), saveMode)
 
   def versions_and_prefixes(): Array[Array[Any]] = {
     Array(

--- a/src/test/scala/org/neo4j/spark/service/Neo4jQueryServiceTest.scala
+++ b/src/test/scala/org/neo4j/spark/service/Neo4jQueryServiceTest.scala
@@ -68,7 +68,7 @@ class Neo4jQueryServiceTest {
 
   @ParameterizedTest
   @MethodSource(Array("versions_and_prefixes"))
-  def testNodeMultipleLabels(neo4j: Neo4j, customCypherVersion: String, prefix: String): Unit = {
+  def testNodeMultipleLabelsWhenRead(neo4j: Neo4j, customCypherVersion: String, prefix: String): Unit = {
     val options: java.util.Map[String, String] = new java.util.HashMap[String, String]()
     options.put(Neo4jOptions.URL, "bolt://localhost")
     options.put(QueryType.LABELS.toString.toLowerCase, ":Person:Player:Midfield")
@@ -79,6 +79,24 @@ class Neo4jQueryServiceTest {
       new Neo4jQueryService(neo4jOptions, plainReadStrategy(neo4j, neo4jOptions)).createQuery()
 
     assertEquals(s"${prefix}MATCH (n:`Person`:`Player`:`Midfield`) RETURN n", query)
+  }
+
+  @ParameterizedTest
+  @MethodSource(Array("versions_and_prefixes"))
+  def testNodeMultipleLabelsWhenWrite(neo4j: Neo4j, customCypherVersion: String, prefix: String): Unit = {
+    val options: java.util.Map[String, String] = new java.util.HashMap[String, String]()
+    options.put(Neo4jOptions.URL, "bolt://localhost")
+    options.put(QueryType.LABELS.toString.toLowerCase, ":Person:Player:Midfield")
+    options.put(Neo4jOptions.CYPHER_VERSION, customCypherVersion)
+    val neo4jOptions: Neo4jOptions = new Neo4jOptions(options)
+
+    val query: String =
+      new Neo4jQueryService(neo4jOptions, plainWriteStrategy(neo4j, neo4jOptions, SaveMode.Append)).createQuery().trim
+
+    assertEquals(
+      s"${prefix}UNWIND $$events AS event CREATE (node:`Person`:`Player`:`Midfield`) SET node += event.properties",
+      query
+    )
   }
 
   @ParameterizedTest
@@ -94,7 +112,7 @@ class Neo4jQueryServiceTest {
       neo4jOptions,
       new Neo4jQueryReadStrategy(
         neo4j,
-        new CypherRenderer(neo4j, neo4jOptions),
+        CypherRenderer(neo4j, neo4jOptions),
         partitionPagination = PartitionPagination(0, 0, TopN(100))
       )
     ).createQuery()
@@ -115,7 +133,7 @@ class Neo4jQueryServiceTest {
       neo4jOptions,
       new Neo4jQueryReadStrategy(
         neo4j,
-        new CypherRenderer(neo4j, neo4jOptions),
+        CypherRenderer(neo4j, neo4jOptions),
         Array.empty[Filter],
         PartitionPagination.EMPTY,
         Seq("name")
@@ -138,7 +156,7 @@ class Neo4jQueryServiceTest {
       neo4jOptions,
       new Neo4jQueryReadStrategy(
         neo4j,
-        new CypherRenderer(neo4j, neo4jOptions),
+        CypherRenderer(neo4j, neo4jOptions),
         Array.empty[Filter],
         PartitionPagination.EMPTY,
         List("name", "bornDate")
@@ -161,7 +179,7 @@ class Neo4jQueryServiceTest {
       neo4jOptions,
       new Neo4jQueryReadStrategy(
         neo4j,
-        new CypherRenderer(neo4j, neo4jOptions),
+        CypherRenderer(neo4j, neo4jOptions),
         Array.empty[Filter],
         PartitionPagination.EMPTY,
         List("<elementId>")
@@ -187,7 +205,7 @@ class Neo4jQueryServiceTest {
     val query: String =
       new Neo4jQueryService(
         neo4jOptions,
-        new Neo4jQueryReadStrategy(neo4j, new CypherRenderer(neo4j, neo4jOptions), filters)
+        new Neo4jQueryReadStrategy(neo4j, CypherRenderer(neo4j, neo4jOptions), filters)
       ).createQuery()
 
     val paramName = "$" + "name".toParameterName("John Doe")
@@ -212,7 +230,7 @@ class Neo4jQueryServiceTest {
     val query: String =
       new Neo4jQueryService(
         neo4jOptions,
-        new Neo4jQueryReadStrategy(neo4j, new CypherRenderer(neo4j, neo4jOptions), filters)
+        new Neo4jQueryReadStrategy(neo4j, CypherRenderer(neo4j, neo4jOptions), filters)
       ).createQuery()
 
     val nameParameterName = "$" + "name".toParameterName("John Doe")
@@ -244,7 +262,7 @@ class Neo4jQueryServiceTest {
     val query: String =
       new Neo4jQueryService(
         neo4jOptions,
-        new Neo4jQueryReadStrategy(neo4j, new CypherRenderer(neo4j, neo4jOptions), filters)
+        new Neo4jQueryReadStrategy(neo4j, CypherRenderer(neo4j, neo4jOptions), filters)
       ).createQuery()
 
     val nameParameterName = "$" + "name".toParameterName(null)
@@ -273,7 +291,7 @@ class Neo4jQueryServiceTest {
     val query: String =
       new Neo4jQueryService(
         neo4jOptions,
-        new Neo4jQueryReadStrategy(neo4j, new CypherRenderer(neo4j, neo4jOptions), filters)
+        new Neo4jQueryReadStrategy(neo4j, CypherRenderer(neo4j, neo4jOptions), filters)
       ).createQuery()
 
     val nameOneParameterName = "$" + "name".toParameterName("Person Name")
@@ -304,7 +322,7 @@ class Neo4jQueryServiceTest {
       neo4jOptions,
       new Neo4jQueryReadStrategy(
         neo4j,
-        new CypherRenderer(neo4j, neo4jOptions),
+        CypherRenderer(neo4j, neo4jOptions),
         Array.empty[Filter],
         PartitionPagination.EMPTY,
         List("source.name")
@@ -335,7 +353,7 @@ class Neo4jQueryServiceTest {
       neo4jOptions,
       new Neo4jQueryReadStrategy(
         neo4j,
-        new CypherRenderer(neo4j, neo4jOptions),
+        CypherRenderer(neo4j, neo4jOptions),
         Array.empty[Filter],
         PartitionPagination.EMPTY,
         List("source.name", "<source.elementId>")
@@ -370,7 +388,7 @@ class Neo4jQueryServiceTest {
       neo4jOptions,
       new Neo4jQueryReadStrategy(
         neo4j,
-        new CypherRenderer(neo4j, neo4jOptions),
+        CypherRenderer(neo4j, neo4jOptions),
         Array.empty[Filter],
         PartitionPagination(0, 0, TopN(limit = 100)),
         List("source.name", "<source.elementId>")
@@ -405,7 +423,7 @@ class Neo4jQueryServiceTest {
       neo4jOptions,
       new Neo4jQueryReadStrategy(
         neo4j,
-        new CypherRenderer(neo4j, neo4jOptions),
+        CypherRenderer(neo4j, neo4jOptions),
         Array.empty[Filter],
         PartitionPagination.EMPTY,
         List("source.name", "source.id", "rel.someprops", "target.date")
@@ -439,7 +457,7 @@ class Neo4jQueryServiceTest {
     val query: String =
       new Neo4jQueryService(
         neo4jOptions,
-        new Neo4jQueryReadStrategy(neo4j, new CypherRenderer(neo4j, neo4jOptions), filters)
+        new Neo4jQueryReadStrategy(neo4j, CypherRenderer(neo4j, neo4jOptions), filters)
       ).createQuery()
 
     val parameterName = "$" + "source.name".toParameterName("John Doe")
@@ -471,7 +489,7 @@ class Neo4jQueryServiceTest {
     val query: String =
       new Neo4jQueryService(
         neo4jOptions,
-        new Neo4jQueryReadStrategy(neo4j, new CypherRenderer(neo4j, neo4jOptions), filters)
+        new Neo4jQueryReadStrategy(neo4j, CypherRenderer(neo4j, neo4jOptions), filters)
       ).createQuery()
 
     val paramOneName = "$" + "source.name".toParameterName("John Doe")
@@ -505,7 +523,7 @@ class Neo4jQueryServiceTest {
     val query: String =
       new Neo4jQueryService(
         neo4jOptions,
-        new Neo4jQueryReadStrategy(neo4j, new CypherRenderer(neo4j, neo4jOptions), filters)
+        new Neo4jQueryReadStrategy(neo4j, CypherRenderer(neo4j, neo4jOptions), filters)
       ).createQuery()
 
     val sourceIdParameterName = "$" + "source.id".toParameterName(14)
@@ -540,7 +558,7 @@ class Neo4jQueryServiceTest {
     val query: String =
       new Neo4jQueryService(
         neo4jOptions,
-        new Neo4jQueryReadStrategy(neo4j, new CypherRenderer(neo4j, neo4jOptions), filters)
+        new Neo4jQueryReadStrategy(neo4j, CypherRenderer(neo4j, neo4jOptions), filters)
       ).createQuery()
 
     val parameterNames: Map[String, String] = HashMap(
@@ -586,7 +604,7 @@ class Neo4jQueryServiceTest {
     val query: String =
       new Neo4jQueryService(
         neo4jOptions,
-        new Neo4jQueryReadStrategy(neo4j, new CypherRenderer(neo4j, neo4jOptions), filters)
+        new Neo4jQueryReadStrategy(neo4j, CypherRenderer(neo4j, neo4jOptions), filters)
       ).createQuery()
 
     val parameterNames = Map(
@@ -642,7 +660,7 @@ class Neo4jQueryServiceTest {
     val query: String =
       new Neo4jQueryService(
         neo4jOptions,
-        new Neo4jQueryReadStrategy(neo4j, new CypherRenderer(neo4j, neo4jOptions), filters)
+        new Neo4jQueryReadStrategy(neo4j, CypherRenderer(neo4j, neo4jOptions), filters)
       ).createQuery()
 
     val parameterNames = Map(
@@ -682,13 +700,13 @@ class Neo4jQueryServiceTest {
     val neo4jOptions: Neo4jOptions = new Neo4jOptions(options)
 
     val query: String =
-      new Neo4jQueryService(neo4jOptions, new Neo4jQueryWriteStrategy(neo4j, SaveMode.Overwrite)).createQuery()
+      new Neo4jQueryService(neo4jOptions, plainWriteStrategy(neo4j, neo4jOptions)).createQuery()
 
     assertEquals(
       s"""${prefix}UNWIND $$events AS event
-         |MERGE (node:Location {name: event.keys.name, type: event.keys.type, featureId: event.keys.featureId})
+         |MERGE (node:`Location` {name: event.keys.name, type: event.keys.type, featureId: event.keys.featureId})
          |SET node += event.properties
-         |""".stripMargin,
+         |""".stripMargin.trim.replaceAll("\n", " "),
       query
     )
   }
@@ -708,7 +726,7 @@ class Neo4jQueryServiceTest {
     val neo4jOptions: Neo4jOptions = new Neo4jOptions(options)
 
     val query: String =
-      new Neo4jQueryService(neo4jOptions, new Neo4jQueryWriteStrategy(neo4j, SaveMode.Overwrite)).createQuery()
+      new Neo4jQueryService(neo4jOptions, plainWriteStrategy(neo4j, neo4jOptions)).createQuery()
 
     assertEquals(
       s"""${prefix}UNWIND $$events AS event
@@ -738,7 +756,7 @@ class Neo4jQueryServiceTest {
     val neo4jOptions: Neo4jOptions = new Neo4jOptions(options)
 
     val query: String =
-      new Neo4jQueryService(neo4jOptions, new Neo4jQueryWriteStrategy(neo4j, SaveMode.Overwrite)).createQuery()
+      new Neo4jQueryService(neo4jOptions, plainWriteStrategy(neo4j, neo4jOptions)).createQuery()
 
     assertEquals(
       s"""${prefix}UNWIND $$events AS event
@@ -772,7 +790,7 @@ class Neo4jQueryServiceTest {
     val neo4jOptions: Neo4jOptions = new Neo4jOptions(options)
 
     val query: String =
-      new Neo4jQueryService(neo4jOptions, new Neo4jQueryWriteStrategy(neo4j, SaveMode.Overwrite)).createQuery()
+      new Neo4jQueryService(neo4jOptions, plainWriteStrategy(neo4j, neo4jOptions)).createQuery()
 
     assertEquals(
       s"""|${prefix}UNWIND $$events AS event
@@ -800,7 +818,7 @@ class Neo4jQueryServiceTest {
       neo4jOptions,
       new Neo4jQueryReadStrategy(
         neo4j,
-        new CypherRenderer(neo4j, neo4jOptions),
+        CypherRenderer(neo4j, neo4jOptions),
         Array.empty[Filter],
         PartitionPagination.EMPTY,
         Seq("name", "SUM(DISTINCT age)", "SUM(age)"),
@@ -821,7 +839,7 @@ class Neo4jQueryServiceTest {
       neo4jOptions,
       new Neo4jQueryReadStrategy(
         neo4j,
-        new CypherRenderer(neo4j, neo4jOptions),
+        CypherRenderer(neo4j, neo4jOptions),
         Array.empty[Filter],
         PartitionPagination.EMPTY,
         Seq("name", "COUNT(DISTINCT name)", "COUNT(name)"),
@@ -841,7 +859,7 @@ class Neo4jQueryServiceTest {
       neo4jOptions,
       new Neo4jQueryReadStrategy(
         neo4j,
-        new CypherRenderer(neo4j, neo4jOptions),
+        CypherRenderer(neo4j, neo4jOptions),
         Array.empty[Filter],
         PartitionPagination.EMPTY,
         Seq("name", "MAX(age)", "MIN(age)"),
@@ -875,7 +893,7 @@ class Neo4jQueryServiceTest {
       neo4jOptions,
       new Neo4jQueryReadStrategy(
         neo4j,
-        new CypherRenderer(neo4j, neo4jOptions),
+        CypherRenderer(neo4j, neo4jOptions),
         Array.empty,
         PartitionPagination.EMPTY,
         List("source.fullName", "SUM(DISTINCT `target.price`)", "SUM(`target.price`)"),
@@ -901,7 +919,7 @@ class Neo4jQueryServiceTest {
       neo4jOptions,
       new Neo4jQueryReadStrategy(
         neo4j,
-        new CypherRenderer(neo4j, neo4jOptions),
+        CypherRenderer(neo4j, neo4jOptions),
         Array.empty,
         PartitionPagination.EMPTY,
         List("source.fullName", "COUNT(DISTINCT `target.id`)", "COUNT(`target.id`)"),
@@ -925,7 +943,7 @@ class Neo4jQueryServiceTest {
       neo4jOptions,
       new Neo4jQueryReadStrategy(
         neo4j,
-        new CypherRenderer(neo4j, neo4jOptions),
+        CypherRenderer(neo4j, neo4jOptions),
         Array.empty,
         PartitionPagination.EMPTY,
         List("source.fullName", "MAX(`target.price`)", "MIN(`target.price`)"),
@@ -960,7 +978,7 @@ class Neo4jQueryServiceTest {
       neo4jOptions,
       new Neo4jQueryReadStrategy(
         neo4j,
-        new CypherRenderer(neo4j, neo4jOptions),
+        CypherRenderer(neo4j, neo4jOptions),
         partitionPagination = PartitionPagination(
           0,
           0,
@@ -994,7 +1012,7 @@ class Neo4jQueryServiceTest {
       neo4jOptions,
       new Neo4jQueryReadStrategy(
         neo4j,
-        new CypherRenderer(neo4j, neo4jOptions),
+        CypherRenderer(neo4j, neo4jOptions),
         requiredColumns = Array("name").toIndexedSeq,
         partitionPagination = PartitionPagination(
           0,
@@ -1032,7 +1050,7 @@ class Neo4jQueryServiceTest {
       neo4jOptions,
       new Neo4jQueryReadStrategy(
         neo4j,
-        new CypherRenderer(neo4j, neo4jOptions),
+        CypherRenderer(neo4j, neo4jOptions),
         Array.empty[Filter],
         PartitionPagination(
           0,
@@ -1076,7 +1094,7 @@ class Neo4jQueryServiceTest {
       neo4jOptions,
       new Neo4jQueryReadStrategy(
         neo4j,
-        new CypherRenderer(neo4j, neo4jOptions),
+        CypherRenderer(neo4j, neo4jOptions),
         Array.empty[Filter],
         PartitionPagination(
           0,
@@ -1120,7 +1138,7 @@ class Neo4jQueryServiceTest {
       neo4jOptions,
       new Neo4jQueryReadStrategy(
         neo4j,
-        new CypherRenderer(neo4j, neo4jOptions),
+        CypherRenderer(neo4j, neo4jOptions),
         Array.empty[Filter],
         PartitionPagination(
           0,
@@ -1163,13 +1181,14 @@ class Neo4jQueryServiceTest {
     options.put(Neo4jOptions.URL, "bolt://localhost")
     options.put(QueryType.LABELS.toString.toLowerCase, "Person")
     val neo4jOptions: Neo4jOptions = new Neo4jOptions(withTuning(options, tuningOptions))
+    val neo4jInfo = neo4j(version(5, 0), COMMUNITY)
 
     val writeService = new Neo4jQueryService(
       neo4jOptions,
-      new Neo4jQueryWriteStrategy(neo4j(version(5, 0), COMMUNITY), SaveMode.Overwrite)
+      new Neo4jQueryWriteStrategy(neo4jInfo, CypherRenderer(neo4jInfo, neo4jOptions), SaveMode.Overwrite)
     )
 
-    val wantQuery = "UNWIND $events AS event\nMERGE (node:Person )\nSET node += event.properties"
+    val wantQuery = "UNWIND $events AS event MERGE (node:`Person`) SET node += event.properties"
     assertEquals(s"$prefix\n$wantQuery".trim, writeService.createQuery().trim)
   }
 
@@ -1202,10 +1221,11 @@ class Neo4jQueryServiceTest {
     options.put("relationship.source.labels", "Person")
     options.put("relationship.target.labels", "Person")
     val neo4jOptions: Neo4jOptions = new Neo4jOptions(withTuning(options, tuningOptions))
+    val neo4jInfo = neo4j(version(5, 0), COMMUNITY)
 
     val writeService = new Neo4jQueryService(
       neo4jOptions,
-      new Neo4jQueryWriteStrategy(neo4j(version(5, 0), COMMUNITY), SaveMode.Overwrite)
+      new Neo4jQueryWriteStrategy(neo4jInfo, CypherRenderer(neo4jInfo, neo4jOptions), SaveMode.Overwrite)
     )
 
     val wantQuery =
@@ -1221,14 +1241,14 @@ class Neo4jQueryServiceTest {
     options.put(Neo4jOptions.URL, "bolt://localhost")
     options.put(QueryType.QUERY.toString.toLowerCase, "MATCH (o:Object) RETURN o")
     val neo4jOptions: Neo4jOptions = new Neo4jOptions(withTuning(options, tuningOptions))
-    val neo4jVersion = neo4j(version(5, 0), COMMUNITY)
+    val neo4jInfo = neo4j(version(5, 0), COMMUNITY)
 
     val noPreambleReadService =
       new Neo4jQueryService(
         neo4jOptions,
         new Neo4jQueryReadStrategy(
-          neo4jVersion,
-          new CypherRenderer(neo4jVersion, neo4jOptions),
+          neo4jInfo,
+          CypherRenderer(neo4jInfo, neo4jOptions),
           withPreamble = false
         )
       )
@@ -1244,14 +1264,15 @@ class Neo4jQueryServiceTest {
     options.put(Neo4jOptions.URL, "bolt://localhost")
     options.put(QueryType.QUERY.toString.toLowerCase, "MATCH (o:Object) RETURN o")
     val neo4jOptions: Neo4jOptions = new Neo4jOptions(withTuning(options, tuningOptions))
+    val neo4jInfo = neo4j(version(5, 0), COMMUNITY)
 
     val noPreambleWriteService =
       new Neo4jQueryService(
         neo4jOptions,
-        new Neo4jQueryWriteStrategy(neo4j(version(5, 0), COMMUNITY), SaveMode.Overwrite, false)
+        new Neo4jQueryWriteStrategy(neo4jInfo, CypherRenderer(neo4jInfo, neo4jOptions), SaveMode.Overwrite, false)
       )
 
-    val wantQuery = "UNWIND $events AS event\nMATCH (o:Object) RETURN o"
+    val wantQuery = "UNWIND $events AS event MATCH (o:Object) RETURN o"
     assertEquals(wantQuery, noPreambleWriteService.createQuery().trim)
   }
 
@@ -1269,10 +1290,10 @@ class Neo4jQueryServiceTest {
     options.put(QueryType.QUERY.toString.toLowerCase, "MATCH (o:Object) RETURN o")
     options.put(Neo4jOptions.CYPHER_VERSION, customCypherVersion)
     val neo4jOptions: Neo4jOptions = new Neo4jOptions(withTuning(options, tuningOptions))
-    val versionedReadService = new Neo4jQueryService(neo4jOptions, plainReadStrategy(neo4j, neo4jOptions))
+    val readService = new Neo4jQueryService(neo4jOptions, plainReadStrategy(neo4j, neo4jOptions))
 
     val wantQuery = s"$tuningPrefix\n${cypherVersionPreamble}MATCH (o:Object) RETURN o"
-    assertEquals(wantQuery.trim, versionedReadService.createQuery().trim)
+    assertEquals(wantQuery.trim, readService.createQuery().trim)
   }
 
   @ParameterizedTest
@@ -1290,11 +1311,11 @@ class Neo4jQueryServiceTest {
     options.put(Neo4jOptions.CYPHER_VERSION, customCypherVersion)
     val neo4jOptions: Neo4jOptions = new Neo4jOptions(withTuning(options, tuningOptions))
 
-    val versionedWriteService =
-      new Neo4jQueryService(neo4jOptions, new Neo4jQueryWriteStrategy(neo4j, SaveMode.Overwrite))
+    val writeService =
+      new Neo4jQueryService(neo4jOptions, plainWriteStrategy(neo4j, neo4jOptions))
 
-    val wantQuery = s"$tuningPrefix\n${cypherVersionPreamble}UNWIND $$events AS event\nMATCH (o:Object) RETURN o"
-    assertEquals(wantQuery.trim, versionedWriteService.createQuery().trim)
+    val wantQuery = s"$tuningPrefix\n${cypherVersionPreamble}UNWIND $$events AS event MATCH (o:Object) RETURN o"
+    assertEquals(wantQuery.trim, writeService.createQuery().trim)
   }
 
   @ParameterizedTest
@@ -1337,16 +1358,19 @@ class Neo4jQueryServiceTest {
     val neo4jOptions: Neo4jOptions = new Neo4jOptions(withTuning(options, tuningOptions))
 
     val versionedWriteService =
-      new Neo4jQueryService(neo4jOptions, new Neo4jQueryWriteStrategy(neo4j, SaveMode.Overwrite))
+      new Neo4jQueryService(neo4jOptions, plainWriteStrategy(neo4j, neo4jOptions))
 
     val wantQuery =
-      s"$tuningPrefix\n${cypherVersionPreamble}WITH $$scriptResult AS scriptResult UNWIND $$events AS event\nMATCH (o:Object) RETURN o"
+      s"$tuningPrefix\n${cypherVersionPreamble}WITH $$scriptResult AS scriptResult UNWIND $$events AS event MATCH (o:Object) RETURN o"
 
     assertEquals(wantQuery.trim, versionedWriteService.createQuery().trim)
   }
 
   def plainReadStrategy(neo4j: Neo4j, neo4jOptions: Neo4jOptions): Neo4jQueryReadStrategy =
-    new Neo4jQueryReadStrategy(neo4j, new CypherRenderer(neo4j, neo4jOptions))
+    new Neo4jQueryReadStrategy(neo4j, CypherRenderer(neo4j, neo4jOptions))
+
+  def plainWriteStrategy(neo4j: Neo4j, neo4jOptions: Neo4jOptions, saveMode: SaveMode = SaveMode.Overwrite): Neo4jQueryWriteStrategy =
+    new Neo4jQueryWriteStrategy(neo4j, CypherRenderer(neo4j, neo4jOptions), saveMode)
 
   def versions_and_prefixes(): Array[Array[Any]] = {
     Array(
@@ -1376,13 +1400,7 @@ class Neo4jQueryServiceTest {
   def tuning_parameters(): Array[Array[Any]] = {
     Array(
       Array(Neo4jTuningOptions.empty, ""),
-      Array(Neo4jTuningOptions.empty, ""),
       Array(Neo4jTuningOptions.empty.copy(runtime = "parallel"), "CYPHER runtime=parallel"),
-      Array(Neo4jTuningOptions.empty.copy(runtime = "parallel"), "CYPHER runtime=parallel"),
-      Array(
-        Neo4jTuningOptions.empty.copy(replan = "force", operatorEngine = "compiled"),
-        "CYPHER replan=force operatorEngine=compiled"
-      ),
       Array(
         Neo4jTuningOptions.empty.copy(replan = "force", operatorEngine = "compiled"),
         "CYPHER replan=force operatorEngine=compiled"

--- a/src/test/scala/org/neo4j/spark/service/Neo4jQueryServiceTest.scala
+++ b/src/test/scala/org/neo4j/spark/service/Neo4jQueryServiceTest.scala
@@ -802,6 +802,40 @@ class Neo4jQueryServiceTest {
 
   @ParameterizedTest
   @MethodSource(Array("versions_and_prefixes"))
+  def testCompoundKeysForRelationshipWithPropsAndAppended(
+    neo4j: Neo4j,
+    customCypherVersion: String,
+    prefix: String
+  ): Unit = {
+    val options: java.util.Map[String, String] = new java.util.HashMap[String, String]()
+    options.put(Neo4jOptions.URL, "bolt://localhost")
+    options.put("relationship", "BOUGHT")
+    options.put("relationship.source.labels", "Person")
+    options.put("relationship.source.node.keys", "FirstName:name,LastName:lastName")
+    options.put("relationship.source.save.mode", "Append")
+    options.put("relationship.target.labels", "Product")
+    options.put("relationship.target.node.keys", "ProductPrice:price,ProductId:id")
+    options.put("relationship.target.save.mode", "Overwrite")
+
+    options.put(Neo4jOptions.CYPHER_VERSION, customCypherVersion)
+    val neo4jOptions: Neo4jOptions = new Neo4jOptions(options)
+
+    val query: String =
+      new Neo4jQueryService(neo4jOptions, plainWriteStrategy(neo4j, neo4jOptions, SaveMode.Append)).createQuery()
+
+    assertEquals(
+      s"""${prefix}UNWIND $$events AS event
+         |CREATE (source:`Person` {name: event.source.keys.name, lastName: event.source.keys.lastName}) SET source += event.source.properties
+         |MERGE (target:`Product` {price: event.target.keys.price, id: event.target.keys.id}) SET target += event.target.properties
+         |CREATE (source)-[rel:`BOUGHT`]->(target)
+         |SET rel += event.rel.properties
+         |""".stripMargin.replaceAll("\n", " ").trim,
+      query.trim
+    )
+  }
+
+  @ParameterizedTest
+  @MethodSource(Array("versions_and_prefixes"))
   def testRelationshipWithKeySaveStrategy(neo4j: Neo4j, customCypherVersion: String, prefix: String): Unit = {
     val options: java.util.Map[String, String] = new java.util.HashMap[String, String]()
     options.put(Neo4jOptions.URL, "bolt://localhost")

--- a/src/test/scala/org/neo4j/spark/service/Neo4jQueryServiceTest.scala
+++ b/src/test/scala/org/neo4j/spark/service/Neo4jQueryServiceTest.scala
@@ -772,6 +772,36 @@ class Neo4jQueryServiceTest {
 
   @ParameterizedTest
   @MethodSource(Array("versions_and_prefixes"))
+  def testCompoundKeysForRelationshipMergeMerge(neo4j: Neo4j, customCypherVersion: String, prefix: String): Unit = {
+    val options: java.util.Map[String, String] = new java.util.HashMap[String, String]()
+    options.put(Neo4jOptions.URL, "bolt://localhost")
+    options.put("relationship", "BOUGHT")
+    options.put("relationship.source.labels", "Person")
+    options.put("relationship.source.node.keys", "FirstName:name,LastName:lastName")
+    options.put("relationship.source.save.mode", "Overwrite")
+    options.put("relationship.target.labels", "Product")
+    options.put("relationship.target.node.keys", "ProductPrice:price,ProductId:id")
+    options.put("relationship.target.save.mode", "Overwrite")
+
+    options.put(Neo4jOptions.CYPHER_VERSION, customCypherVersion)
+    val neo4jOptions: Neo4jOptions = new Neo4jOptions(options)
+
+    val query: String =
+      new Neo4jQueryService(neo4jOptions, plainWriteStrategy(neo4j, neo4jOptions)).createQuery()
+
+    assertEquals(
+      s"""${prefix}UNWIND $$events AS event
+         |MERGE (source:`Person` {name: event.source.keys.name, lastName: event.source.keys.lastName}) SET source += event.source.properties
+         |MERGE (target:`Product` {price: event.target.keys.price, id: event.target.keys.id}) SET target += event.target.properties
+         |MERGE (source)-[rel:`BOUGHT`]->(target)
+         |SET rel += event.rel.properties
+         |""".stripMargin.replaceAll("\n", " ").trim,
+      query.trim
+    )
+  }
+
+  @ParameterizedTest
+  @MethodSource(Array("versions_and_prefixes"))
   def testRelationshipWithKeySaveStrategy(neo4j: Neo4j, customCypherVersion: String, prefix: String): Unit = {
     val options: java.util.Map[String, String] = new java.util.HashMap[String, String]()
     options.put(Neo4jOptions.URL, "bolt://localhost")

--- a/src/test/scala/org/neo4j/spark/service/Neo4jQueryServiceTest.scala
+++ b/src/test/scala/org/neo4j/spark/service/Neo4jQueryServiceTest.scala
@@ -730,8 +730,8 @@ class Neo4jQueryServiceTest {
 
     assertEquals(
       s"""${prefix}UNWIND $$events AS event
-         |MATCH (source:`Person` {name: event.source.keys.name, lastName: event.source.keys.lastName}),
-         |(target:`Product`:`Merch` {price: event.target.keys.price, id: event.target.keys.id})
+         |MATCH (source:`Person` {name: event.source.keys.name, lastName: event.source.keys.lastName})
+         |MATCH (target:`Product`:`Merch` {price: event.target.keys.price, id: event.target.keys.id})
          |MERGE (source)-[rel:`BOUGHT`]->(target)
          |SET rel += event.rel.properties
          |""".stripMargin.replaceAll("\n", " ").trim,
@@ -1292,8 +1292,8 @@ class Neo4jQueryServiceTest {
       new Neo4jQueryWriteStrategy(neo4jInfo, new CypherRenderer(neo4jInfo, neo4jOptions), SaveMode.Overwrite)
     )
     val wantQuery = """UNWIND $events AS event
-                      |MATCH (source:`Person`),
-                      |(target:`Person`)
+                      |MATCH (source:`Person`)
+                      |MATCH (target:`Person`)
                       |MERGE (source)-[rel:`KNOWS`]->(target)
                       |SET rel += event.rel.properties""".stripMargin.replaceAll("\n", " ")
 


### PR DESCRIPTION
refactor of Neo4jQueryService to use cypher dsl library instead of
concatenating strings

one side effect of this is that cypher dsl has a good tendency to
escape identifiers so some queries are different

finally, the dsl prefer spaces over new-line so test cases are
adjusted to replace new line assertions with space assertions.