### PR TITLE
feat: allow users to enable the legacy type conversion

### DIFF
--- a/src/main/scala/org/neo4j/spark/converter/DataConverter.scala
+++ b/src/main/scala/org/neo4j/spark/converter/DataConverter.scala
@@ -33,6 +33,7 @@ import org.neo4j.driver.types.IsoDuration
 import org.neo4j.driver.types.Node
 import org.neo4j.driver.types.Relationship
 import org.neo4j.spark.service.SchemaService
+import org.neo4j.spark.util.Neo4jOptions
 import org.neo4j.spark.util.Neo4jUtil
 
 import java.time._
@@ -57,9 +58,9 @@ trait DataConverter[T] {
 }
 
 object SparkToNeo4jDataConverter {
-  def apply(): SparkToNeo4jDataConverter = new SparkToNeo4jDataConverter()
+  def apply(options: Neo4jOptions): SparkToNeo4jDataConverter = new SparkToNeo4jDataConverter(options)
 
-  def dayTimeMicrosToNeo4jDuration(micros: Long): Value = {
+  private def dayTimeMicrosToNeo4jDuration(micros: Long): Value = {
     val oneSecondInMicros = 1000000L
     val oneDayInMicros = 24 * 3600 * oneSecondInMicros
     val numberDays = Math.floorDiv(micros, oneDayInMicros)
@@ -70,30 +71,35 @@ object SparkToNeo4jDataConverter {
   }
 
   // while Neo4j supports years, this driver version's API does not expose it.
-  def yearMonthIntervalToNeo4jDuration(months: Int): Value = {
+  private def yearMonthIntervalToNeo4jDuration(months: Int): Value = {
     Values.isoDuration(months.toLong, 0L, 0L, 0)
   }
 }
 
-class SparkToNeo4jDataConverter extends DataConverter[Value] {
+class SparkToNeo4jDataConverter(options: Neo4jOptions) extends DataConverter[Value] {
 
   override def convert(value: Any, dataType: DataType): Value = {
     value match {
-      case date: java.sql.Date           => convert(date.toLocalDate, dataType)
-      case timestamp: java.sql.Timestamp => convert(timestamp.toInstant.atZone(ZoneOffset.UTC), dataType)
+      case date: java.sql.Date => convert(date.toLocalDate, dataType)
+      case timestamp: java.sql.Timestamp =>
+        if (options.legacyTypeConversionEnabled) {
+          convert(timestamp.toLocalDateTime, dataType)
+        } else {
+          convert(timestamp.toInstant.atZone(ZoneOffset.UTC), dataType)
+        }
       case intValue: Int if dataType == DataTypes.DateType =>
         convert(
           DateTimeUtils
             .toJavaDate(intValue),
           dataType
         )
-      case intValue: Int if dataType.isInstanceOf[YearMonthIntervalType] =>
+      case intValue: Int if dataType.isInstanceOf[YearMonthIntervalType] && !options.legacyTypeConversionEnabled =>
         SparkToNeo4jDataConverter.yearMonthIntervalToNeo4jDuration(intValue)
       case longValue: Long if dataType == DataTypes.TimestampType =>
         convert(DateTimeUtils.toJavaTimestamp(longValue), dataType)
-      case longValue: Long if dataType == DataTypes.TimestampNTZType =>
+      case longValue: Long if dataType == DataTypes.TimestampNTZType && !options.legacyTypeConversionEnabled =>
         convert(DateTimeUtils.microsToLocalDateTime(longValue), dataType)
-      case longValue: Long if dataType.isInstanceOf[DayTimeIntervalType] =>
+      case longValue: Long if dataType.isInstanceOf[DayTimeIntervalType] && !options.legacyTypeConversionEnabled =>
         SparkToNeo4jDataConverter.dayTimeMicrosToNeo4jDuration(longValue)
       case unsafeRow: UnsafeRow =>
         val structType = extractStructType(dataType)
@@ -139,7 +145,7 @@ class SparkToNeo4jDataConverter extends DataConverter[Value] {
           case arrayType: ArrayType => arrayType.elementType
           case _                    => dataType
         }
-        if (sparkType == DataTypes.ByteType) {
+        if (sparkType == DataTypes.ByteType && !options.legacyTypeConversionEnabled) {
           Values.value(unsafeArray.toByteArray())
         } else {
           val javaList = unsafeArray.toSeq[AnyRef](sparkType)
@@ -166,10 +172,10 @@ class SparkToNeo4jDataConverter extends DataConverter[Value] {
 }
 
 object Neo4jToSparkDataConverter {
-  def apply(): Neo4jToSparkDataConverter = new Neo4jToSparkDataConverter()
+  def apply(options: Neo4jOptions): Neo4jToSparkDataConverter = new Neo4jToSparkDataConverter(options)
 }
 
-class Neo4jToSparkDataConverter extends DataConverter[Any] {
+class Neo4jToSparkDataConverter(options: Neo4jOptions) extends DataConverter[Any] {
 
   override def convert(value: Any, dataType: DataType): Any = {
     if (dataType != null && dataType == DataTypes.StringType && value != null && !value.isInstanceOf[String]) {
@@ -214,8 +220,13 @@ class Neo4jToSparkDataConverter extends DataConverter[Any] {
             UTF8String.fromString(d.toString)
           ))
         case zt: ZonedDateTime => DateTimeUtils.instantToMicros(zt.toInstant)
-        case dt: LocalDateTime => DateTimeUtils.localDateTimeToMicros(dt)
-        case d: LocalDate      => d.toEpochDay.toInt
+        case dt: LocalDateTime =>
+          if (options.legacyTypeConversionEnabled) {
+            DateTimeUtils.instantToMicros(dt.toInstant(ZoneOffset.UTC))
+          } else {
+            DateTimeUtils.localDateTimeToMicros(dt)
+          }
+        case d: LocalDate => d.toEpochDay.toInt
         case lt: LocalTime =>
           InternalRow.fromSeq(Seq(
             UTF8String.fromString(SchemaService.TIME_TYPE_LOCAL),

--- a/src/main/scala/org/neo4j/spark/converter/TypeConverter.scala
+++ b/src/main/scala/org/neo4j/spark/converter/TypeConverter.scala
@@ -29,18 +29,17 @@ import org.neo4j.spark.converter.CypherToSparkTypeConverter.timeType
 import org.neo4j.spark.converter.SparkToCypherTypeConverter.mapping
 import org.neo4j.spark.service.SchemaService.normalizedClassName
 import org.neo4j.spark.util.Neo4jImplicits.EntityImplicits
+import org.neo4j.spark.util.Neo4jOptions
 
 import scala.jdk.CollectionConverters.ListHasAsScala
 import scala.jdk.CollectionConverters.MapHasAsScala
 
 trait TypeConverter[SOURCE_TYPE, DESTINATION_TYPE] {
-
   def convert(sourceType: SOURCE_TYPE, value: Any = null): DESTINATION_TYPE
-
 }
 
 object CypherToSparkTypeConverter {
-  def apply(): CypherToSparkTypeConverter = new CypherToSparkTypeConverter()
+  def apply(options: Neo4jOptions): CypherToSparkTypeConverter = new CypherToSparkTypeConverter(options)
 
   private val cleanTerms: String = "Unmodifiable|Internal|Iso|2D|3D|Offset"
 
@@ -67,67 +66,79 @@ object CypherToSparkTypeConverter {
   ))
 }
 
-class CypherToSparkTypeConverter extends TypeConverter[String, DataType] {
+class CypherToSparkTypeConverter(options: Neo4jOptions) extends TypeConverter[String, DataType] {
 
-  override def convert(sourceType: String, value: Any = null): DataType = sourceType
-    .replaceAll(cleanTerms, "") match {
-    case "Node" | "Relationship" => if (value != null) value.asInstanceOf[Entity].toStruct else DataTypes.NullType
-    case "NodeArray" | "RelationshipArray" =>
-      if (value != null) DataTypes.createArrayType(value.asInstanceOf[Entity].toStruct) else DataTypes.NullType
-    case "Boolean"                    => DataTypes.BooleanType
-    case "Long"                       => DataTypes.LongType
-    case "Double"                     => DataTypes.DoubleType
-    case "Point"                      => pointType
-    case "DateTime" | "ZonedDateTime" => DataTypes.TimestampType
-    case "LocalDateTime"              => DataTypes.TimestampNTZType
-    case "Time" | "LocalTime"         => timeType
-    case "Date" | "LocalDate"         => DataTypes.DateType
-    case "Duration"                   => durationType
-    case "ByteArray"                  => DataTypes.BinaryType
-    case "Map" => {
-      val valueType = if (value == null) {
-        DataTypes.NullType
-      } else {
-        val map = value.asInstanceOf[java.util.Map[String, AnyRef]].asScala
-        val types = map.values
-          .map(normalizedClassName)
-          .toSet
-        if (types.size == 1) convert(types.head, map.values.head) else DataTypes.StringType
-      }
-      DataTypes.createMapType(DataTypes.StringType, valueType)
+  override def convert(sourceType: String, value: Any = null): DataType = {
+    var cleanedSourceType = sourceType.replaceAll(cleanTerms, "")
+    if (options.legacyTypeConversionEnabled) {
+      cleanedSourceType = cleanedSourceType.replaceAll("Local|Zoned", "")
     }
-    case "Array" => {
-      val valueType = if (value == null) {
-        DataTypes.NullType
-      } else {
-        val list = value.asInstanceOf[java.util.List[AnyRef]].asScala
-        val types = list
-          .map(normalizedClassName)
-          .toSet
-        if (types.size == 1) convert(types.head, list.head) else DataTypes.StringType
+    cleanedSourceType match {
+      case "Node" | "Relationship" =>
+        if (value != null) value.asInstanceOf[Entity].toStruct(options) else DataTypes.NullType
+      case "NodeArray" | "RelationshipArray" =>
+        if (value != null) DataTypes.createArrayType(value.asInstanceOf[Entity].toStruct(options))
+        else DataTypes.NullType
+      case "Boolean"                    => DataTypes.BooleanType
+      case "Long"                       => DataTypes.LongType
+      case "Double"                     => DataTypes.DoubleType
+      case "Point"                      => pointType
+      case "DateTime" | "ZonedDateTime" => DataTypes.TimestampType
+      case "LocalDateTime" =>
+        if (options.legacyTypeConversionEnabled) {
+          DataTypes.TimestampType
+        } else {
+          DataTypes.TimestampNTZType
+        }
+      case "Time" | "LocalTime" => timeType
+      case "Date" | "LocalDate" => DataTypes.DateType
+      case "Duration"           => durationType
+      case "ByteArray"          => DataTypes.BinaryType
+      case "Map" => {
+        val valueType = if (value == null) {
+          DataTypes.NullType
+        } else {
+          val map = value.asInstanceOf[java.util.Map[String, AnyRef]].asScala
+          val types = map.values
+            .map(value => normalizedClassName(value, options))
+            .toSet
+          if (types.size == 1) convert(types.head, map.values.head) else DataTypes.StringType
+        }
+        DataTypes.createMapType(DataTypes.StringType, valueType)
       }
-      DataTypes.createArrayType(valueType)
+      case "Array" => {
+        val valueType = if (value == null) {
+          DataTypes.NullType
+        } else {
+          val list = value.asInstanceOf[java.util.List[AnyRef]].asScala
+          val types = list
+            .map(value => normalizedClassName(value, options))
+            .toSet
+          if (types.size == 1) convert(types.head, list.head) else DataTypes.StringType
+        }
+        DataTypes.createArrayType(valueType)
+      }
+      // These are from APOC
+      case "StringArray"                          => DataTypes.createArrayType(DataTypes.StringType)
+      case "LongArray"                            => DataTypes.createArrayType(DataTypes.LongType)
+      case "DoubleArray"                          => DataTypes.createArrayType(DataTypes.DoubleType)
+      case "BooleanArray"                         => DataTypes.createArrayType(DataTypes.BooleanType)
+      case "PointArray"                           => DataTypes.createArrayType(pointType)
+      case "DateTimeArray" | "ZonedDateTimeArray" => DataTypes.createArrayType(DataTypes.TimestampType)
+      case "TimeArray" | "LocalTimeArray"         => DataTypes.createArrayType(timeType)
+      case "DateArray" | "LocalDateArray"         => DataTypes.createArrayType(DataTypes.DateType)
+      case "DurationArray"                        => DataTypes.createArrayType(durationType)
+      case "byte[]"                               => DataTypes.BinaryType
+      // Default is String
+      case _ => DataTypes.StringType
     }
-    // These are from APOC
-    case "StringArray"                          => DataTypes.createArrayType(DataTypes.StringType)
-    case "LongArray"                            => DataTypes.createArrayType(DataTypes.LongType)
-    case "DoubleArray"                          => DataTypes.createArrayType(DataTypes.DoubleType)
-    case "BooleanArray"                         => DataTypes.createArrayType(DataTypes.BooleanType)
-    case "PointArray"                           => DataTypes.createArrayType(pointType)
-    case "DateTimeArray" | "ZonedDateTimeArray" => DataTypes.createArrayType(DataTypes.TimestampType)
-    case "TimeArray" | "LocalTimeArray"         => DataTypes.createArrayType(timeType)
-    case "DateArray" | "LocalDateArray"         => DataTypes.createArrayType(DataTypes.DateType)
-    case "DurationArray"                        => DataTypes.createArrayType(durationType)
-    case "byte[]"                               => DataTypes.BinaryType
-    // Default is String
-    case _ => DataTypes.StringType
   }
 }
 
 object SparkToCypherTypeConverter {
-  def apply(): SparkToCypherTypeConverter = new SparkToCypherTypeConverter()
+  def apply(options: Neo4jOptions): SparkToCypherTypeConverter = new SparkToCypherTypeConverter(options)
 
-  private val mapping: Map[DataType, String] = Map(
+  private val baseMappings: Map[DataType, String] = Map(
     DataTypes.BooleanType -> "BOOLEAN",
     DataTypes.StringType -> "STRING",
     DecimalType.SYSTEM_DEFAULT -> "STRING",
@@ -138,34 +149,50 @@ object SparkToCypherTypeConverter {
     DataTypes.FloatType -> "FLOAT",
     DataTypes.DoubleType -> "FLOAT",
     DataTypes.DateType -> "DATE",
-    DataTypes.TimestampType -> "ZONED DATETIME",
-    DataTypes.TimestampNTZType -> "LOCAL DATETIME",
-    DayTimeIntervalType() -> "DURATION",
-    YearMonthIntervalType() -> "DURATION",
     durationType -> "DURATION",
     pointType -> "POINT",
     // Cypher graph entities do not allow null values in arrays
     DataTypes.createArrayType(DataTypes.BooleanType, false) -> "LIST<BOOLEAN NOT NULL>",
     DataTypes.createArrayType(DataTypes.StringType, false) -> "LIST<STRING NOT NULL>",
     DataTypes.createArrayType(DecimalType.SYSTEM_DEFAULT, false) -> "LIST<STRING NOT NULL>",
-    DataTypes.createArrayType(DataTypes.ByteType, false) -> "ByteArray",
     DataTypes.createArrayType(DataTypes.ShortType, false) -> "LIST<INTEGER NOT NULL>",
     DataTypes.createArrayType(DataTypes.IntegerType, false) -> "LIST<INTEGER NOT NULL>",
     DataTypes.createArrayType(DataTypes.LongType, false) -> "LIST<INTEGER NOT NULL>",
     DataTypes.createArrayType(DataTypes.FloatType, false) -> "LIST<FLOAT NOT NULL>",
     DataTypes.createArrayType(DataTypes.DoubleType, false) -> "LIST<FLOAT NOT NULL>",
     DataTypes.createArrayType(DataTypes.DateType, false) -> "LIST<DATE NOT NULL>",
-    DataTypes.createArrayType(DataTypes.TimestampType, false) -> "LIST<ZONED DATETIME NOT NULL>",
-    DataTypes.createArrayType(DataTypes.TimestampNTZType, false) -> "LIST<LOCAL DATETIME NOT NULL>",
-    DataTypes.createArrayType(DayTimeIntervalType(), false) -> "LIST<DURATION NOT NULL>",
-    DataTypes.createArrayType(DayTimeIntervalType(), true) -> "LIST<DURATION NOT NULL>",
-    DataTypes.createArrayType(YearMonthIntervalType(), false) -> "LIST<DURATION NOT NULL>",
-    DataTypes.createArrayType(YearMonthIntervalType(), true) -> "LIST<DURATION NOT NULL>",
     DataTypes.createArrayType(durationType, false) -> "LIST<DURATION NOT NULL>",
     DataTypes.createArrayType(pointType, false) -> "LIST<POINT NOT NULL>"
   )
+
+  private def mapping(sourceType: DataType, options: Neo4jOptions): String = {
+    val mappings = sourceTypeMappings(options)
+    mappings(sourceType)
+  }
+
+  private def sourceTypeMappings(options: Neo4jOptions): Map[DataType, String] = {
+    var result = baseMappings
+    if (options.legacyTypeConversionEnabled) {
+      result += (DataTypes.TimestampType -> "LOCAL DATETIME")
+      result += (DataTypes.createArrayType(DataTypes.TimestampType, false) -> "LIST<LOCAL DATETIME NOT NULL>")
+      result += (DataTypes.createArrayType(DataTypes.TimestampType, true) -> "LIST<LOCAL DATETIME NOT NULL>")
+    } else {
+      result += (DataTypes.TimestampType -> "ZONED DATETIME")
+      result += (DataTypes.TimestampNTZType -> "LOCAL DATETIME")
+      result += (DayTimeIntervalType() -> "DURATION")
+      result += (YearMonthIntervalType() -> "DURATION")
+      result += (DataTypes.createArrayType(DataTypes.ByteType, false) -> "ByteArray")
+      result += (DataTypes.createArrayType(DataTypes.TimestampType, false) -> "LIST<ZONED DATETIME NOT NULL>")
+      result += (DataTypes.createArrayType(DataTypes.TimestampNTZType, false) -> "LIST<LOCAL DATETIME NOT NULL>")
+      result += (DataTypes.createArrayType(DayTimeIntervalType(), false) -> "LIST<DURATION NOT NULL>")
+      result += (DataTypes.createArrayType(DayTimeIntervalType(), true) -> "LIST<DURATION NOT NULL>")
+      result += (DataTypes.createArrayType(YearMonthIntervalType(), false) -> "LIST<DURATION NOT NULL>")
+      result += (DataTypes.createArrayType(YearMonthIntervalType(), true) -> "LIST<DURATION NOT NULL>")
+    }
+    result
+  }
 }
 
-class SparkToCypherTypeConverter extends TypeConverter[DataType, String] {
-  override def convert(sourceType: DataType, value: Any): String = mapping(sourceType)
+class SparkToCypherTypeConverter(options: Neo4jOptions) extends TypeConverter[DataType, String] {
+  override def convert(sourceType: DataType, value: Any): String = mapping(sourceType, options)
 }

--- a/src/main/scala/org/neo4j/spark/reader/Neo4jScanBuilder.scala
+++ b/src/main/scala/org/neo4j/spark/reader/Neo4jScanBuilder.scala
@@ -57,7 +57,7 @@ class Neo4jScanBuilder(neo4jInfo: Neo4j, neo4jOptions: Neo4jOptions, jobId: Stri
       neo4jOptions,
       jobId,
       requiredSchema,
-      predicates.flatMap(_.toFilter),
+      predicates.flatMap(_.toFilter(neo4jOptions)),
       requiredColumns,
       aggregateColumns,
       topN.orElse(limit.map((limit: Int) => TopN(limit)))

--- a/src/main/scala/org/neo4j/spark/service/MappingService.scala
+++ b/src/main/scala/org/neo4j/spark/service/MappingService.scala
@@ -43,7 +43,7 @@ class Neo4jWriteMappingStrategy(private val options: Neo4jOptions)
     extends Neo4jMappingStrategy[InternalRow, Option[java.util.Map[String, AnyRef]]]
     with Logging {
 
-  private val dataConverter = SparkToNeo4jDataConverter()
+  private val dataConverter = SparkToNeo4jDataConverter(options)
 
   override def node(row: InternalRow, schema: StructType): Option[java.util.Map[String, AnyRef]] = {
     val rowMap: java.util.Map[String, Object] = new java.util.HashMap[String, Object]
@@ -210,7 +210,7 @@ class Neo4jWriteMappingStrategy(private val options: Neo4jOptions)
 class Neo4jReadMappingStrategy(private val options: Neo4jOptions, requiredColumns: StructType)
     extends Neo4jMappingStrategy[Record, InternalRow] {
 
-  private val dataConverter = Neo4jToSparkDataConverter()
+  private val dataConverter = Neo4jToSparkDataConverter(options)
 
   override def node(record: Record, schema: StructType): InternalRow = {
     if (requiredColumns.nonEmpty) {

--- a/src/main/scala/org/neo4j/spark/service/SchemaService.scala
+++ b/src/main/scala/org/neo4j/spark/service/SchemaService.scala
@@ -77,9 +77,9 @@ class SchemaService(
 
   private val sessionTransactionConfig = options.toNeo4jTransactionConfig
 
-  private val cypherToSparkTypeConverter = CypherToSparkTypeConverter()
+  private val cypherToSparkTypeConverter = CypherToSparkTypeConverter(options)
 
-  private val sparkToCypherTypeConverter = SparkToCypherTypeConverter()
+  private val sparkToCypherTypeConverter = SparkToCypherTypeConverter(options)
 
   private def structForNode(labels: Seq[String] = options.nodeMetadata.labels) = {
     val structFields: mutable.Buffer[StructField] = (try {
@@ -170,9 +170,9 @@ class SchemaService(
           case SchemaStrategy.SAMPLE => {
             val types = t._2.map(value => {
               if (options.query.queryType == QueryType.QUERY) {
-                normalizedClassName(value)
+                normalizedClassName(value, options)
               } else {
-                normalizedClassNameFromGraphEntity(value)
+                normalizedClassNameFromGraphEntity(value, options)
               }
             }).toSet
 
@@ -960,9 +960,9 @@ object SchemaService {
 
   val DURATION_TYPE = "duration"
 
-  def normalizedClassName(value: AnyRef): String = value match {
-    case _: Array[Byte]         => "ByteArray"
-    case _: java.util.List[_]   => "Array"
+  def normalizedClassName(value: AnyRef, options: Neo4jOptions): String = value match {
+    case _: Array[Byte]       => if (options.legacyTypeConversionEnabled) value.getClass.getSimpleName else "ByteArray"
+    case _: java.util.List[_] => "Array"
     case _: java.util.Map[_, _] => "Map"
     case null                   => "String"
     case _                      => value.getClass.getSimpleName
@@ -970,8 +970,8 @@ object SchemaService {
 
   // from nodes and relationships we cannot have maps as properties and elements in lists are the same type
   // special treatment for ByteArray required (pattern matching on Array != List)
-  def normalizedClassNameFromGraphEntity(value: AnyRef): String = value match {
-    case binary: Array[Byte]     => "ByteArray"
+  def normalizedClassNameFromGraphEntity(value: AnyRef, options: Neo4jOptions): String = value match {
+    case _: Array[Byte] => if (options.legacyTypeConversionEnabled) value.getClass.getSimpleName else "ByteArray"
     case list: java.util.List[_] => s"${list.get(0).getClass.getSimpleName}Array"
     case null                    => "String"
     case _                       => value.getClass.getSimpleName

--- a/src/main/scala/org/neo4j/spark/util/Neo4jImplicits.scala
+++ b/src/main/scala/org/neo4j/spark/util/Neo4jImplicits.scala
@@ -46,9 +46,6 @@ import javax.lang.model.SourceVersion
 
 object Neo4jImplicits {
 
-  private val sparkToNeo4jDataConverter = SparkToNeo4jDataConverter()
-  private val cypherToSparkTypeConverter = CypherToSparkTypeConverter()
-
   implicit class CypherImplicits(str: String) {
     private def isValidCypherIdentifier() = SourceVersion.isIdentifier(str) && !str.trim.startsWith("$")
 
@@ -88,13 +85,13 @@ object Neo4jImplicits {
 
   implicit class EntityImplicits(entity: Entity) {
 
-    def toStruct: StructType = {
+    def toStruct(options: Neo4jOptions): StructType = {
       val fields = entity.asMap().asScala
         .groupBy(_._1)
         .map(t => {
           val value = t._2.head._2
-          val cypherType = SchemaService.normalizedClassNameFromGraphEntity(value)
-          StructField(t._1, cypherToSparkTypeConverter.convert(cypherType))
+          val cypherType = SchemaService.normalizedClassNameFromGraphEntity(value, options)
+          StructField(t._1, CypherToSparkTypeConverter(options).convert(cypherType))
         })
       val entityFields = entity match {
         case _: Node => {
@@ -139,44 +136,49 @@ object Neo4jImplicits {
 
   implicit class PredicateImplicit(predicate: Predicate) {
 
-    def toFilter: Option[Filter] = {
+    def toFilter(options: Neo4jOptions): Option[Filter] = {
       predicate.name() match {
         case "IS_NULL"     => Some(IsNull(predicate.rawAttributeName()))
         case "IS_NOT_NULL" => Some(IsNotNull(predicate.rawAttributeName()))
         case "STARTS_WITH" =>
-          predicate.rawLiteralValue().map(lit => StringStartsWith(predicate.rawAttributeName(), lit.asString()))
+          predicate.rawLiteralValue(options).map(lit => StringStartsWith(predicate.rawAttributeName(), lit.asString()))
         case "ENDS_WITH" =>
-          predicate.rawLiteralValue().map(lit => StringEndsWith(predicate.rawAttributeName(), lit.asString()))
+          predicate.rawLiteralValue(options).map(lit => StringEndsWith(predicate.rawAttributeName(), lit.asString()))
         case "CONTAINS" =>
-          predicate.rawLiteralValue().map(lit => StringContains(predicate.rawAttributeName(), lit.asString()))
-        case "IN" => Some(In(predicate.rawAttributeName(), predicate.rawLiteralValues()))
-        case "="  => predicate.rawLiteralValue().map(lit => EqualTo(predicate.rawAttributeName(), lit.asObject()))
-        case "<>" => predicate.rawLiteralValue().map(lit => Not(EqualTo(predicate.rawAttributeName(), lit.asObject())))
+          predicate.rawLiteralValue(options).map(lit => StringContains(predicate.rawAttributeName(), lit.asString()))
+        case "IN" => Some(In(predicate.rawAttributeName(), predicate.rawLiteralValues(options)))
+        case "=" => predicate.rawLiteralValue(options).map(lit => EqualTo(predicate.rawAttributeName(), lit.asObject()))
+        case "<>" =>
+          predicate.rawLiteralValue(options).map(lit => Not(EqualTo(predicate.rawAttributeName(), lit.asObject())))
         case "<=>" =>
-          predicate.rawLiteralValue().map(lit => EqualNullSafe(predicate.rawAttributeName(), lit.asObject()))
-        case "<" => predicate.rawLiteralValue().map(lit => LessThan(predicate.rawAttributeName(), lit.asObject()))
+          predicate.rawLiteralValue(options).map(lit => EqualNullSafe(predicate.rawAttributeName(), lit.asObject()))
+        case "<" =>
+          predicate.rawLiteralValue(options).map(lit => LessThan(predicate.rawAttributeName(), lit.asObject()))
         case "<=" =>
-          predicate.rawLiteralValue().map(lit => LessThanOrEqual(predicate.rawAttributeName(), lit.asObject()))
-        case ">" => predicate.rawLiteralValue().map(lit => GreaterThan(predicate.rawAttributeName(), lit.asObject()))
+          predicate.rawLiteralValue(options).map(lit => LessThanOrEqual(predicate.rawAttributeName(), lit.asObject()))
+        case ">" =>
+          predicate.rawLiteralValue(options).map(lit => GreaterThan(predicate.rawAttributeName(), lit.asObject()))
         case ">=" =>
-          predicate.rawLiteralValue().map(lit => GreaterThanOrEqual(predicate.rawAttributeName(), lit.asObject()))
+          predicate.rawLiteralValue(options).map(lit =>
+            GreaterThanOrEqual(predicate.rawAttributeName(), lit.asObject())
+          )
         case "AND" =>
           val andPredicate = predicate.asInstanceOf[filter.And]
-          (andPredicate.left().toFilter, andPredicate.right().toFilter) match {
+          (andPredicate.left().toFilter(options), andPredicate.right().toFilter(options)) match {
             case (_, None)                 => None
             case (None, _)                 => None
             case (Some(left), Some(right)) => Some(And(left, right))
           }
         case "OR" =>
           val andPredicate = predicate.asInstanceOf[filter.Or]
-          (andPredicate.left().toFilter, andPredicate.right().toFilter) match {
+          (andPredicate.left().toFilter(options), andPredicate.right().toFilter(options)) match {
             case (_, None)                 => None
             case (None, _)                 => None
             case (Some(left), Some(right)) => Some(Or(left, right))
           }
         case "NOT" =>
           val notPredicate = predicate.asInstanceOf[filter.Not]
-          notPredicate.child().toFilter.map(Not)
+          notPredicate.child().toFilter(options).map(Not)
         case "ALWAYS_TRUE"  => Some(AlwaysTrue)
         case "ALWAYS_FALSE" => Some(AlwaysFalse)
       }
@@ -186,19 +188,19 @@ object Neo4jImplicits {
       predicate.references().head.fieldNames().mkString(".")
     }
 
-    def rawLiteralValue(): Option[Value] = {
+    def rawLiteralValue(options: Neo4jOptions): Option[Value] = {
       predicate.children()
         .filter(_.isInstanceOf[Literal[_]])
         .map(_.asInstanceOf[Literal[_]])
         .headOption
-        .map(literal => sparkToNeo4jDataConverter.convert(literal.value(), literal.dataType()))
+        .map(literal => SparkToNeo4jDataConverter(options).convert(literal.value(), literal.dataType()))
     }
 
-    def rawLiteralValues(): Array[Any] = {
+    def rawLiteralValues(options: Neo4jOptions): Array[Any] = {
       predicate.children()
         .filter(_.isInstanceOf[Literal[_]])
         .map(_.asInstanceOf[Literal[_]])
-        .map(v => sparkToNeo4jDataConverter.convert(v.value(), v.dataType()).asObject())
+        .map(v => SparkToNeo4jDataConverter(options).convert(v.value(), v.dataType()).asObject())
     }
   }
 

--- a/src/main/scala/org/neo4j/spark/util/Neo4jOptions.scala
+++ b/src/main/scala/org/neo4j/spark/util/Neo4jOptions.scala
@@ -31,6 +31,7 @@ import java.io.File
 import java.net.URI
 import java.time.Duration
 import java.util
+import java.util.Locale
 import java.util.ServiceLoader
 import java.util.UUID
 import java.util.concurrent.CompletableFuture
@@ -184,6 +185,11 @@ class Neo4jOptions(private val options: java.util.Map[String, String]) extends S
   )
 
   val nodeMetadata: Neo4jNodeMetadata = initNeo4jNodeMetadata()
+
+  val legacyTypeConversionEnabled: Boolean = getParameter(
+    TYPE_CONVERSION,
+    DEFAULT_TYPE_CONVERSION
+  ).toLowerCase(Locale.ROOT).equals("legacy")
 
   private def mapPropsString(strOpt: Option[String]): Option[Map[String, String]] = strOpt.map(str =>
     str.split(",")
@@ -764,6 +770,9 @@ object Neo4jOptions {
   val TUNING_UPDATE_STRATEGY = "cypher.update.strategy"
   val TUNING_UPDATE_STRATEGY_IN_CYPHER = "updateStrategy"
 
+  // Data conversion
+  val TYPE_CONVERSION = "type.conversion"
+
   // defaults
   val DEFAULT_EMPTY = ""
   val DEFAULT_TIMEOUT: Int = -1
@@ -804,6 +813,8 @@ object Neo4jOptions {
   var DEFAULT_AUTH_PARAMETERS: Map[String, String] =
     Seq("username", "password", "ticket", "principal", "credentials", "realm", "scheme", "token")
       .map(name => name -> DEFAULT_EMPTY).toMap
+
+  private val DEFAULT_TYPE_CONVERSION = "default"
 
   def fromSession(sparkSession: Option[SparkSession], options: java.util.Map[String, String]): Neo4jOptions = {
     val sessionLevelOptions = sparkSession

--- a/src/test/scala/org/neo4j/spark/DataSourceSchemaWriterTSE.scala
+++ b/src/test/scala/org/neo4j/spark/DataSourceSchemaWriterTSE.scala
@@ -19,14 +19,20 @@ package org.neo4j.spark
 import org.apache.spark.sql.DataFrame
 import org.apache.spark.sql.SaveMode
 import org.apache.spark.sql.SparkSession
+import org.apache.spark.sql.catalyst.util.DateTimeUtils
 import org.apache.spark.sql.types.DataTypes
+import org.apache.spark.sql.types.DayTimeIntervalType
 import org.apache.spark.sql.types.StructField
 import org.apache.spark.sql.types.StructType
+import org.apache.spark.sql.types.YearMonthIntervalType
+import org.junit.jupiter.api.Assertions.assertArrayEquals
 import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertTrue
 import org.junit.jupiter.api.Assumptions.assumeTrue
 import org.junit.jupiter.api.BeforeAll
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
+import org.neo4j.driver.types.IsoDuration
 import org.neo4j.spark.testsupport.SparkConnectorScalaBaseTSE
 import org.neo4j.spark.testsupport.SparkConnectorScalaSuiteIT
 import org.neo4j.spark.testsupport.TestUtil
@@ -39,6 +45,8 @@ import java.sql.Date
 import java.sql.Timestamp
 import java.time.LocalDate
 import java.time.LocalDateTime
+import java.time.ZoneId
+import java.time.ZoneOffset
 import java.time.ZonedDateTime
 import java.util.TimeZone
 
@@ -905,5 +913,179 @@ class DataSourceSchemaWriterTSE extends SparkConnectorScalaBaseTSE {
     )
 
     assertEquals(expectedConstraint, actualConstraint)
+  }
+
+  @Test
+  def shouldWriteNodeWithLegacyTypeConversionDisabledByDefault(): Unit = {
+    val df = sparkSession.sql(
+      """
+        |SELECT
+        |  'legacy-type-conversion' AS id,
+        |  timestamp('2025-01-01 11:11:11') AS timestamp,
+        |  CAST('2025-01-01 11:11:11' AS TIMESTAMP_NTZ) AS timestampNtz,
+        |  INTERVAL '4' DAY AS dayInterval,
+        |  INTERVAL '10 05' DAY TO HOUR AS dayToHour,
+        |  timestamp('2025-01-02 18:30:00.454') - timestamp('2024-01-01 00:00:00') AS arithmeticDuration,
+        |  INTERVAL '3' YEAR AS yearInterval,
+        |  INTERVAL '1-2' YEAR TO MONTH AS yearToMonth,
+        |  CAST('erik' AS BINARY) AS binary,
+        |  CAST(array(1, 2, 3) AS array<tinyint>) AS byteArray
+        |""".stripMargin
+    )
+    assertTrue(df.schema("dayInterval").dataType.isInstanceOf[DayTimeIntervalType])
+    assertTrue(df.schema("dayToHour").dataType.isInstanceOf[DayTimeIntervalType])
+    assertTrue(df.schema("arithmeticDuration").dataType.isInstanceOf[DayTimeIntervalType])
+    assertTrue(df.schema("yearInterval").dataType.isInstanceOf[YearMonthIntervalType])
+    assertTrue(df.schema("yearToMonth").dataType.isInstanceOf[YearMonthIntervalType])
+
+    df.write
+      .mode(SaveMode.Overwrite)
+      .format(classOf[DataSource].getName)
+      .option("url", SparkConnectorScalaSuiteIT.server.getBoltUrl)
+      .option("labels", ":LegacyTypeConversionDisabled")
+      .option("node.keys", "id")
+      .save()
+
+    val actual = SparkConnectorScalaSuiteIT.session().run(
+      """
+        |MATCH (n:LegacyTypeConversionDisabled {id: 'legacy-type-conversion'})
+        |RETURN n
+        |""".stripMargin
+    )
+      .single()
+      .get("n")
+      .asNode()
+      .asMap()
+      .asScala
+      .toMap
+    assertEquals(
+      Set(
+        "id",
+        "timestamp",
+        "timestampNtz",
+        "dayInterval",
+        "dayToHour",
+        "arithmeticDuration",
+        "yearInterval",
+        "yearToMonth",
+        "binary",
+        "byteArray"
+      ),
+      actual.keySet
+    )
+    assertEquals("legacy-type-conversion", actual("id"))
+    val expectedZoned = ZonedDateTime.of(2025, 1, 1, 11, 11, 11, 0, ZoneOffset.UTC)
+    assertEquals(expectedZoned, actual("timestamp"))
+    val expectedNtz = LocalDateTime.of(2025, 1, 1, 11, 11, 11)
+    assertEquals(expectedNtz, actual("timestampNtz"))
+    val dayInterval = actual("dayInterval").asInstanceOf[IsoDuration]
+    assertEquals(0L, dayInterval.months())
+    assertEquals(4L, dayInterval.days())
+    assertEquals(0L, dayInterval.seconds())
+    assertEquals(0, dayInterval.nanoseconds())
+    val dayToHour = actual("dayToHour").asInstanceOf[IsoDuration]
+    assertEquals(0L, dayToHour.months())
+    assertEquals(10L, dayToHour.days())
+    assertEquals(18000L, dayToHour.seconds())
+    assertEquals(0, dayToHour.nanoseconds())
+    val arithmetic = actual("arithmeticDuration").asInstanceOf[IsoDuration]
+    assertEquals(0L, arithmetic.months())
+    assertEquals(367L, arithmetic.days())
+    assertEquals(66600L, arithmetic.seconds())
+    assertEquals(454000000, arithmetic.nanoseconds())
+    val yearInterval = actual("yearInterval").asInstanceOf[IsoDuration]
+    assertEquals(36L, yearInterval.months())
+    assertEquals(0L, yearInterval.days())
+    assertEquals(0L, yearInterval.seconds())
+    assertEquals(0, yearInterval.nanoseconds())
+    val yearToMonth = actual("yearToMonth").asInstanceOf[IsoDuration]
+    assertEquals(14L, yearToMonth.months())
+    assertEquals(0L, yearToMonth.days())
+    assertEquals(0L, yearToMonth.seconds())
+    assertEquals(0, yearToMonth.nanoseconds())
+    assertArrayEquals(Array[Byte](101, 114, 105, 107), actual("binary").asInstanceOf[Array[Byte]])
+    assertArrayEquals(Array[Byte](1, 2, 3), actual("byteArray").asInstanceOf[Array[Byte]])
+  }
+
+  @Test
+  def shouldWriteNodeWithLegacyTypeConversionEnabled(): Unit = {
+    val df = sparkSession.sql(
+      """
+        |SELECT
+        |  'legacy-type-conversion' AS id,
+        |  timestamp('2025-01-01 11:11:11') AS timestamp,
+        |  CAST('2025-01-01 11:11:11' AS TIMESTAMP_NTZ) AS timestampNtz,
+        |  INTERVAL '4' DAY AS dayInterval,
+        |  INTERVAL '10 05' DAY TO HOUR AS dayToHour,
+        |  timestamp('2025-01-02 18:30:00.454') - timestamp('2024-01-01 00:00:00') AS arithmeticDuration,
+        |  INTERVAL '3' YEAR AS yearInterval,
+        |  INTERVAL '1-2' YEAR TO MONTH AS yearToMonth,
+        |  CAST('erik' AS BINARY) AS binary,
+        |  CAST(array(1, 2, 3) AS array<tinyint>) AS byteArray
+        |""".stripMargin
+    )
+    assertTrue(df.schema("dayInterval").dataType.isInstanceOf[DayTimeIntervalType])
+    assertTrue(df.schema("dayToHour").dataType.isInstanceOf[DayTimeIntervalType])
+    assertTrue(df.schema("arithmeticDuration").dataType.isInstanceOf[DayTimeIntervalType])
+    assertTrue(df.schema("yearInterval").dataType.isInstanceOf[YearMonthIntervalType])
+    assertTrue(df.schema("yearToMonth").dataType.isInstanceOf[YearMonthIntervalType])
+
+    df.write
+      .mode(SaveMode.Overwrite)
+      .format(classOf[DataSource].getName)
+      .option("url", SparkConnectorScalaSuiteIT.server.getBoltUrl)
+      .option("labels", ":LegacyTypeConversionEnabled")
+      .option("node.keys", "id")
+      .option(Neo4jOptions.TYPE_CONVERSION, "legacy")
+      .save()
+
+    val actual = SparkConnectorScalaSuiteIT.session().run(
+      """
+        |MATCH (n:LegacyTypeConversionEnabled {id: 'legacy-type-conversion'})
+        |RETURN n
+        |""".stripMargin
+    )
+      .single()
+      .get("n")
+      .asNode()
+      .asMap()
+      .asScala
+      .toMap
+    assertEquals(
+      Set(
+        "id",
+        "timestamp",
+        "timestampNtz",
+        "dayInterval",
+        "dayToHour",
+        "arithmeticDuration",
+        "yearInterval",
+        "yearToMonth",
+        "binary",
+        "byteArray"
+      ),
+      actual.keySet
+    )
+    assertEquals("legacy-type-conversion", actual("id"))
+    val expectedTimestamp = ZonedDateTime.of(2025, 1, 1, 11, 11, 11, 0, ZoneOffset.UTC)
+      .withZoneSameInstant(ZoneId.systemDefault())
+      .toLocalDateTime
+    assertEquals(expectedTimestamp, actual("timestamp"))
+    assertEquals(
+      DateTimeUtils.localDateTimeToMicros(LocalDateTime.of(2025, 1, 1, 11, 11, 11)),
+      actual("timestampNtz").asInstanceOf[java.lang.Number].longValue()
+    )
+    assertEquals(4L * 24L * 3600L * 1000000L, actual("dayInterval").asInstanceOf[java.lang.Number].longValue())
+    assertEquals((10L * 24L + 5L) * 3600L * 1000000L, actual("dayToHour").asInstanceOf[java.lang.Number].longValue())
+    assertEquals(
+      (367L * 24L * 3600L + 66600L) * 1000000L + 454000L,
+      actual("arithmeticDuration").asInstanceOf[java.lang.Number].longValue()
+    )
+    assertEquals(36L, actual("yearInterval").asInstanceOf[java.lang.Number].longValue())
+    assertEquals(14L, actual("yearToMonth").asInstanceOf[java.lang.Number].longValue())
+    assertArrayEquals(Array[Byte](101, 114, 105, 107), actual("binary").asInstanceOf[Array[Byte]])
+    val byteArray = actual("byteArray").asInstanceOf[java.util.List[_]].asScala
+      .map(_.asInstanceOf[java.lang.Number].longValue())
+    assertEquals(Seq(1L, 2L, 3L), byteArray)
   }
 }


### PR DESCRIPTION
Users can now force the legacy conversion logic for existing supported types, as it was before #816 and #796.

This concerns timestamps, durations/intervals and byte arrays.

Cherry pick of: 1ac19c3b4b0c5973f1c56be8c7db7fc3828c5c26