### PR TITLE
feat: cypher parameters are now fully dynamic

### DIFF
--- a/src/main/scala/org/neo4j/spark/cypher/CypherPreamble.scala
+++ b/src/main/scala/org/neo4j/spark/cypher/CypherPreamble.scala
@@ -20,13 +20,12 @@ import org.neo4j.caniuse.CanIUse.INSTANCE.canIUse
 import org.neo4j.caniuse.Cypher.{INSTANCE => Cypher}
 import org.neo4j.caniuse.Neo4j
 import org.neo4j.spark.util.Neo4jOptions
-import org.neo4j.spark.util.Neo4jTuningOptions
 
 object CypherPreamble {
 
   def fullPreamble(neo4j: Neo4j, neo4jOptions: Neo4jOptions): String = {
     val version = versionPreamble(neo4j, neo4jOptions)
-    val tuning = tuningPreamble(neo4jOptions.tuning)
+    val tuning = tuningPreamble(neo4jOptions)
 
     if (tuning.isEmpty) {
       s"$version"
@@ -47,18 +46,14 @@ object CypherPreamble {
     }
   }
 
-  private def tuningPreamble(tuningOptions: Neo4jTuningOptions): String = {
+  def tuningPreamble(options: Neo4jOptions): String = {
     val cypher = "CYPHER "
 
-    val clause = tuningOptions.toMap
-      .filter { case (_, value) => value.nonEmpty }
-      .map { case (key, value) =>
-        if (!Neo4jTuningOptions.validTuningParameters.getOrElse(key, Set.empty).contains(value)) {
-          throw new IllegalArgumentException(
-            s"Found and stopped at first invalid tuning parameter for spark connector: $key=$value"
-          )
-        }
-        s"$key=$value"
+    val clause = options.tuning
+      .filter { case (parameter, value) => parameter.nonEmpty && value.nonEmpty }
+      .map {
+        case (parameter, value) if isValidElseThrow(parameter, value) =>
+          s"$parameter=$value"
       }
       .mkString(cypher, " ", "")
 
@@ -66,5 +61,23 @@ object CypherPreamble {
       ""
     else
       clause
+  }
+
+  private def isValidElseThrow(parameter: String, parameterValue: String): Boolean = {
+    val regex = "^[a-zA-Z0-9_.-]+$"
+
+    if (!parameter.matches(regex)) {
+      throw new IllegalArgumentException(
+        "Cypher tuning parameter name must be alphanumeric, underscore or hyphen. Found: " + parameter
+      )
+    }
+
+    if (!parameterValue.matches(regex)) {
+      throw new IllegalArgumentException(
+        "Cypher tuning parameter value must be alphanumeric, underscore or hyphen. Found: " + parameterValue
+      )
+    }
+
+    true
   }
 }

--- a/src/main/scala/org/neo4j/spark/service/Neo4jQueryService.scala
+++ b/src/main/scala/org/neo4j/spark/service/Neo4jQueryService.scala
@@ -39,7 +39,6 @@ import org.neo4j.spark.util.Neo4jImplicits._
 import org.neo4j.spark.util.Neo4jNodeMetadata
 import org.neo4j.spark.util.Neo4jOptions
 import org.neo4j.spark.util.Neo4jRelationshipMetadata
-import org.neo4j.spark.util.Neo4jTuningOptions
 import org.neo4j.spark.util.Neo4jUtil
 import org.neo4j.spark.util.Neo4jUtil.RELATIONSHIP_ALIAS
 import org.neo4j.spark.util.Neo4jUtil.RELATIONSHIP_SOURCE_ALIAS
@@ -550,7 +549,7 @@ class Neo4jQueryReadStrategy(
   }
 
   override def createStatementForGDS(options: Neo4jOptions): String = {
-    if (options.tuning != Neo4jTuningOptions.empty) {
+    if (options.tuning.nonEmpty) {
       throw new UnsupportedOperationException("Query tuning parameters are not supported for GDS queries")
     }
 

--- a/src/main/scala/org/neo4j/spark/util/Neo4jOptions.scala
+++ b/src/main/scala/org/neo4j/spark/util/Neo4jOptions.scala
@@ -151,16 +151,7 @@ class Neo4jOptions(private val options: java.util.Map[String, String]) extends S
 
   val cypherVersion: String = getParameter(CYPHER_VERSION)
 
-  val tuning: Neo4jTuningOptions = Neo4jTuningOptions(
-    getParameter(TUNING_EXPRESSION_ENGINE),
-    getParameter(TUNING_INFER_SCHEMA_PARTS),
-    getParameter(TUNING_INTERPRETED_PIPES_FALLBACK),
-    getParameter(TUNING_OPERATOR_ENGINE),
-    getParameter(TUNING_PLANNER),
-    getParameter(TUNING_REPLAN),
-    getParameter(TUNING_RUNTIME),
-    getParameter(TUNING_UPDATE_STRATEGY)
-  )
+  val tuning: Map[String, String] = extractNeo4jTuningOptions()
 
   val connection: Neo4jDriverOptions = Neo4jDriverOptions(
     getRequiredParameter(URL),
@@ -366,6 +357,13 @@ class Neo4jOptions(private val options: java.util.Map[String, String]) extends S
       .map(t => (t._1.substring(TX_METADATA_OPTION_PREFIX.length), t._2))
       .toMap
       .toNestedPrimitiveDeserializedJsonJavaMap
+
+  private def extractNeo4jTuningOptions(): Map[String, String] =
+    options.asScala
+      .view
+      .filterKeys(k => k.toLowerCase.startsWith(CYPHER_TUNING_OPTION_PREFIX))
+      .map(t => (t._1.substring(CYPHER_TUNING_OPTION_PREFIX.length), t._2))
+      .toMap
 
   private def minimumNotificationSeverity(strictMode: Boolean): NotificationSeverity = {
     if (strictMode) {
@@ -606,49 +604,6 @@ case class Neo4jDriverOptions(
 
 }
 
-case class Neo4jTuningOptions(
-  expressionEngine: String,
-  inferSchemaParts: String,
-  interpretedPipesFallback: String,
-  operatorEngine: String,
-  planner: String,
-  replan: String,
-  runtime: String,
-  updateStrategy: String
-) {
-
-  def toMap: Map[String, String] = Map(
-    Neo4jOptions.TUNING_EXPRESSION_ENGINE_IN_CYPHER -> expressionEngine,
-    Neo4jOptions.TUNING_INFER_SCHEMA_PARTS_IN_CYPHER -> inferSchemaParts,
-    Neo4jOptions.TUNING_INTERPRETED_PIPES_FALLBACK_IN_CYPHER -> interpretedPipesFallback,
-    Neo4jOptions.TUNING_OPERATOR_ENGINE_IN_CYPHER -> operatorEngine,
-    Neo4jOptions.TUNING_PLANNER_IN_CYPHER -> planner,
-    Neo4jOptions.TUNING_REPLAN_IN_CYPHER -> replan,
-    Neo4jOptions.TUNING_RUNTIME_IN_CYPHER -> runtime,
-    Neo4jOptions.TUNING_UPDATE_STRATEGY_IN_CYPHER -> updateStrategy
-  )
-}
-
-object Neo4jTuningOptions {
-  val empty = Neo4jTuningOptions("", "", "", "", "", "", "", "")
-
-  val validTuningParameters: Map[String, Set[String]] = Map(
-    Neo4jOptions.TUNING_EXPRESSION_ENGINE_IN_CYPHER -> Set("default", "interpreted", "compiled"),
-    Neo4jOptions.TUNING_INFER_SCHEMA_PARTS_IN_CYPHER -> Set("off", "most_selective_label"),
-    Neo4jOptions.TUNING_INTERPRETED_PIPES_FALLBACK_IN_CYPHER -> Set(
-      "default",
-      "disabled",
-      "whitelisted_plans_only",
-      "all"
-    ),
-    Neo4jOptions.TUNING_OPERATOR_ENGINE_IN_CYPHER -> Set("default", "interpreted", "compiled"),
-    Neo4jOptions.TUNING_PLANNER_IN_CYPHER -> Set("cost", "idp", "dp"),
-    Neo4jOptions.TUNING_REPLAN_IN_CYPHER -> Set("default", "force", "skip"),
-    Neo4jOptions.TUNING_RUNTIME_IN_CYPHER -> Set("slotted", "pipelined", "parallel"),
-    Neo4jOptions.TUNING_UPDATE_STRATEGY_IN_CYPHER -> Set("default", "eager")
-  )
-}
-
 object Neo4jOptions {
 
   // connection options
@@ -753,22 +708,7 @@ object Neo4jOptions {
 
   // custom cypher version and query tuning parameters
   val CYPHER_VERSION = "cypher.version"
-  val TUNING_EXPRESSION_ENGINE = "cypher.expression.engine"
-  val TUNING_EXPRESSION_ENGINE_IN_CYPHER = "expressionEngine"
-  val TUNING_INFER_SCHEMA_PARTS = "cypher.infer.schema.parts"
-  val TUNING_INFER_SCHEMA_PARTS_IN_CYPHER = "inferSchemaParts"
-  val TUNING_INTERPRETED_PIPES_FALLBACK = "cypher.interpreted.pipes.fallback"
-  val TUNING_INTERPRETED_PIPES_FALLBACK_IN_CYPHER = "interpretedPipesFallback"
-  val TUNING_OPERATOR_ENGINE = "cypher.operator.engine"
-  val TUNING_OPERATOR_ENGINE_IN_CYPHER = "operatorEngine"
-  val TUNING_PLANNER = "cypher.planner"
-  val TUNING_PLANNER_IN_CYPHER = "planner"
-  val TUNING_REPLAN = "cypher.replan"
-  val TUNING_REPLAN_IN_CYPHER = "replan"
-  val TUNING_RUNTIME = "cypher.runtime"
-  val TUNING_RUNTIME_IN_CYPHER = "runtime"
-  val TUNING_UPDATE_STRATEGY = "cypher.update.strategy"
-  val TUNING_UPDATE_STRATEGY_IN_CYPHER = "updateStrategy"
+  val CYPHER_TUNING_OPTION_PREFIX = "cypher.tuning."
 
   // Data conversion
   val TYPE_CONVERSION = "type.conversion"

--- a/src/test/scala/org/neo4j/spark/cypher/CypherPreambleTest.scala
+++ b/src/test/scala/org/neo4j/spark/cypher/CypherPreambleTest.scala
@@ -1,0 +1,166 @@
+/*
+ * Copyright (c) "Neo4j"
+ * Neo4j Sweden AB [https://neo4j.com]
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.neo4j.spark.cypher
+
+import org.assertj.core.api.Assertions.assertThat
+import org.assertj.core.api.Assertions.assertThatThrownBy
+import org.junit.jupiter.api.DynamicTest
+import org.junit.jupiter.api.DynamicTest.dynamicTest
+import org.junit.jupiter.api.TestFactory
+import org.neo4j.caniuse.Neo4j
+import org.neo4j.spark.util.Neo4jOptions
+
+import java.util.stream.Stream
+
+import scala.jdk.CollectionConverters.SeqHasAsJava
+
+private case class TuningTestCase(
+  name: String,
+  tuningOptions: Map[String, String],
+  expectedOutput: String = null
+)
+
+private case class VersionTestCase(
+  name: String,
+  neo4j: Neo4j,
+  cypherVersionOption: String = null,
+  expectedOutput: String = null
+)
+
+class CypherPreambleTest {
+
+  @TestFactory
+  def tuning_preambles_are_empty(): Stream[DynamicTest] = {
+
+    val cases = Seq(
+      TuningTestCase("no options are set", Map.empty),
+      TuningTestCase("incorrect prefix are ignored", Map("cypher.typo.tuning.update.strategy" -> "eager")),
+      TuningTestCase("empty values are ignored", Map("cypher.tuning.empty" -> ""))
+    )
+
+    cases.map { testCase =>
+      dynamicTest(
+        "when " + testCase.name,
+        () => {
+          val options = new java.util.HashMap[String, String]()
+          options.put(Neo4jOptions.URL, "stub-url-doesnt-matter-but-is-required")
+
+          testCase.tuningOptions.foreach { case (key, value) =>
+            options.put(key, value)
+          }
+
+          val neo4jOptions = new Neo4jOptions(options)
+          val tuningPreamble = CypherPreamble.tuningPreamble(neo4jOptions)
+
+          assertThat(tuningPreamble).isEmpty()
+        }
+      )
+    }
+      .asJava.stream()
+  }
+
+  @TestFactory
+  def tuning_preambles_are_valid(): Stream[DynamicTest] = {
+
+    val cases = Seq(
+      TuningTestCase("a single option is set", Map("cypher.tuning.runtime" -> "parallel"), "CYPHER runtime=parallel"),
+      TuningTestCase(
+        "a single option is set (case invariant key)",
+        Map("cYphEr.tuNIng.ruNTImE" -> "paRalLel"),
+        "CYPHER ruNTImE=paRalLel"
+      ),
+      TuningTestCase(
+        "multiple options are set",
+        Map("cypher.tuning.runtime" -> "parallel", "cypher.tuning.planner" -> "cost"),
+        "CYPHER planner=cost runtime=parallel"
+      ),
+      TuningTestCase(
+        "multiple options should still ignore empty values",
+        Map("cypher.tuning.interpretedPipesFallback" -> "whitelisted_plans_only", "cypher.tuning.ignore.me" -> ""),
+        "CYPHER interpretedPipesFallback=whitelisted_plans_only"
+      ),
+      TuningTestCase(
+        "single multi-word option is set",
+        Map("cypher.tuning.operatorEngine" -> "interpreted"),
+        "CYPHER operatorEngine=interpreted"
+      ),
+      TuningTestCase(
+        "multiple multi-word options are set",
+        Map("cypher.tuning.operatorEngine" -> "interpreted", "cypher.tuning.customValue" -> "some-value"),
+        "CYPHER operatorEngine=interpreted customValue=some-value"
+      )
+    )
+
+    cases.map { testCase =>
+      dynamicTest(
+        "when " + testCase.name,
+        () => {
+          val options = new java.util.HashMap[String, String]()
+          options.put(Neo4jOptions.URL, "stub-url-doesnt-matter-but-is-required")
+
+          testCase.tuningOptions.foreach { case (key, value) =>
+            options.put(key, value)
+          }
+
+          val neo4jOptions = new Neo4jOptions(options)
+          val tuningPreamble = CypherPreamble.tuningPreamble(neo4jOptions)
+
+          assertThat(tuningPreamble).isEqualTo(testCase.expectedOutput)
+        }
+      )
+    }
+      .asJava.stream()
+  }
+
+  @TestFactory
+  def tuning_preambles_are_illegal(): Stream[DynamicTest] = {
+
+    val cases = Seq(
+      TuningTestCase("key breaks naming rule because of space", Map("cypher.tuning.a key with space" -> "value")),
+      TuningTestCase(
+        "value breaks value rule because of space",
+        Map("cypher.tuning.update.strategy" -> "no spaces please")
+      ),
+      TuningTestCase(
+        "key breaks value rule because of bad char",
+        Map("cypher.tuning.custom¤option" -> "no_special_chars")
+      ),
+      TuningTestCase("value breaks value rule because of bad char", Map("cypher.tuning.planner" -> "wonky£value"))
+    )
+
+    cases.map { testCase =>
+      dynamicTest(
+        "when " + testCase.name,
+        () => {
+          val options = new java.util.HashMap[String, String]()
+          options.put(Neo4jOptions.URL, "stub-url-doesnt-matter-but-is-required")
+
+          testCase.tuningOptions.foreach { case (key, value) =>
+            options.put(key, value)
+          }
+
+          val neo4jOptions = new Neo4jOptions(options)
+
+          assertThatThrownBy(() => CypherPreamble.tuningPreamble(neo4jOptions)).isExactlyInstanceOf(
+            classOf[IllegalArgumentException]
+          )
+        }
+      )
+    }
+      .asJava.stream()
+  }
+}

--- a/src/test/scala/org/neo4j/spark/service/Neo4jQueryServiceIT.scala
+++ b/src/test/scala/org/neo4j/spark/service/Neo4jQueryServiceIT.scala
@@ -93,7 +93,7 @@ class Neo4jQueryServiceIT extends SparkConnectorScalaSuiteWithGdsBase {
     val options: java.util.Map[String, String] = new java.util.HashMap[String, String]()
     options.put(Neo4jOptions.URL, SparkConnectorScalaSuiteWithGdsBase.server.getBoltUrl)
     options.put("gds", "gds.pageRank.stream")
-    options.put(Neo4jOptions.TUNING_EXPRESSION_ENGINE, "compiled")
+    options.put("cypher.tuning.expression.engine", "compiled")
     val neo4jOptions: Neo4jOptions = new Neo4jOptions(options)
 
     val field = new DummyNamedReference("score")

--- a/src/test/scala/org/neo4j/spark/service/Neo4jQueryServiceTest.scala
+++ b/src/test/scala/org/neo4j/spark/service/Neo4jQueryServiceTest.scala
@@ -41,7 +41,6 @@ import org.neo4j.spark.cypher.CypherRenderer
 import org.neo4j.spark.util.DummyNamedReference
 import org.neo4j.spark.util.Neo4jImplicits.CypherImplicits
 import org.neo4j.spark.util.Neo4jOptions
-import org.neo4j.spark.util.Neo4jTuningOptions
 import org.neo4j.spark.util.QueryType
 
 import java.util.Collections
@@ -1226,7 +1225,7 @@ class Neo4jQueryServiceTest {
 
   @ParameterizedTest
   @MethodSource(Array("tuning_parameters"))
-  def testTuningPreambleForLabelsWhenRead(tuningOptions: Neo4jTuningOptions, prefix: String): Unit = {
+  def testTuningPreambleForLabelsWhenRead(tuningOptions: Map[String, String], prefix: String): Unit = {
     val options: java.util.Map[String, String] = new java.util.HashMap[String, String]()
     options.put(Neo4jOptions.URL, "bolt://localhost")
     options.put(QueryType.LABELS.toString.toLowerCase, "Person")
@@ -1240,7 +1239,7 @@ class Neo4jQueryServiceTest {
 
   @ParameterizedTest
   @MethodSource(Array("tuning_parameters"))
-  def testTuningPreambleForLabelsWhenWrite(tuningOptions: Neo4jTuningOptions, prefix: String): Unit = {
+  def testTuningPreambleForLabelsWhenWrite(tuningOptions: Map[String, String], prefix: String): Unit = {
     val options: java.util.Map[String, String] = new java.util.HashMap[String, String]()
     options.put(Neo4jOptions.URL, "bolt://localhost")
     options.put(QueryType.LABELS.toString.toLowerCase, "Person")
@@ -1258,7 +1257,7 @@ class Neo4jQueryServiceTest {
 
   @ParameterizedTest
   @MethodSource(Array("tuning_parameters"))
-  def testTuningPreambleForRelationshipWhenRead(tuningOptions: Neo4jTuningOptions, prefix: String): Unit = {
+  def testTuningPreambleForRelationshipWhenRead(tuningOptions: Map[String, String], prefix: String): Unit = {
     val options: java.util.Map[String, String] = new java.util.HashMap[String, String]()
     options.put(Neo4jOptions.URL, "bolt://localhost")
     options.put("relationship", "KNOWS")
@@ -1277,7 +1276,7 @@ class Neo4jQueryServiceTest {
 
   @ParameterizedTest
   @MethodSource(Array("tuning_parameters"))
-  def testTuningPreambleForRelationshipWhenWrite(tuningOptions: Neo4jTuningOptions, prefix: String): Unit = {
+  def testTuningPreambleForRelationshipWhenWrite(tuningOptions: Map[String, String], prefix: String): Unit = {
     val options: java.util.Map[String, String] = new java.util.HashMap[String, String]()
     options.put(Neo4jOptions.URL, "bolt://localhost")
     options.put("relationship", "KNOWS")
@@ -1302,7 +1301,7 @@ class Neo4jQueryServiceTest {
 
   @ParameterizedTest
   @MethodSource(Array("tuning_parameters"))
-  def testCanSkipPreambleWhenRead(tuningOptions: Neo4jTuningOptions, ignored: String): Unit = {
+  def testCanSkipPreambleWhenRead(tuningOptions: Map[String, String], ignored: String): Unit = {
     val options: java.util.Map[String, String] = new java.util.HashMap[String, String]()
     options.put(Neo4jOptions.URL, "bolt://localhost")
     options.put(QueryType.QUERY.toString.toLowerCase, "MATCH (o:Object) RETURN o")
@@ -1325,7 +1324,7 @@ class Neo4jQueryServiceTest {
 
   @ParameterizedTest
   @MethodSource(Array("tuning_parameters"))
-  def testCanSkipPreambleWhenWrite(tuningOptions: Neo4jTuningOptions, ignored: String): Unit = {
+  def testCanSkipPreambleWhenWrite(tuningOptions: Map[String, String], ignored: String): Unit = {
     val options: java.util.Map[String, String] = new java.util.HashMap[String, String]()
     options.put(Neo4jOptions.URL, "bolt://localhost")
     options.put(QueryType.QUERY.toString.toLowerCase, "MATCH (o:Object) RETURN o")
@@ -1348,7 +1347,7 @@ class Neo4jQueryServiceTest {
     neo4j: Neo4j,
     customCypherVersion: String,
     cypherVersionPreamble: String,
-    tuningOptions: Neo4jTuningOptions,
+    tuningOptions: Map[String, String],
     tuningPrefix: String
   ): Unit = {
     val options: java.util.Map[String, String] = new java.util.HashMap[String, String]()
@@ -1368,7 +1367,7 @@ class Neo4jQueryServiceTest {
     neo4j: Neo4j,
     customCypherVersion: String,
     cypherVersionPreamble: String,
-    tuningOptions: Neo4jTuningOptions,
+    tuningOptions: Map[String, String],
     tuningPrefix: String
   ): Unit = {
     val options: java.util.Map[String, String] = new java.util.HashMap[String, String]()
@@ -1390,7 +1389,7 @@ class Neo4jQueryServiceTest {
     neo4j: Neo4j,
     customCypherVersion: String,
     cypherVersionPreamble: String,
-    tuningOptions: Neo4jTuningOptions,
+    tuningOptions: Map[String, String],
     tuningPrefix: String
   ): Unit = {
     val options: java.util.Map[String, String] = new java.util.HashMap[String, String]()
@@ -1413,7 +1412,7 @@ class Neo4jQueryServiceTest {
     neo4j: Neo4j,
     customCypherVersion: String,
     cypherVersionPreamble: String,
-    tuningOptions: Neo4jTuningOptions,
+    tuningOptions: Map[String, String],
     tuningPrefix: String
   ): Unit = {
     val options: java.util.Map[String, String] = new java.util.HashMap[String, String]()
@@ -1469,12 +1468,8 @@ class Neo4jQueryServiceTest {
 
   def tuning_parameters(): Array[Array[Any]] = {
     Array(
-      Array(Neo4jTuningOptions.empty, ""),
-      Array(Neo4jTuningOptions.empty.copy(runtime = "parallel"), "CYPHER runtime=parallel"),
-      Array(
-        Neo4jTuningOptions.empty.copy(replan = "force", operatorEngine = "compiled"),
-        "CYPHER replan=force operatorEngine=compiled"
-      )
+      Array(Map.empty[String, String], ""),
+      Array(Map[String, String]("cypher.tuning.withCustom" -> "set"), "CYPHER withCustom=set")
     )
   }
 
@@ -1489,19 +1484,18 @@ class Neo4jQueryServiceTest {
       versionParameter(0), // neo4j: Neo4j
       versionParameter(1), // customVersion: String
       versionParameter(2), // versionPrefix: String
-      tuningParameter(0), // tuningOptions: Neo4jTuningOptions
+      tuningParameter(0), // tuningOptions: Map[String, String]
       tuningParameter(1) // tuningPrefix: String
     )
   }
 
   private def withTuning(
     options: java.util.Map[String, String],
-    tuning: Neo4jTuningOptions
+    tuning: Map[String, String]
   ): java.util.Map[String, String] = {
-    tuning.toMap.foreach {
+    tuning.foreach {
       case (key, value) =>
-        val dotCasedKey = key.replaceAll("([A-Z])", ".$1").toLowerCase
-        options.put(s"cypher.$dotCasedKey", value)
+        options.put(key, value)
     }
     options
   }


### PR DESCRIPTION
Having white-list/static style of allowed cypher tuning parameters in
the preamble will likely not scale in the future if new parameters are
added in the cypher lang.

In hindsight it is much better to allow dynamic parameters for the
preamble. This PR introduces dynamic options for cypher tunings.

The options prefix is: "cypher.tuning.". Every option you set with this
prefix will then be passed to the `CYPHER` preamble as key-value pairs.

Examples:

```
.options("cypher.tuning.runtime", "parallel") =>
CYPHER runtime=parallel

.options("cypher.tuning.anyParameterYouWish", "set_to_value") =>
CYPHER anyParameterYouWish=set_to_value
```

Only validations run is that the parameter name must be alphanumeric
and must not contain any spaces or dots. However hyphens and
underscores are allowed.