### PR TITLE
feat: wrap user-defined read query as CALL subquery

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -165,6 +165,11 @@
             <version>${cypherdsl.version}</version>
         </dependency>
         <dependency>
+            <groupId>org.neo4j</groupId>
+            <artifactId>neo4j-cypher-dsl-parser</artifactId>
+            <version>${cypherdsl.version}</version>
+        </dependency>
+        <dependency>
             <groupId>org.neo4j.connectors</groupId>
             <artifactId>commons-authn-spi</artifactId>
             <version>${connectors-commons.version}</version>

--- a/src/main/scala/org/neo4j/spark/cypher/AutomaticAliaser.scala
+++ b/src/main/scala/org/neo4j/spark/cypher/AutomaticAliaser.scala
@@ -1,0 +1,71 @@
+/*
+ * Copyright (c) "Neo4j"
+ * Neo4j Sweden AB [https://neo4j.com]
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.neo4j.spark.cypher
+
+import org.neo4j.cypherdsl.core.Expression
+import org.neo4j.cypherdsl.core.FunctionInvocation
+import org.neo4j.cypherdsl.core.ListExpression
+import org.neo4j.cypherdsl.core.ListOperator
+import org.neo4j.cypherdsl.core.Literal
+import org.neo4j.cypherdsl.core.MapExpression
+import org.neo4j.cypherdsl.core.Parameter
+import org.neo4j.cypherdsl.core.Property
+import org.neo4j.cypherdsl.core.ast.Visitable
+import org.neo4j.cypherdsl.core.renderer.Configuration
+import org.neo4j.cypherdsl.core.renderer.GeneralizedRenderer
+import org.neo4j.cypherdsl.core.renderer.Renderer
+import org.neo4j.cypherdsl.parser.CypherParser
+import org.neo4j.cypherdsl.parser.ExpressionCreatedEventType.ON_RETURN_ITEM
+import org.neo4j.cypherdsl.parser.Options
+import org.neo4j.spark.cypher.AutomaticAliaser.defaultRenderer
+
+class AutomaticAliaser(private val fragmentRenderer: GeneralizedRenderer = defaultRenderer()) {
+
+  def aliasResults(query: String): String = {
+    val statement: Visitable = CypherParser.parse(query, renderingOptions())
+    fragmentRenderer.render(statement)
+  }
+
+  private def renderingOptions() =
+    Options.newOptions.withCallback(
+      ON_RETURN_ITEM,
+      classOf[Expression],
+      alias _
+    ).build
+
+  private def alias(expression: Expression): Expression =
+    expression match {
+      case literal: Literal[_]                    => literal.as(fragmentRenderer.render(literal))
+      case param: Parameter[_]                    => param.as(fragmentRenderer.render(param))
+      case listExpression: ListExpression         => listExpression.as(fragmentRenderer.render(listExpression))
+      case mapExpression: MapExpression           => mapExpression.as(fragmentRenderer.render(mapExpression))
+      case functionInvocation: FunctionInvocation => functionInvocation.as(fragmentRenderer.render(functionInvocation))
+      case listAccess: ListOperator               => listAccess.as(fragmentRenderer.render(listAccess))
+      case property: Property                     => property.as(fragmentRenderer.render(property))
+      case _                                      => expression
+    }
+}
+
+private object AutomaticAliaser {
+
+  def defaultRenderer(): GeneralizedRenderer = {
+    val config = Configuration.newConfig()
+      .alwaysEscapeNames(false)
+      .build()
+    Renderer.getRenderer(config, classOf[GeneralizedRenderer])
+  }
+}

--- a/src/main/scala/org/neo4j/spark/reader/BasePartitionReader.scala
+++ b/src/main/scala/org/neo4j/spark/reader/BasePartitionReader.scala
@@ -26,6 +26,7 @@ import org.neo4j.driver.Record
 import org.neo4j.driver.Session
 import org.neo4j.driver.Transaction
 import org.neo4j.driver.Values
+import org.neo4j.spark.cypher.AutomaticAliaser
 import org.neo4j.spark.cypher.CypherRenderer
 import org.neo4j.spark.service._
 import org.neo4j.spark.util.DriverCache
@@ -153,6 +154,7 @@ abstract class BasePartitionReader(
       new Neo4jQueryReadStrategy(
         neo4j,
         new CypherRenderer(neo4j, options),
+        new AutomaticAliaser(),
         filters,
         partitionSkipLimit,
         requiredColumns.fieldNames.toIndexedSeq,

--- a/src/main/scala/org/neo4j/spark/service/MappingService.scala
+++ b/src/main/scala/org/neo4j/spark/service/MappingService.scala
@@ -296,9 +296,7 @@ class Neo4jReadMappingStrategy(private val options: Neo4jOptions, requiredColumn
   }
 
   override def query(elem: Record, schema: StructType): InternalRow = mapToInternalRow(
-    elem.asMap(new function.Function[Value, Any] {
-      override def apply(t: Value): Any = t.asObject()
-    }),
+    elem.asMap((t: Value) => t.asObject()),
     schema
   )
 }

--- a/src/main/scala/org/neo4j/spark/service/Neo4jQueryService.scala
+++ b/src/main/scala/org/neo4j/spark/service/Neo4jQueryService.scala
@@ -26,7 +26,15 @@ import org.apache.spark.sql.sources.And
 import org.apache.spark.sql.sources.Filter
 import org.apache.spark.sql.sources.Or
 import org.neo4j.caniuse.Neo4j
+import org.neo4j.cypherdsl.core.Cypher.callRawCypher
 import org.neo4j.cypherdsl.core._
+import org.neo4j.cypherdsl.core.renderer.Configuration
+import org.neo4j.cypherdsl.core.renderer.GeneralizedRenderer
+import org.neo4j.cypherdsl.core.renderer.Renderer
+import org.neo4j.cypherdsl.parser.CypherParser
+import org.neo4j.cypherdsl.parser.ExpressionCreatedEventType
+import org.neo4j.cypherdsl.parser.Options
+import org.neo4j.spark.cypher.AutomaticAliaser
 import org.neo4j.spark.cypher.CypherPreamble.fullPreamble
 import org.neo4j.spark.cypher.CypherRenderer
 import org.neo4j.spark.service.Neo4jQueryStrategy.VARIABLE_EVENT
@@ -191,6 +199,7 @@ class Neo4jQueryWriteStrategy(
 class Neo4jQueryReadStrategy(
   private val neo4j: Neo4j,
   private val renderer: CypherRenderer,
+  private val aliaser: AutomaticAliaser,
   private val filters: Array[Filter] = Array.empty[Filter],
   private val partitionPagination: PartitionPagination = PartitionPagination.EMPTY,
   private val requiredColumns: Seq[String] = Seq.empty,
@@ -202,23 +211,33 @@ class Neo4jQueryReadStrategy(
   private val hasSkipLimit: Boolean = partitionPagination.skip != -1 && partitionPagination.topN.limit != -1
 
   override def createStatementForQuery(options: Neo4jOptions): String = {
-    if (partitionPagination.topN.orders.nonEmpty) {
-      logWarning(
-        s"""Top N push-down optimizations with aggregations are not supported for custom queries.
-           |\tThese aggregations are going to be ignored.
-           |\tPlease specify the aggregations in the custom query directly""".stripMargin
-      )
-    }
-
-    val limitedQuery = if (hasSkipLimit) {
-      s"${options.query.value} SKIP ${partitionPagination.skip} LIMIT ${partitionPagination.topN.limit}"
-    } else {
-      s"${options.query.value}"
-    }
-
     val scriptResult = scriptResultClause(options)
+    val query = aliaser.aliasResults(options.query.value)
+    var statement: StatementBuilder.BuildableStatement[ResultStatement] =
+      callRawCypher(s"$scriptResult${query}")
+        .returning(Cypher.asterisk())
+    if (partitionPagination.topN.orders.nonEmpty) {
+      statement = statement
+        .asInstanceOf[StatementBuilder.TerminalExposesOrderBy]
+        .orderBy(partitionPagination.topN
+          .orders
+          .map(order => {
+            convertSort(order)
+          })
+          .toSeq
+          .asJava)
+    }
+    if (partitionPagination.skip != -1) {
+      statement = statement.asInstanceOf[StatementBuilder.TerminalExposesSkip]
+        .skip(partitionPagination.skip)
+    }
+    if (partitionPagination.topN.limit != -1) {
+      statement = statement.asInstanceOf[StatementBuilder.TerminalExposesLimit]
+        .limit(partitionPagination.topN.limit)
+    }
+
     val preamble = if (withPreamble) fullPreamble(neo4j, options) else ""
-    s"$preamble$scriptResult$limitedQuery"
+    s"$preamble${renderer.render(statement.build())}"
   }
 
   override def createStatementForRelationships(options: Neo4jOptions): String = {
@@ -258,15 +277,21 @@ class Neo4jQueryReadStrategy(
         }
       case _ => Some(entity)
     }
-    val direction =
-      if (order.direction() == SortDirection.ASCENDING) SortItem.Direction.ASC else SortItem.Direction.DESC
 
     Cypher.sort(
       container
         .map(_.property(sortExpression.removeAlias()))
         .getOrElse(Cypher.name(sortExpression.unquote())),
-      direction
+      direction(order)
     )
+  }
+
+  private def convertSort(order: SortOrder): SortItem = {
+    Cypher.sort(Cypher.name(order.expression().describe().unquote()), direction(order))
+  }
+
+  private def direction(order: SortOrder): SortItem.Direction = {
+    if (order.direction() == SortDirection.ASCENDING) SortItem.Direction.ASC else SortItem.Direction.DESC
   }
 
   private def buildReturnExpression(sourceNode: Node, targetNode: Node, relationship: Relationship): Seq[Expression] = {
@@ -310,14 +335,19 @@ class Neo4jQueryReadStrategy(
     fields: Seq[Expression]
   ): Statement = {
     val ret = if (hasSkipLimit) {
-      val id = entity match {
+      val id: FunctionInvocation = entity match {
         case node: Node        => Cypher.elementId(node)
         case rel: Relationship => Cypher.elementId(rel)
       }
-      query
-        .`with`(entity)
-        // Spark does not push down limits/top N when aggregation is involved
-        .orderBy(id)
+
+      val statement = query.`with`(entity)
+      val orderedStatement: StatementBuilder.ExposesSkip = if (partitionPagination.topN.orders.nonEmpty) {
+        statement.orderBy(partitionPagination.topN.orders.map(order => convertSort(entity, order)): _*)
+      } else {
+        statement.orderBy(id)
+      }
+
+      orderedStatement
         .skip(partitionPagination.skip)
         .limit(partitionPagination.topN.limit)
         .returning(fields: _*)

--- a/src/main/scala/org/neo4j/spark/service/SchemaService.scala
+++ b/src/main/scala/org/neo4j/spark/service/SchemaService.scala
@@ -36,6 +36,7 @@ import org.neo4j.driver.summary
 import org.neo4j.spark.config.TopN
 import org.neo4j.spark.converter.CypherToSparkTypeConverter
 import org.neo4j.spark.converter.SparkToCypherTypeConverter
+import org.neo4j.spark.cypher.AutomaticAliaser
 import org.neo4j.spark.cypher.CypherPreamble.fullPreamble
 import org.neo4j.spark.cypher.CypherRenderer
 import org.neo4j.spark.service.SchemaService.normalizedClassName
@@ -71,7 +72,7 @@ class SchemaService(
   private val renderer = new CypherRenderer(neo4j, options)
 
   private val queryReadStrategy =
-    new Neo4jQueryReadStrategy(neo4j, renderer, filters, withPreamble = false)
+    new Neo4jQueryReadStrategy(neo4j, renderer, new AutomaticAliaser(), filters, withPreamble = false)
 
   private val session: Session = driverCache.getOrCreate().session(options.session.toNeo4jSession())
 

--- a/src/main/scala/org/neo4j/spark/streaming/BaseStreamingPartitionReader.scala
+++ b/src/main/scala/org/neo4j/spark/streaming/BaseStreamingPartitionReader.scala
@@ -23,6 +23,7 @@ import org.apache.spark.sql.sources.LessThanOrEqual
 import org.apache.spark.sql.types.StructType
 import org.neo4j.caniuse.Neo4j
 import org.neo4j.cypherdsl.core.Cypher
+import org.neo4j.spark.cypher.AutomaticAliaser
 import org.neo4j.spark.cypher.CypherPreamble.fullPreamble
 import org.neo4j.spark.cypher.CypherRenderer
 import org.neo4j.spark.reader.BasePartitionReader
@@ -102,6 +103,7 @@ class BaseStreamingPartitionReader(
           new Neo4jQueryReadStrategy(
             neo4j,
             new CypherRenderer(neo4j, options),
+            new AutomaticAliaser(),
             filters,
             partitionSkipLimit,
             requiredColumns.fieldNames.toIndexedSeq,

--- a/src/test/scala/org/neo4j/spark/GraphDataScienceIT.scala
+++ b/src/test/scala/org/neo4j/spark/GraphDataScienceIT.scala
@@ -40,6 +40,7 @@ import org.junit.jupiter.params.provider.MethodSource
 import org.neo4j.caniuse.Neo4j
 import org.neo4j.caniuse.Neo4jDetector
 import org.neo4j.driver.Driver
+import org.neo4j.spark.cypher.AutomaticAliaser
 import org.neo4j.spark.cypher.CypherRenderer
 import org.neo4j.spark.service.Neo4jQueryReadStrategy
 import org.neo4j.spark.service.Neo4jQueryService
@@ -316,6 +317,7 @@ class GraphDataScienceIT {
       new Neo4jQueryReadStrategy(
         neo4j,
         new CypherRenderer(neo4j, neo4jOptions),
+        new AutomaticAliaser(),
         Array.empty,
         PartitionPagination.EMPTY,
         List(
@@ -365,6 +367,7 @@ class GraphDataScienceIT {
         new Neo4jQueryReadStrategy(
           neo4j,
           new CypherRenderer(neo4j, neo4jOptions),
+          new AutomaticAliaser(),
           Array.empty,
           PartitionPagination.EMPTY,
           List(

--- a/src/test/scala/org/neo4j/spark/ReadIT.scala
+++ b/src/test/scala/org/neo4j/spark/ReadIT.scala
@@ -1685,7 +1685,7 @@ class ReadIT {
         .load()
 
       assertThat(df.count()).isEqualTo(100)
-      assertThat(df.columns.toSeq).isEqualTo(immutable.Seq("personId", "productId", "map", "someString", "map2"))
+      assertThat(df.columns).containsOnly("personId", "productId", "map", "someString", "map2")
     }
 
     @Test
@@ -1705,7 +1705,7 @@ class ReadIT {
         .load()
 
       assertThat(df.count()).isEqualTo(0)
-      assertThat(df.columns.toSeq).isEqualTo(immutable.Seq("personId", "productId", "map", "someString", "map2"))
+      assertThat(df.columns).containsOnly("personId", "productId", "map", "someString", "map2")
     }
 
     @Test
@@ -1819,20 +1819,6 @@ class ReadIT {
           && row.getAs[java.lang.Double]("quantity") != null
       ))
         .isEqualTo(100)
-    }
-
-    @Test
-    def orders_columns_by_their_declaration_order_in_query_return_clause(): Unit = {
-      driver.executableQuery("CREATE (:Instrument{name: 'Drums', id: 1}), (:Instrument{name: 'Guitar', id: 2})")
-        .execute()
-
-      val df = spark.read
-        .format(classOf[DataSource].getName)
-        .option("query", "MATCH (i:Instrument) RETURN elementId(i) as internal_id, i.id as id, i.name as name, i.name")
-        .load()
-        .orderBy("id")
-
-      assertThat(df.columns.toSet).isEqualTo(Set("internal_id", "id", "name", "i.name"))
     }
 
     @Test

--- a/src/test/scala/org/neo4j/spark/cypher/AutomaticAliaserIT.scala
+++ b/src/test/scala/org/neo4j/spark/cypher/AutomaticAliaserIT.scala
@@ -34,6 +34,7 @@ import org.neo4j.cypherdsl.core.Cypher.asterisk
 import org.neo4j.cypherdsl.core.Cypher.callRawCypher
 import org.neo4j.driver.Driver
 import org.neo4j.driver.exceptions.ClientException
+import org.neo4j.spark.testsupport.Neo4jContainerProvider.ADMIN_PASSWORD
 import org.neo4j.spark.testsupport.Neo4jExtensions.Neo4jContainerExtensions
 import org.neo4j.spark.testsupport.TestUtil
 import org.testcontainers.junit.jupiter.Container
@@ -50,7 +51,7 @@ class AutomaticAliaserIT {
 
   @Container
   private val container = new Neo4jContainer(TestUtil.neo4jImage())
-    .withAdminPassword("letmein!")
+    .withAdminPassword(ADMIN_PASSWORD)
     .withEnv("NEO4J_ACCEPT_LICENSE_AGREEMENT", "yes")
 
   private var driver: Option[Driver] = None

--- a/src/test/scala/org/neo4j/spark/cypher/AutomaticAliaserIT.scala
+++ b/src/test/scala/org/neo4j/spark/cypher/AutomaticAliaserIT.scala
@@ -1,0 +1,169 @@
+/*
+ * Copyright (c) "Neo4j"
+ * Neo4j Sweden AB [https://neo4j.com]
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.neo4j.spark.cypher
+
+import org.assertj.core.api.Assertions.assertThat
+import org.assertj.core.api.Assertions.assertThatCode
+import org.assertj.core.api.Assertions.assertThatObject
+import org.assertj.core.api.Assertions.assertThatThrownBy
+import org.junit.jupiter.api.AfterEach
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.TestInstance
+import org.junit.jupiter.api.TestInstance.Lifecycle.PER_CLASS
+import org.junit.jupiter.params.ParameterizedTest
+import org.junit.jupiter.params.provider.Arguments
+import org.junit.jupiter.params.provider.Arguments.argumentSet
+import org.junit.jupiter.params.provider.MethodSource
+import org.neo4j.cypherdsl.core.Cypher
+import org.neo4j.cypherdsl.core.Cypher.asterisk
+import org.neo4j.cypherdsl.core.Cypher.callRawCypher
+import org.neo4j.driver.Driver
+import org.neo4j.driver.exceptions.ClientException
+import org.neo4j.spark.testsupport.Neo4jExtensions.Neo4jContainerExtensions
+import org.neo4j.spark.testsupport.TestUtil
+import org.testcontainers.junit.jupiter.Container
+import org.testcontainers.junit.jupiter.Testcontainers
+import org.testcontainers.neo4j.Neo4jContainer
+
+import java.util.stream.Stream
+
+import scala.jdk.CollectionConverters.MapHasAsJava
+
+@Testcontainers
+@TestInstance(PER_CLASS)
+class AutomaticAliaserIT {
+
+  @Container
+  private val container = new Neo4jContainer(TestUtil.neo4jImage())
+    .withAdminPassword("letmein!")
+    .withEnv("NEO4J_ACCEPT_LICENSE_AGREEMENT", "yes")
+
+  private var driver: Option[Driver] = None
+
+  private val aliaser = new AutomaticAliaser()
+
+  @BeforeEach
+  def prepare(): Unit = {
+    val newDriver = container.driver()
+    newDriver.verifyConnectivity()
+    driver = Option(newDriver)
+  }
+
+  @AfterEach
+  def cleanUp(): Unit = {
+    driver.foreach(_.close())
+  }
+
+  @ParameterizedTest
+  @MethodSource(Array("alias_cases"))
+  def aliases_query_for_subquery_embedding(subquery: String, params: Map[String, AnyRef]): Unit = {
+    assertThat(driver.isDefined).isTrue
+    val renderer = container.cypherRenderer()
+    val unaliasedQueryStatement = callRawCypher(subquery).returning(asterisk()).build()
+    // see https://neo4j.com/docs/status-codes/current/errors/gql-errors/42N21/
+    verifyQueryFailsWithAliasingError(renderer.render(unaliasedQueryStatement))
+
+    val aliasedQueryStatement = callRawCypher(aliaser.aliasResults(subquery)).returning(asterisk()).build()
+
+    assertThatCode(() =>
+      driver.get.executableQuery(renderer.render(aliasedQueryStatement))
+        .withParameters(params.asJava)
+        .execute()
+    )
+      .doesNotThrowAnyException()
+  }
+
+  private def alias_cases(): Stream[Arguments] = {
+    {
+      Stream.of(
+        argumentSet(
+          "unaliased number literal",
+          "RETURN 42",
+          Map[String, AnyRef]()
+        ),
+        argumentSet(
+          "unaliased boolean literal",
+          "RETURN false",
+          Map[String, AnyRef]()
+        ),
+        argumentSet(
+          "unaliased string literal",
+          "RETURN 'foo'",
+          Map[String, AnyRef]()
+        ),
+        argumentSet(
+          "unaliased array literal",
+          "RETURN ['foo']",
+          Map[String, AnyRef]()
+        ),
+        argumentSet(
+          "unaliased map literal",
+          "RETURN {foo: 'bar'}",
+          Map[String, AnyRef]()
+        ),
+        argumentSet(
+          "unaliased parameter",
+          "RETURN $foo",
+          Map[String, AnyRef]("foo" -> "")
+        ),
+        argumentSet(
+          "unaliased function call",
+          "UNWIND [1, 2, 3] AS x RETURN avg(x)",
+          Map[String, AnyRef]()
+        ),
+        argumentSet(
+          "unaliased node property",
+          "MATCH (n:Person) RETURN n.bar",
+          Map[String, AnyRef]()
+        ),
+        argumentSet(
+          "unaliased relationship property",
+          "MATCH ()-[r:LINKS]->() RETURN r.bar",
+          Map[String, AnyRef]()
+        ),
+        argumentSet(
+          "unaliased field access",
+          "UNWIND [{foo: 'bar'}] AS object RETURN object.foo",
+          Map[String, AnyRef]()
+        ),
+        argumentSet(
+          "unaliased indexed array access",
+          "UNWIND [['foo']] AS array RETURN array[0]",
+          Map[String, AnyRef]()
+        )
+      )
+    }
+
+  }
+
+  private def verifyQueryFailsWithAliasingError(query: String): Unit = {
+    assertThatThrownBy(() => driver.get.executableQuery(query).execute())
+      .isInstanceOfSatisfying(
+        classOf[ClientException],
+        (e: ClientException) =>
+          assertThatObject(e.gqlStatus() == "42N21" || Option(e.getMessage).exists(_.contains("must be aliased")))
+            .overridingErrorMessage(
+              "expected query to fail with GQL status <42N21> or message containing <must be aliased>, " +
+                "but got GQL status <%s> and message <%s>",
+              e.gqlStatus(),
+              e.getMessage
+            )
+            .isEqualTo(true)
+      )
+  }
+}

--- a/src/test/scala/org/neo4j/spark/cypher/AutomaticAliaserTest.scala
+++ b/src/test/scala/org/neo4j/spark/cypher/AutomaticAliaserTest.scala
@@ -1,0 +1,169 @@
+/*
+ * Copyright (c) "Neo4j"
+ * Neo4j Sweden AB [https://neo4j.com]
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.neo4j.spark.cypher;
+
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.TestInstance
+import org.junit.jupiter.api.TestInstance.Lifecycle
+import org.junit.jupiter.params.ParameterizedTest
+import org.junit.jupiter.params.provider.Arguments
+import org.junit.jupiter.params.provider.Arguments.argumentSet
+import org.junit.jupiter.params.provider.MethodSource
+
+import java.util.stream.Stream;
+
+@TestInstance(Lifecycle.PER_CLASS)
+class AutomaticAliaserTest {
+
+  @ParameterizedTest
+  @MethodSource(Array("alias_cases"))
+  def aliases_query(initialQuery: String, expectedQuery: String): Unit = {
+    val query = new AutomaticAliaser().aliasResults(initialQuery)
+
+    assertThat(query).isEqualTo(expectedQuery)
+  }
+
+  @ParameterizedTest
+  @MethodSource(Array("preserve_cases"))
+  def preserves_query(query: String): Unit = {
+    val result = new AutomaticAliaser().aliasResults(query)
+
+    assertThat(result).isEqualTo(query)
+  }
+
+  private def alias_cases(): Stream[Arguments] = {
+    Stream.of(
+      argumentSet(
+        "unaliased number literal",
+        "RETURN 42",
+        "RETURN 42 AS `42`"
+      ),
+      argumentSet(
+        "unaliased boolean literal",
+        "RETURN false",
+        "RETURN false AS false"
+      ),
+      argumentSet(
+        "unaliased string literal",
+        "RETURN 'foo'",
+        "RETURN 'foo' AS `'foo'`"
+      ),
+      argumentSet(
+        "unaliased array literal",
+        "RETURN ['foo']",
+        "RETURN ['foo'] AS `['foo']`"
+      ),
+      argumentSet(
+        "unaliased map literal",
+        "RETURN {foo: 'bar'}",
+        "RETURN {foo: 'bar'} AS `{foo: 'bar'}`"
+      ),
+      argumentSet(
+        "unaliased parameter",
+        "RETURN $foo",
+        "RETURN $foo AS `$foo`"
+      ),
+      argumentSet(
+        "unaliased function call",
+        "UNWIND [1, 2, 3] AS x RETURN avg(x)",
+        "UNWIND [1, 2, 3] AS x RETURN avg(x) AS `avg(x)`"
+      ),
+      argumentSet(
+        "unaliased node property",
+        "MATCH (n:Person) RETURN n.bar",
+        "MATCH (n:Person) RETURN n.bar AS `n.bar`"
+      ),
+      argumentSet(
+        "unaliased relationship property",
+        "MATCH ()-[r:LINKS]->() RETURN r.bar",
+        "MATCH ()-[r:LINKS]->() RETURN r.bar AS `r.bar`"
+      ),
+      argumentSet(
+        "unaliased field access",
+        "UNWIND [{foo: 'bar'}] AS object RETURN object.foo",
+        "UNWIND [{foo: 'bar'}] AS object RETURN object.foo AS `object.foo`"
+      ),
+      argumentSet(
+        "unaliased indexed array access",
+        "UNWIND [['foo']] AS array RETURN array[0]",
+        "UNWIND [['foo']] AS array RETURN array[0] AS `array[0]`"
+      )
+    )
+  }
+
+  private def preserve_cases(): Stream[Arguments] = {
+    Stream.of(
+      argumentSet(
+        "whole node",
+        "MATCH (n:Person) RETURN n"
+      ),
+      argumentSet(
+        "whole rel",
+        "MATCH ()-[r:LINKS]->() RETURN r"
+      ),
+      argumentSet(
+        "whole path",
+        "MATCH p = (:Person)-[:LINKS]->() RETURN p"
+      ),
+      argumentSet(
+        "aliased number literal",
+        "RETURN 42 AS foo"
+      ),
+      argumentSet(
+        "aliased boolean literal",
+        "RETURN false AS foo"
+      ),
+      argumentSet(
+        "aliased string literal",
+        "RETURN 'foo' AS foo"
+      ),
+      argumentSet(
+        "aliased array literal",
+        "RETURN ['foo'] AS foo"
+      ),
+      argumentSet(
+        "aliased map literal",
+        "RETURN {foo: 'bar'} AS foo"
+      ),
+      argumentSet(
+        "aliased parameter",
+        "RETURN $foo AS foo"
+      ),
+      argumentSet(
+        "aliased function call",
+        "UNWIND [1, 2, 3] AS x RETURN avg(x) AS foo"
+      ),
+      argumentSet(
+        "aliased node property",
+        "MATCH (n:Person) RETURN n.bar AS foo"
+      ),
+      argumentSet(
+        "aliased relationship property",
+        "MATCH ()-[r:LINKS]->() RETURN r.bar AS foo"
+      ),
+      argumentSet(
+        "aliased field access",
+        "UNWIND [{foo: 'bar'}] AS object RETURN object.foo AS foo"
+      ),
+      argumentSet(
+        "aliased indexed array access",
+        "UNWIND [['foo']] AS array RETURN array[0] AS foo"
+      )
+    )
+  }
+}

--- a/src/test/scala/org/neo4j/spark/service/Neo4jQueryServiceTest.scala
+++ b/src/test/scala/org/neo4j/spark/service/Neo4jQueryServiceTest.scala
@@ -32,6 +32,8 @@ import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.TestInstance
 import org.junit.jupiter.params.ParameterizedTest
 import org.junit.jupiter.params.provider.MethodSource
+import org.neo4j.caniuse.CanIUse.{INSTANCE => CanIUse}
+import org.neo4j.caniuse.Cypher.{INSTANCE => Cypher}
 import org.neo4j.caniuse.Neo4j
 import org.neo4j.caniuse.Neo4jDeploymentType.SELF_MANAGED
 import org.neo4j.caniuse.Neo4jEdition
@@ -1128,7 +1130,8 @@ class Neo4jQueryServiceTest {
         )
       ).createQuery()
 
-      val callParens = if (neo4j.getVersion.compareTo(new Neo4jVersion(5, 23, 0)) >= 0) " () " else " "
+      val callParens =
+        if (CanIUse.canIUse(Cypher.callSubqueryWithVariableScopeClause()).withNeo4j(neo4j)) " () " else " "
       assertThat(
         query
       ).isEqualTo(
@@ -1221,7 +1224,8 @@ class Neo4jQueryServiceTest {
       val neo4jOptions = new Neo4jOptions(optionsMap ++ tuningOptions)
       val readService = new Neo4jQueryService(neo4jOptions, plainReadStrategy(neo4j, neo4jOptions))
 
-      val callParens = if (neo4j.getVersion.compareTo(new Neo4jVersion(5, 23, 0)) >= 0) " () " else " "
+      val callParens =
+        if (CanIUse.canIUse(Cypher.callSubqueryWithVariableScopeClause()).withNeo4j(neo4j)) " () " else " "
       val wantQuery =
         s"$tuningPrefix\n${cypherVersionPreamble}CALL$callParens{MATCH (o:Object) RETURN o} RETURN *"
       assertThat(readService.createQuery().trim).isEqualTo(wantQuery.trim)
@@ -1246,7 +1250,8 @@ class Neo4jQueryServiceTest {
       val neo4jOptions = new Neo4jOptions(optionsMap ++ tuningOptions)
       val versionedReadService = new Neo4jQueryService(neo4jOptions, plainReadStrategy(neo4j, neo4jOptions))
 
-      val callParens = if (neo4j.getVersion.compareTo(new Neo4jVersion(5, 23, 0)) >= 0) " () " else " "
+      val callParens =
+        if (CanIUse.canIUse(Cypher.callSubqueryWithVariableScopeClause()).withNeo4j(neo4j)) " () " else " "
       val wantQuery =
         s"$tuningPrefix\n${cypherVersionPreamble}CALL$callParens{WITH $$scriptResult AS scriptResult MATCH (o:Object) RETURN o} RETURN *"
 

--- a/src/test/scala/org/neo4j/spark/service/Neo4jQueryServiceTest.scala
+++ b/src/test/scala/org/neo4j/spark/service/Neo4jQueryServiceTest.scala
@@ -39,6 +39,7 @@ import org.neo4j.caniuse.Neo4jEdition.COMMUNITY
 import org.neo4j.caniuse.Neo4jEdition.ENTERPRISE
 import org.neo4j.caniuse.Neo4jVersion
 import org.neo4j.spark.config.TopN
+import org.neo4j.spark.cypher.AutomaticAliaser
 import org.neo4j.spark.cypher.CypherRenderer
 import org.neo4j.spark.util.DummyNamedReference
 import org.neo4j.spark.util.Neo4jImplicits.CypherImplicits
@@ -109,6 +110,7 @@ class Neo4jQueryServiceTest {
         new Neo4jQueryReadStrategy(
           neo4j,
           new CypherRenderer(neo4j, neo4jOptions),
+          new AutomaticAliaser(),
           partitionPagination = PartitionPagination(0, 0, TopN(100))
         )
       ).createQuery()
@@ -134,6 +136,7 @@ class Neo4jQueryServiceTest {
         new Neo4jQueryReadStrategy(
           neo4j,
           new CypherRenderer(neo4j, neo4jOptions),
+          new AutomaticAliaser(),
           Array.empty[Filter],
           PartitionPagination.EMPTY,
           Seq("name")
@@ -161,6 +164,7 @@ class Neo4jQueryServiceTest {
         new Neo4jQueryReadStrategy(
           neo4j,
           new CypherRenderer(neo4j, neo4jOptions),
+          new AutomaticAliaser(),
           Array.empty[Filter],
           PartitionPagination.EMPTY,
           List("name", "bornDate")
@@ -188,6 +192,7 @@ class Neo4jQueryServiceTest {
         new Neo4jQueryReadStrategy(
           neo4j,
           new CypherRenderer(neo4j, neo4jOptions),
+          new AutomaticAliaser(),
           Array.empty[Filter],
           PartitionPagination.EMPTY,
           List("<elementId>")
@@ -217,7 +222,7 @@ class Neo4jQueryServiceTest {
       val query: String =
         new Neo4jQueryService(
           neo4jOptions,
-          new Neo4jQueryReadStrategy(neo4j, new CypherRenderer(neo4j, neo4jOptions), filters)
+          new Neo4jQueryReadStrategy(neo4j, new CypherRenderer(neo4j, neo4jOptions), new AutomaticAliaser(), filters)
         ).createQuery()
 
       val paramName = "$" + "name".toParameterName("John Doe")
@@ -246,7 +251,7 @@ class Neo4jQueryServiceTest {
       val query: String =
         new Neo4jQueryService(
           neo4jOptions,
-          new Neo4jQueryReadStrategy(neo4j, new CypherRenderer(neo4j, neo4jOptions), filters)
+          new Neo4jQueryReadStrategy(neo4j, new CypherRenderer(neo4j, neo4jOptions), new AutomaticAliaser(), filters)
         ).createQuery()
 
       val nameParameterName = "$" + "name".toParameterName("John Doe")
@@ -281,7 +286,7 @@ class Neo4jQueryServiceTest {
       val query: String =
         new Neo4jQueryService(
           neo4jOptions,
-          new Neo4jQueryReadStrategy(neo4j, new CypherRenderer(neo4j, neo4jOptions), filters)
+          new Neo4jQueryReadStrategy(neo4j, new CypherRenderer(neo4j, neo4jOptions), new AutomaticAliaser(), filters)
         ).createQuery()
 
       val nameParameterName = "$" + "name".toParameterName(null)
@@ -313,7 +318,7 @@ class Neo4jQueryServiceTest {
       val query: String =
         new Neo4jQueryService(
           neo4jOptions,
-          new Neo4jQueryReadStrategy(neo4j, new CypherRenderer(neo4j, neo4jOptions), filters)
+          new Neo4jQueryReadStrategy(neo4j, new CypherRenderer(neo4j, neo4jOptions), new AutomaticAliaser(), filters)
         ).createQuery()
 
       val nameOneParameterName = "$" + "name".toParameterName("Person Name")
@@ -348,6 +353,7 @@ class Neo4jQueryServiceTest {
         new Neo4jQueryReadStrategy(
           neo4j,
           new CypherRenderer(neo4j, neo4jOptions),
+          new AutomaticAliaser(),
           Array.empty[Filter],
           PartitionPagination.EMPTY,
           List("source.name")
@@ -382,6 +388,7 @@ class Neo4jQueryServiceTest {
         new Neo4jQueryReadStrategy(
           neo4j,
           new CypherRenderer(neo4j, neo4jOptions),
+          new AutomaticAliaser(),
           Array.empty[Filter],
           PartitionPagination.EMPTY,
           List("source.name", "<source.elementId>")
@@ -416,6 +423,7 @@ class Neo4jQueryServiceTest {
         new Neo4jQueryReadStrategy(
           neo4j,
           new CypherRenderer(neo4j, neo4jOptions),
+          new AutomaticAliaser(),
           Array.empty[Filter],
           PartitionPagination(0, 0, TopN(limit = 100)),
           List("source.name", "<source.elementId>")
@@ -455,6 +463,7 @@ class Neo4jQueryServiceTest {
         new Neo4jQueryReadStrategy(
           neo4j,
           new CypherRenderer(neo4j, neo4jOptions),
+          new AutomaticAliaser(),
           Array.empty[Filter],
           PartitionPagination.EMPTY,
           List("source.name", "source.id", "rel.someprops", "target.date")
@@ -491,7 +500,7 @@ class Neo4jQueryServiceTest {
       val query: String =
         new Neo4jQueryService(
           neo4jOptions,
-          new Neo4jQueryReadStrategy(neo4j, new CypherRenderer(neo4j, neo4jOptions), filters)
+          new Neo4jQueryReadStrategy(neo4j, new CypherRenderer(neo4j, neo4jOptions), new AutomaticAliaser(), filters)
         ).createQuery()
 
       val parameterName = "$" + "source.name".toParameterName("John Doe")
@@ -526,7 +535,7 @@ class Neo4jQueryServiceTest {
       val query: String =
         new Neo4jQueryService(
           neo4jOptions,
-          new Neo4jQueryReadStrategy(neo4j, new CypherRenderer(neo4j, neo4jOptions), filters)
+          new Neo4jQueryReadStrategy(neo4j, new CypherRenderer(neo4j, neo4jOptions), new AutomaticAliaser(), filters)
         ).createQuery()
 
       val paramOneName = "$" + "source.name".toParameterName("John Doe")
@@ -563,7 +572,7 @@ class Neo4jQueryServiceTest {
       val query: String =
         new Neo4jQueryService(
           neo4jOptions,
-          new Neo4jQueryReadStrategy(neo4j, new CypherRenderer(neo4j, neo4jOptions), filters)
+          new Neo4jQueryReadStrategy(neo4j, new CypherRenderer(neo4j, neo4jOptions), new AutomaticAliaser(), filters)
         ).createQuery()
 
       val sourceIdParameterName = "$" + "source.id".toParameterName(14)
@@ -601,7 +610,7 @@ class Neo4jQueryServiceTest {
       val query: String =
         new Neo4jQueryService(
           neo4jOptions,
-          new Neo4jQueryReadStrategy(neo4j, new CypherRenderer(neo4j, neo4jOptions), filters)
+          new Neo4jQueryReadStrategy(neo4j, new CypherRenderer(neo4j, neo4jOptions), new AutomaticAliaser(), filters)
         ).createQuery()
 
       val parameterNames: Map[String, String] = HashMap(
@@ -650,7 +659,7 @@ class Neo4jQueryServiceTest {
       val query: String =
         new Neo4jQueryService(
           neo4jOptions,
-          new Neo4jQueryReadStrategy(neo4j, new CypherRenderer(neo4j, neo4jOptions), filters)
+          new Neo4jQueryReadStrategy(neo4j, new CypherRenderer(neo4j, neo4jOptions), new AutomaticAliaser(), filters)
         ).createQuery()
 
       val parameterNames = Map(
@@ -706,7 +715,7 @@ class Neo4jQueryServiceTest {
       val query: String =
         new Neo4jQueryService(
           neo4jOptions,
-          new Neo4jQueryReadStrategy(neo4j, new CypherRenderer(neo4j, neo4jOptions), filters)
+          new Neo4jQueryReadStrategy(neo4j, new CypherRenderer(neo4j, neo4jOptions), new AutomaticAliaser(), filters)
         ).createQuery()
 
       val parameterNames = Map(
@@ -753,6 +762,7 @@ class Neo4jQueryServiceTest {
         new Neo4jQueryReadStrategy(
           neo4j,
           new CypherRenderer(neo4j, neo4jOptions),
+          new AutomaticAliaser(),
           Array.empty[Filter],
           PartitionPagination.EMPTY,
           Seq("name", "SUM(DISTINCT age)", "SUM(age)"),
@@ -773,6 +783,7 @@ class Neo4jQueryServiceTest {
         new Neo4jQueryReadStrategy(
           neo4j,
           new CypherRenderer(neo4j, neo4jOptions),
+          new AutomaticAliaser(),
           Array.empty[Filter],
           PartitionPagination.EMPTY,
           Seq("name", "COUNT(DISTINCT name)", "COUNT(name)"),
@@ -792,6 +803,7 @@ class Neo4jQueryServiceTest {
         new Neo4jQueryReadStrategy(
           neo4j,
           new CypherRenderer(neo4j, neo4jOptions),
+          new AutomaticAliaser(),
           Array.empty[Filter],
           PartitionPagination.EMPTY,
           Seq("name", "MAX(age)", "MIN(age)"),
@@ -830,6 +842,7 @@ class Neo4jQueryServiceTest {
         new Neo4jQueryReadStrategy(
           neo4j,
           new CypherRenderer(neo4j, neo4jOptions),
+          new AutomaticAliaser(),
           Array.empty,
           PartitionPagination.EMPTY,
           List("source.fullName", "SUM(DISTINCT `target.price`)", "SUM(`target.price`)"),
@@ -855,6 +868,7 @@ class Neo4jQueryServiceTest {
         new Neo4jQueryReadStrategy(
           neo4j,
           new CypherRenderer(neo4j, neo4jOptions),
+          new AutomaticAliaser(),
           Array.empty,
           PartitionPagination.EMPTY,
           List("source.fullName", "COUNT(DISTINCT `target.id`)", "COUNT(`target.id`)"),
@@ -878,6 +892,7 @@ class Neo4jQueryServiceTest {
         new Neo4jQueryReadStrategy(
           neo4j,
           new CypherRenderer(neo4j, neo4jOptions),
+          new AutomaticAliaser(),
           Array.empty,
           PartitionPagination.EMPTY,
           List("source.fullName", "MAX(`target.price`)", "MIN(`target.price`)"),
@@ -916,6 +931,7 @@ class Neo4jQueryServiceTest {
         new Neo4jQueryReadStrategy(
           neo4j,
           new CypherRenderer(neo4j, neo4jOptions),
+          new AutomaticAliaser(),
           partitionPagination = PartitionPagination(
             0,
             0,
@@ -954,6 +970,7 @@ class Neo4jQueryServiceTest {
         new Neo4jQueryReadStrategy(
           neo4j,
           new CypherRenderer(neo4j, neo4jOptions),
+          new AutomaticAliaser(),
           requiredColumns = Array("name").toIndexedSeq,
           partitionPagination = PartitionPagination(
             0,
@@ -996,6 +1013,7 @@ class Neo4jQueryServiceTest {
         new Neo4jQueryReadStrategy(
           neo4j,
           new CypherRenderer(neo4j, neo4jOptions),
+          new AutomaticAliaser(),
           Array.empty[Filter],
           PartitionPagination(
             0,
@@ -1043,6 +1061,7 @@ class Neo4jQueryServiceTest {
         new Neo4jQueryReadStrategy(
           neo4j,
           new CypherRenderer(neo4j, neo4jOptions),
+          new AutomaticAliaser(),
           Array.empty[Filter],
           PartitionPagination(
             0,
@@ -1074,7 +1093,7 @@ class Neo4jQueryServiceTest {
 
     @ParameterizedTest
     @MethodSource(Array("versions_and_prefixes"))
-    def custom_queries_when_top_n_partition_pagination_ignores_aggregations(
+    def custom_queries_when_top_n_partition_pagination(
       neo4j: Neo4j,
       customCypherVersion: String,
       prefix: String
@@ -1090,6 +1109,7 @@ class Neo4jQueryServiceTest {
         new Neo4jQueryReadStrategy(
           neo4j,
           new CypherRenderer(neo4j, neo4jOptions),
+          new AutomaticAliaser(),
           Array.empty[Filter],
           PartitionPagination(
             0,
@@ -1108,7 +1128,12 @@ class Neo4jQueryServiceTest {
         )
       ).createQuery()
 
-      assertThat(query).isEqualTo(s"${prefix}MATCH (p:Person) RETURN p SKIP 0 LIMIT 24")
+      val callParens = if (neo4j.getVersion.compareTo(new Neo4jVersion(5, 23, 0)) >= 0) " () " else " "
+      assertThat(
+        query
+      ).isEqualTo(
+        s"${prefix}CALL$callParens{MATCH (p:Person) RETURN p} RETURN * ORDER BY name DESC SKIP 0 LIMIT 24"
+      )
     }
 
     @ParameterizedTest
@@ -1170,12 +1195,12 @@ class Neo4jQueryServiceTest {
           new Neo4jQueryReadStrategy(
             neo4jInfo,
             new CypherRenderer(neo4jInfo, neo4jOptions),
+            new AutomaticAliaser(),
             withPreamble = false
           )
         )
 
-      val wantQuery = "MATCH (o:Object) RETURN o"
-      assertThat(noPreambleReadService.createQuery().trim).isEqualTo(wantQuery)
+      assertThat(noPreambleReadService.createQuery().trim).isEqualTo("CALL {MATCH (o:Object) RETURN o} RETURN *")
     }
 
     @ParameterizedTest
@@ -1196,7 +1221,9 @@ class Neo4jQueryServiceTest {
       val neo4jOptions = new Neo4jOptions(optionsMap ++ tuningOptions)
       val readService = new Neo4jQueryService(neo4jOptions, plainReadStrategy(neo4j, neo4jOptions))
 
-      val wantQuery = s"$tuningPrefix\n${cypherVersionPreamble}MATCH (o:Object) RETURN o"
+      val callParens = if (neo4j.getVersion.compareTo(new Neo4jVersion(5, 23, 0)) >= 0) " () " else " "
+      val wantQuery =
+        s"$tuningPrefix\n${cypherVersionPreamble}CALL$callParens{MATCH (o:Object) RETURN o} RETURN *"
       assertThat(readService.createQuery().trim).isEqualTo(wantQuery.trim)
     }
 
@@ -1219,14 +1246,15 @@ class Neo4jQueryServiceTest {
       val neo4jOptions = new Neo4jOptions(optionsMap ++ tuningOptions)
       val versionedReadService = new Neo4jQueryService(neo4jOptions, plainReadStrategy(neo4j, neo4jOptions))
 
+      val callParens = if (neo4j.getVersion.compareTo(new Neo4jVersion(5, 23, 0)) >= 0) " () " else " "
       val wantQuery =
-        s"$tuningPrefix\n${cypherVersionPreamble}WITH $$scriptResult AS scriptResult MATCH (o:Object) RETURN o"
+        s"$tuningPrefix\n${cypherVersionPreamble}CALL$callParens{WITH $$scriptResult AS scriptResult MATCH (o:Object) RETURN o} RETURN *"
 
       assertThat(versionedReadService.createQuery().trim).isEqualTo(wantQuery.trim)
     }
 
     private def plainReadStrategy(neo4j: Neo4j, neo4jOptions: Neo4jOptions): Neo4jQueryReadStrategy =
-      new Neo4jQueryReadStrategy(neo4j, new CypherRenderer(neo4j, neo4jOptions))
+      new Neo4jQueryReadStrategy(neo4j, new CypherRenderer(neo4j, neo4jOptions), new AutomaticAliaser())
   }
 
   @Nested
@@ -1606,11 +1634,7 @@ object Neo4jQueryServiceTest {
       Array(neo4j(version(5, 26), COMMUNITY), "", "CYPHER 5 "),
       Array(neo4j(version(5, 26), ENTERPRISE), "", "CYPHER 5 "),
       Array(neo4j(version(2025, 1), COMMUNITY), "", "CYPHER 5 "),
-      Array(neo4j(version(2025, 1), ENTERPRISE), "", "CYPHER 5 "),
-      Array(neo4j(version(5, 0), COMMUNITY), "25", "CYPHER 25 "),
-      Array(neo4j(version(5, 0), ENTERPRISE), "25", "CYPHER 25 "),
-      Array(neo4j(version(5, 0), COMMUNITY), "5", "CYPHER 5 "),
-      Array(neo4j(version(5, 0), ENTERPRISE), "5", "CYPHER 5 ")
+      Array(neo4j(version(2025, 1), ENTERPRISE), "", "CYPHER 5 ")
     )
   }
 

--- a/src/test/scala/org/neo4j/spark/testsupport/Neo4jContainerProvider.scala
+++ b/src/test/scala/org/neo4j/spark/testsupport/Neo4jContainerProvider.scala
@@ -48,5 +48,5 @@ class Neo4jContainerProvider extends ArgumentsProvider {
 }
 
 object Neo4jContainerProvider {
-  private val ADMIN_PASSWORD = "letmein!"
+  val ADMIN_PASSWORD = "letmein!"
 }

--- a/src/test/scala/org/neo4j/spark/testsupport/Neo4jExtensions.scala
+++ b/src/test/scala/org/neo4j/spark/testsupport/Neo4jExtensions.scala
@@ -18,17 +18,29 @@ package org.neo4j.spark.testsupport
 
 import org.apache.spark.SparkConf
 import org.apache.spark.sql.SparkSession
+import org.neo4j.caniuse.Neo4jDetector
 import org.neo4j.driver.AuthTokens
 import org.neo4j.driver.Driver
 import org.neo4j.driver.GraphDatabase
 import org.neo4j.driver.QueryConfig
+import org.neo4j.spark.cypher.CypherRenderer
+import org.neo4j.spark.util.Neo4jOptions
 import org.testcontainers.neo4j.Neo4jContainer
 
 import scala.jdk.CollectionConverters.MapHasAsJava
+import scala.util.Try
+import scala.util.Using
 
 object Neo4jExtensions {
 
   implicit class Neo4jContainerExtensions(container: Neo4jContainer) {
+
+    def cypherRenderer(options: Neo4jOptions = defaultNeo4jSparkOptions): CypherRenderer = {
+      Using(driver()) { driver =>
+        val neo4j = Neo4jDetector.INSTANCE.detect(driver)
+        return new CypherRenderer(neo4j, options)
+      }.get
+    }
 
     def driver(): Driver = {
       val auth = AuthTokens.basic("neo4j", container.getAdminPassword)
@@ -53,6 +65,16 @@ object Neo4jExtensions {
         "authentication.basic.username" -> "neo4j",
         "authentication.basic.password" -> container.getAdminPassword
       )
+    }
+
+    private def defaultNeo4jSparkOptions = {
+      val options = Map[String, String](
+        "url" -> container.getBoltUrl,
+        "username" -> "neo4j",
+        "password" -> container.getAdminPassword,
+        "query" -> "RETURN 42"
+      )
+      new Neo4jOptions(options)
     }
   }
 


### PR DESCRIPTION
This leverages Cypher DSL's parser and callback-based API to alias
returned columns, if necessary, before the user-defined query gets
wrapped into a containing `CALL` clause.

```cypher
MATCH (n) RETURN n.name
```

**cannot** be transformed into:

```cypher
CALL () { MATCH (n) RETURN n.name } RETURN * // invalid!
// error: Expression in CALL { RETURN ... } must be aliased (use AS)
```

as `n` is not available outside the inner scope.

The new `AutomaticAliaser` facility turns the initial query into:

```cypher
MATCH (n) RETURN n.name AS `n.name`
```

That way, most user-defined queries can be embedded as CALL
subqueries.
As a consequence, previous restrictions such as the rejection
of queries with `SKIP` or `LIMIT` do not apply anymore.

One restriction that still applies is that simple procedure calls
(without `YIELD`) will not work. Subqueries must use `RETURN`.

This commit also now fully applies TopN optimizations to
user-defined queries.