### PR TITLE
build: remove zip assembly

### DIFF
--- a/jreleaser.yml
+++ b/jreleaser.yml
@@ -53,27 +53,6 @@ checksum:
 files:
   globs:
     - pattern: artifacts/*.jar
-    - pattern: artifacts/*.zip
-      extraProperties:
-        skipRelease: "true"
-
-assemble:
-  archive:
-    zip:
-      active: ALWAYS
-      exported: true
-      stereotype: NONE
-      archiveName: neo4j-connector-apache-spark-{{projectVersion}}
-      distributionType: BINARY
-      attachPlatform: false
-      formats:
-        - ZIP
-      fileSets:
-        - input: '{{basedir}}/artifacts'
-          output: .
-          includes:
-            - '{{projectName}}-{{projectVersion}}*.jar'
-      templateDirectory: src/jreleaser/assemblers/zip
 
 hooks:
   script:
@@ -96,7 +75,6 @@ hooks:
           mkdir artifacts || true
           ./maven-release.sh deploy {{matrix.scala}} default::file://{{basedir}}/target/{{matrix.scala}}/maven-artifacts
           cp -r {{basedir}}/target/{{matrix.scala}}/maven-artifacts artifacts/
-          cp -r {{basedir}}/target/{{projectName}}*.zip artifacts/
           cp -r {{basedir}}/target/{{projectName}}*.jar artifacts/
 
 signing:


### PR DESCRIPTION
We were packaging ZIP files for Spark Packages.

We are not planning to upload to Spark Packages anymore, since the platform 
seems mostly abandoned.