### PR TITLE
fix: validations for ErrorIfExists

### DIFF
--- a/src/main/scala/org/neo4j/spark/writer/Neo4jWriterBuilder.scala
+++ b/src/main/scala/org/neo4j/spark/writer/Neo4jWriterBuilder.scala
@@ -56,7 +56,7 @@ class Neo4jWriterBuilder(
         ValidationUtil.isFalse(
           o.relationshipMetadata.sourceSaveMode.equals(NodeSaveMode.ErrorIfExists)
             || o.relationshipMetadata.targetSaveMode.equals(NodeSaveMode.ErrorIfExists),
-          "Save mode 'ErrorIfExists' is not supported on Spark 3.0, use 'Append' instead."
+          "This connector does not support save mode 'ErrorIfExists'. Use save mode 'Append' instead."
         )
       }
     ))

--- a/src/main/scala/org/neo4j/spark/writer/Neo4jWriterBuilder.scala
+++ b/src/main/scala/org/neo4j/spark/writer/Neo4jWriterBuilder.scala
@@ -55,7 +55,7 @@ class Neo4jWriterBuilder(
       (o: Neo4jOptions) => {
         ValidationUtil.isFalse(
           o.relationshipMetadata.sourceSaveMode.equals(NodeSaveMode.ErrorIfExists)
-            && o.relationshipMetadata.targetSaveMode.equals(NodeSaveMode.ErrorIfExists),
+            || o.relationshipMetadata.targetSaveMode.equals(NodeSaveMode.ErrorIfExists),
           "Save mode 'ErrorIfExists' is not supported on Spark 3.0, use 'Append' instead."
         )
       }

--- a/src/test/scala/org/neo4j/spark/DataSourceWriterTSE.scala
+++ b/src/test/scala/org/neo4j/spark/DataSourceWriterTSE.scala
@@ -1197,6 +1197,8 @@ class DataSourceWriterTSE extends SparkConnectorScalaBaseTSE {
 
   @Test
   def `should fail validating options if ErrorIfExists is used`(): Unit = {
+    var didThrow = false
+
     val musicDf = Seq(
       (12, "John Bonham", "Drums"),
       (19, "John Mayer", "Guitar"),
@@ -1221,8 +1223,13 @@ class DataSourceWriterTSE extends SparkConnectorScalaBaseTSE {
     } catch {
       case e: IllegalArgumentException =>
         assertEquals("Save mode 'ErrorIfExists' is not supported on Spark 3.0, use 'Append' instead.", e.getMessage)
-      case _: Throwable => fail(s"should be thrown a ${classOf[IllegalArgumentException].getName}")
+        didThrow = true
+      case e: Throwable =>
+        fail(s"should throw ${classOf[IllegalArgumentException].getName}, but ${e.getClass.getName} was thrown")
     }
+
+    // TODO: When re-writing in assertj just use a should throw assertable
+    assertTrue(didThrow, s"should throw ${classOf[IllegalArgumentException].getName}, but nothing was thrown")
   }
 
   @Test

--- a/src/test/scala/org/neo4j/spark/DataSourceWriterTSE.scala
+++ b/src/test/scala/org/neo4j/spark/DataSourceWriterTSE.scala
@@ -1222,7 +1222,10 @@ class DataSourceWriterTSE extends SparkConnectorScalaBaseTSE {
         .save()
     } catch {
       case e: IllegalArgumentException =>
-        assertEquals("Save mode 'ErrorIfExists' is not supported on Spark 3.0, use 'Append' instead.", e.getMessage)
+        assertEquals(
+          "This connector does not support save mode 'ErrorIfExists'. Use save mode 'Append' instead.",
+          e.getMessage
+        )
         didThrow = true
       case e: Throwable =>
         fail(s"should throw ${classOf[IllegalArgumentException].getName}, but ${e.getClass.getName} was thrown")


### PR DESCRIPTION
Logic for when to disallow ErrorIfExists was wrong, and the test case
covering it did not take into account for when no exception was
thrown.

From what I could tell, this exception was never thrown and the test
case was false positive.

Fixed this by updating the test to also assert that a test case was
indeed thrown. Then fixed the logic for throwing; if any save mode
is 'ErrorIfExists' then we should throw.