### PR TITLE
refactor: use scala map for Neo4jOptions

### DIFF
--- a/src/main/scala/org/neo4j/spark/DataSource.scala
+++ b/src/main/scala/org/neo4j/spark/DataSource.scala
@@ -30,6 +30,8 @@ import org.neo4j.spark.util._
 
 import java.util.UUID
 
+import scala.jdk.CollectionConverters.MapHasAsScala
+
 class DataSource extends TableProvider
     with DataSourceRegister {
 
@@ -75,8 +77,9 @@ class DataSource extends TableProvider
 
   private def getNeo4jOptions(caseInsensitiveStringMap: CaseInsensitiveStringMap) = {
     if (neo4jOptions == null) {
-      neo4jOptions =
-        Neo4jOptions.fromSession(SparkSession.getActiveSession, caseInsensitiveStringMap.asCaseSensitiveMap())
+      val session = SparkSession.getActiveSession
+      val externalOptions = caseInsensitiveStringMap.asCaseSensitiveMap().asScala.toMap
+      neo4jOptions = Neo4jOptions.fromSession(session, externalOptions)
     }
 
     ValidateNeo4jOptionsConsistency(getNeo4jInfo(neo4jOptions.connection), neo4jOptions).validate()

--- a/src/main/scala/org/neo4j/spark/Neo4jTable.scala
+++ b/src/main/scala/org/neo4j/spark/Neo4jTable.scala
@@ -62,9 +62,8 @@ class Neo4jTable(neo4j: Neo4j, schema: StructType, neo4jOptions: Neo4jOptions, j
   }
 
   override def newWriteBuilder(info: LogicalWriteInfo): WriteBuilder = {
-    val mapOptions = neo4jOptions.asMap()
-    mapOptions.put(Neo4jOptions.ACCESS_MODE, AccessMode.WRITE.toString)
-    val writeNeo4jOptions = new Neo4jOptions(mapOptions)
-    new Neo4jWriterBuilder(neo4j, info.queryId(), info.schema(), SaveMode.Append, writeNeo4jOptions)
+    val accessModeWrite = Neo4jOptions.ACCESS_MODE -> AccessMode.WRITE.toString
+    val neo4jWriterOptions = new Neo4jOptions(neo4jOptions.toMap + accessModeWrite)
+    new Neo4jWriterBuilder(neo4j, info.queryId(), info.schema(), SaveMode.Append, neo4jWriterOptions)
   }
 }

--- a/src/main/scala/org/neo4j/spark/util/Neo4jOptions.scala
+++ b/src/main/scala/org/neo4j/spark/util/Neo4jOptions.scala
@@ -45,33 +45,33 @@ import scala.jdk.CollectionConverters.MapHasAsScala
 import scala.jdk.CollectionConverters.SetHasAsJava
 import scala.language.implicitConversions
 
-class Neo4jOptions(private val options: java.util.Map[String, String]) extends Serializable with Logging {
+class Neo4jOptions(private val options: Map[String, String]) extends Serializable with Logging {
 
   import Neo4jOptions._
   import QueryType._
 
-  def asMap() = new util.HashMap[String, String](options)
+  val toMap: Map[String, String] = options
 
   private def getRequiredParameter(parameter: String): String = {
-    if (!options.containsKey(parameter) || options.get(parameter).isEmpty) {
+    if (options.getOrElse(parameter, "").isEmpty) {
       throw new IllegalArgumentException(s"Parameter '$parameter' is required")
     }
 
-    options.get(parameter)
+    options(parameter)
   }
 
   private def getParameter(parameter: String, defaultValue: String = ""): String =
     getParameterOption(parameter).getOrElse(defaultValue)
 
   private def getParameterOption(parameter: String): Option[String] =
-    Some(options.get(parameter))
+    options.get(parameter)
       .flatMap(Option(_)) // to turn null into None
       .map(_.trim)
 
   private def getAuthenticationParameters: Map[String, String] = {
     val authType = getParameter(AUTH_TYPE, DEFAULT_AUTH_TYPE)
     val authNamespace = s"$AUTH.$authType"
-    val providedParameters = options.asScala
+    val providedParameters = options
       .view
       .filterKeys(_.startsWith(authNamespace))
       .map(t => (t._1.substring(authNamespace.length + 1), t._2))
@@ -305,7 +305,7 @@ class Neo4jOptions(private val options: java.util.Map[String, String]) extends S
 
   val streamingOrderBy: String = getParameter(ORDER_BY, getParameter(STREAMING_PROPERTY_NAME))
 
-  val apocConfig: Neo4jApocConfig = Neo4jApocConfig(options.asScala
+  val apocConfig: Neo4jApocConfig = Neo4jApocConfig(options
     .view
     .filterKeys(_.startsWith("apoc."))
     .mapValues(Neo4jUtil.mapper.readValue(_, classOf[java.util.Map[String, AnyRef]]).asScala)
@@ -342,7 +342,7 @@ class Neo4jOptions(private val options: java.util.Map[String, String]) extends S
   }
 
   private def extractNeo4jGdsMetadata(): Neo4jGdsMetadata = Neo4jGdsMetadata(
-    options.asScala
+    options
       .view
       .filterKeys(k => k.startsWith(GDS_OPTION_PREFIX))
       .map(t => (t._1.substring(GDS_OPTION_PREFIX.length), t._2))
@@ -351,7 +351,7 @@ class Neo4jOptions(private val options: java.util.Map[String, String]) extends S
   )
 
   private def extractNeo4jTransactionMetadata(): util.Map[String, Any] =
-    options.asScala
+    options
       .view
       .filterKeys(k => k.startsWith(TX_METADATA_OPTION_PREFIX))
       .map(t => (t._1.substring(TX_METADATA_OPTION_PREFIX.length), t._2))
@@ -359,7 +359,7 @@ class Neo4jOptions(private val options: java.util.Map[String, String]) extends S
       .toNestedPrimitiveDeserializedJsonJavaMap
 
   private def extractNeo4jTuningOptions(): Map[String, String] =
-    options.asScala
+    options
       .view
       .filterKeys(k => k.toLowerCase.startsWith(CYPHER_TUNING_OPTION_PREFIX))
       .map(t => (t._1.substring(CYPHER_TUNING_OPTION_PREFIX.length), t._2))
@@ -757,7 +757,7 @@ object Neo4jOptions {
 
   private val DEFAULT_TYPE_CONVERSION = "default"
 
-  def fromSession(sparkSession: Option[SparkSession], options: java.util.Map[String, String]): Neo4jOptions = {
+  def fromSession(sparkSession: Option[SparkSession], options: Map[String, String]): Neo4jOptions = {
     val sessionLevelOptions = sparkSession
       .map {
         _.conf
@@ -769,7 +769,7 @@ object Neo4jOptions {
       }
       .getOrElse(Map.empty)
 
-    new Neo4jOptions((sessionLevelOptions ++ options.asScala).asJava)
+    new Neo4jOptions(sessionLevelOptions ++ options)
   }
 }
 
@@ -811,15 +811,6 @@ object RelationshipSaveStrategy extends CaseInsensitiveEnumeration {
 
 object NodeSaveMode extends CaseInsensitiveEnumeration {
   val Overwrite, ErrorIfExists, Match, Append = Value
-
-  def fromSaveMode(saveMode: SaveMode): Value = {
-    saveMode match {
-      case SaveMode.Overwrite     => Overwrite
-      case SaveMode.ErrorIfExists => ErrorIfExists
-      case SaveMode.Append        => Append
-      case _                      => throw new IllegalArgumentException(s"SaveMode $saveMode not supported")
-    }
-  }
 }
 
 object SchemaStrategy extends CaseInsensitiveEnumeration {

--- a/src/test/scala/org/neo4j/spark/GraphDataScienceIT.scala
+++ b/src/test/scala/org/neo4j/spark/GraphDataScienceIT.scala
@@ -54,7 +54,6 @@ import org.neo4j.spark.util.DummyNamedReference
 import org.neo4j.spark.util.Neo4jOptions
 import org.testcontainers.neo4j.Neo4jContainer
 
-import scala.jdk.CollectionConverters.MapHasAsJava
 import scala.math.Ordering.Implicits.infixOrderingOps
 
 @TestInstance(TestInstance.Lifecycle.PER_CLASS)
@@ -309,10 +308,7 @@ class GraphDataScienceIT {
 
   @Test
   def generates_read_query_that_aggregates(): Unit = {
-    val neo4jOptions = new Neo4jOptions(
-      (neo4jContainer.authenticatedOptions() ++ Map("gds" -> "gds.pageRank.stream"))
-        .asJava
-    )
+    val neo4jOptions = new Neo4jOptions(neo4jContainer.authenticatedOptions() ++ Map("gds" -> "gds.pageRank.stream"))
 
     val field = new DummyNamedReference("score")
     val query: String = new Neo4jQueryService(
@@ -355,10 +351,10 @@ class GraphDataScienceIT {
   @Test
   def refuses_read_query_with_cypher_preamble(): Unit = {
     val neo4jOptions: Neo4jOptions = new Neo4jOptions(
-      (neo4jContainer.authenticatedOptions() ++ Map(
+      neo4jContainer.authenticatedOptions() ++ Map(
         "gds" -> "gds.pageRank.stream",
         "cypher.tuning.expressionEngine" -> "compiled"
-      )).asJava
+      )
     )
 
     val field = new DummyNamedReference("score")

--- a/src/test/scala/org/neo4j/spark/cypher/CypherPreambleTest.scala
+++ b/src/test/scala/org/neo4j/spark/cypher/CypherPreambleTest.scala
@@ -57,14 +57,9 @@ class CypherPreambleTest {
       dynamicTest(
         "when " + testCase.name,
         () => {
-          val options = new java.util.HashMap[String, String]()
-          options.put(Neo4jOptions.URL, "stub-url-doesnt-matter-but-is-required")
+          val neo4jOptions =
+            new Neo4jOptions(testCase.tuningOptions + (Neo4jOptions.URL -> "stub-url-doesnt-matter-but-is-required"))
 
-          testCase.tuningOptions.foreach { case (key, value) =>
-            options.put(key, value)
-          }
-
-          val neo4jOptions = new Neo4jOptions(options.asScala.toMap)
           val tuningPreamble = CypherPreamble.tuningPreamble(neo4jOptions)
 
           assertThat(tuningPreamble).isEmpty()
@@ -110,17 +105,14 @@ class CypherPreambleTest {
       dynamicTest(
         "when " + testCase.name,
         () => {
-          val options = new java.util.HashMap[String, String]()
-          options.put(Neo4jOptions.URL, "stub-url-doesnt-matter-but-is-required")
+          val neo4jOptions =
+            new Neo4jOptions(testCase.tuningOptions + (Neo4jOptions.URL -> "stub-url-doesnt-matter-but-is-required"))
 
-          testCase.tuningOptions.foreach { case (key, value) =>
-            options.put(key, value)
-          }
+          // we don't care about the order of peramble params, but we care about their individual shape
+          val tuningPreambleSplit = CypherPreamble.tuningPreamble(neo4jOptions).split(" ")
 
-          val neo4jOptions = new Neo4jOptions(options.asScala.toMap)
-          val tuningPreamble = CypherPreamble.tuningPreamble(neo4jOptions)
-
-          assertThat(tuningPreamble).isEqualTo(testCase.expectedOutput)
+          assertThat(tuningPreambleSplit).containsExactlyInAnyOrder(testCase.expectedOutput.split(" "): _*)
+          assertThat(tuningPreambleSplit(0)).isEqualTo("CYPHER")
         }
       )
     }
@@ -147,14 +139,8 @@ class CypherPreambleTest {
       dynamicTest(
         "when " + testCase.name,
         () => {
-          val options = new java.util.HashMap[String, String]()
-          options.put(Neo4jOptions.URL, "stub-url-doesnt-matter-but-is-required")
-
-          testCase.tuningOptions.foreach { case (key, value) =>
-            options.put(key, value)
-          }
-
-          val neo4jOptions = new Neo4jOptions(options.asScala.toMap)
+          val neo4jOptions =
+            new Neo4jOptions(testCase.tuningOptions + (Neo4jOptions.URL -> "stub-url-doesnt-matter-but-is-required"))
 
           assertThatThrownBy(() => CypherPreamble.tuningPreamble(neo4jOptions)).isExactlyInstanceOf(
             classOf[IllegalArgumentException]

--- a/src/test/scala/org/neo4j/spark/cypher/CypherPreambleTest.scala
+++ b/src/test/scala/org/neo4j/spark/cypher/CypherPreambleTest.scala
@@ -26,6 +26,7 @@ import org.neo4j.spark.util.Neo4jOptions
 
 import java.util.stream.Stream
 
+import scala.jdk.CollectionConverters.MapHasAsScala
 import scala.jdk.CollectionConverters.SeqHasAsJava
 
 private case class TuningTestCase(
@@ -63,7 +64,7 @@ class CypherPreambleTest {
             options.put(key, value)
           }
 
-          val neo4jOptions = new Neo4jOptions(options)
+          val neo4jOptions = new Neo4jOptions(options.asScala.toMap)
           val tuningPreamble = CypherPreamble.tuningPreamble(neo4jOptions)
 
           assertThat(tuningPreamble).isEmpty()
@@ -116,7 +117,7 @@ class CypherPreambleTest {
             options.put(key, value)
           }
 
-          val neo4jOptions = new Neo4jOptions(options)
+          val neo4jOptions = new Neo4jOptions(options.asScala.toMap)
           val tuningPreamble = CypherPreamble.tuningPreamble(neo4jOptions)
 
           assertThat(tuningPreamble).isEqualTo(testCase.expectedOutput)
@@ -153,7 +154,7 @@ class CypherPreambleTest {
             options.put(key, value)
           }
 
-          val neo4jOptions = new Neo4jOptions(options)
+          val neo4jOptions = new Neo4jOptions(options.asScala.toMap)
 
           assertThatThrownBy(() => CypherPreamble.tuningPreamble(neo4jOptions)).isExactlyInstanceOf(
             classOf[IllegalArgumentException]

--- a/src/test/scala/org/neo4j/spark/service/AuthenticationTest.scala
+++ b/src/test/scala/org/neo4j/spark/service/AuthenticationTest.scala
@@ -34,16 +34,20 @@ import org.testcontainers.shaded.com.google.common.io.BaseEncoding
 import java.net.URI
 import java.util
 
+import scala.jdk.CollectionConverters.MapHasAsScala
+
 class AuthenticationTest {
 
   @Test
   def testLdapConnectionToken(): Unit = {
     val token = BaseEncoding.base64.encode("user:password".getBytes)
-    val options = new util.HashMap[String, String]
-    options.put("url", "bolt://localhost:7687")
-    options.put("authentication.type", "custom")
-    options.put("authentication.custom.credentials", token)
-    options.put("labels", "Person")
+
+    val options = Map(
+      "url" -> "bolt://localhost:7687",
+      "authentication.type" -> "custom",
+      "authentication.custom.credentials" -> token,
+      "labels" -> "Person"
+    )
 
     stubGraphDatabaseConnectionCallAndAssertToken(options, AuthTokens.custom("", token, "", ""))
   }
@@ -51,15 +55,17 @@ class AuthenticationTest {
   @Test
   def testBearerAuthToken(): Unit = {
     val token = BaseEncoding.base64.encode("user:password".getBytes)
-    val options = new util.HashMap[String, String]
-    options.put("url", "bolt://localhost:7687")
-    options.put("authentication.type", "bearer")
-    options.put("authentication.bearer.token", token)
+
+    val options = Map(
+      "url" -> "bolt://localhost:7687",
+      "authentication.type" -> "bearer",
+      "authentication.bearer.token" -> token
+    )
 
     stubGraphDatabaseConnectionCallAndAssertToken(options, AuthTokens.bearer(token))
   }
 
-  def stubGraphDatabaseConnectionCallAndAssertToken(options: java.util.Map[String, String], token: AuthToken): Unit = {
+  def stubGraphDatabaseConnectionCallAndAssertToken(options: Map[String, String], token: AuthToken): Unit = {
     val neo4jOptions = new Neo4jOptions(options)
     val neo4jDriverOptions = neo4jOptions.connection
     val driverCache = new DriverCache(neo4jDriverOptions)

--- a/src/test/scala/org/neo4j/spark/service/Neo4jQueryServiceTest.scala
+++ b/src/test/scala/org/neo4j/spark/service/Neo4jQueryServiceTest.scala
@@ -68,11 +68,11 @@ class Neo4jQueryServiceTest {
     @ParameterizedTest
     @MethodSource(Array("versions_and_prefixes"))
     def labels_when_one_label_selected(neo4j: Neo4j, customCypherVersion: String, prefix: String): Unit = {
-      val options: java.util.Map[String, String] = new java.util.HashMap[String, String]()
-      options.put(Neo4jOptions.URL, "bolt://localhost")
-      options.put(QueryType.LABELS.toString.toLowerCase, "Person")
-      options.put(Neo4jOptions.CYPHER_VERSION, customCypherVersion)
-      val neo4jOptions: Neo4jOptions = new Neo4jOptions(options)
+      val neo4jOptions = new Neo4jOptions(Map(
+        Neo4jOptions.URL -> "bolt://localhost",
+        QueryType.LABELS.toString.toLowerCase -> "Person",
+        Neo4jOptions.CYPHER_VERSION -> customCypherVersion
+      ))
 
       val query: String =
         new Neo4jQueryService(neo4jOptions, plainReadStrategy(neo4j, neo4jOptions)).createQuery()
@@ -83,11 +83,11 @@ class Neo4jQueryServiceTest {
     @ParameterizedTest
     @MethodSource(Array("versions_and_prefixes"))
     def labels_when_multiple_labels_selected(neo4j: Neo4j, customCypherVersion: String, prefix: String): Unit = {
-      val options: java.util.Map[String, String] = new java.util.HashMap[String, String]()
-      options.put(Neo4jOptions.URL, "bolt://localhost")
-      options.put(QueryType.LABELS.toString.toLowerCase, ":Person:Player:Midfield")
-      options.put(Neo4jOptions.CYPHER_VERSION, customCypherVersion)
-      val neo4jOptions: Neo4jOptions = new Neo4jOptions(options)
+      val neo4jOptions = new Neo4jOptions(Map(
+        Neo4jOptions.URL -> "bolt://localhost",
+        QueryType.LABELS.toString.toLowerCase -> ":Person:Player:Midfield",
+        Neo4jOptions.CYPHER_VERSION -> customCypherVersion
+      ))
 
       val query: String =
         new Neo4jQueryService(neo4jOptions, plainReadStrategy(neo4j, neo4jOptions)).createQuery()
@@ -98,11 +98,11 @@ class Neo4jQueryServiceTest {
     @ParameterizedTest
     @MethodSource(Array("versions_and_prefixes"))
     def labels_when_partitioned(neo4j: Neo4j, customCypherVersion: String, prefix: String): Unit = {
-      val options: java.util.Map[String, String] = new java.util.HashMap[String, String]()
-      options.put(Neo4jOptions.URL, "bolt://localhost")
-      options.put(QueryType.LABELS.toString.toLowerCase, ":Person:Player:Midfield")
-      options.put(Neo4jOptions.CYPHER_VERSION, customCypherVersion)
-      val neo4jOptions: Neo4jOptions = new Neo4jOptions(options)
+      val neo4jOptions = new Neo4jOptions(Map(
+        Neo4jOptions.URL -> "bolt://localhost",
+        QueryType.LABELS.toString.toLowerCase -> ":Person:Player:Midfield",
+        Neo4jOptions.CYPHER_VERSION -> customCypherVersion
+      ))
 
       val query: String = new Neo4jQueryService(
         neo4jOptions,
@@ -123,11 +123,11 @@ class Neo4jQueryServiceTest {
       customCypherVersion: String,
       prefix: String
     ): Unit = {
-      val options: java.util.Map[String, String] = new java.util.HashMap[String, String]()
-      options.put(Neo4jOptions.URL, "bolt://localhost")
-      options.put(QueryType.LABELS.toString.toLowerCase, "Person")
-      options.put(Neo4jOptions.CYPHER_VERSION, customCypherVersion)
-      val neo4jOptions: Neo4jOptions = new Neo4jOptions(options)
+      val neo4jOptions = new Neo4jOptions(Map(
+        Neo4jOptions.URL -> "bolt://localhost",
+        QueryType.LABELS.toString.toLowerCase -> "Person",
+        Neo4jOptions.CYPHER_VERSION -> customCypherVersion
+      ))
 
       val query: String = new Neo4jQueryService(
         neo4jOptions,
@@ -150,11 +150,11 @@ class Neo4jQueryServiceTest {
       customCypherVersion: String,
       prefix: String
     ): Unit = {
-      val options: java.util.Map[String, String] = new java.util.HashMap[String, String]()
-      options.put(Neo4jOptions.URL, "bolt://localhost")
-      options.put(QueryType.LABELS.toString.toLowerCase, "Person")
-      options.put(Neo4jOptions.CYPHER_VERSION, customCypherVersion)
-      val neo4jOptions: Neo4jOptions = new Neo4jOptions(options)
+      val neo4jOptions = new Neo4jOptions(Map(
+        Neo4jOptions.URL -> "bolt://localhost",
+        QueryType.LABELS.toString.toLowerCase -> "Person",
+        Neo4jOptions.CYPHER_VERSION -> customCypherVersion
+      ))
 
       val query: String = new Neo4jQueryService(
         neo4jOptions,
@@ -177,11 +177,11 @@ class Neo4jQueryServiceTest {
       customCypherVersion: String,
       prefix: String
     ): Unit = {
-      val options: java.util.Map[String, String] = new java.util.HashMap[String, String]()
-      options.put(Neo4jOptions.URL, "bolt://localhost")
-      options.put(QueryType.LABELS.toString.toLowerCase, "Person")
-      options.put(Neo4jOptions.CYPHER_VERSION, customCypherVersion)
-      val neo4jOptions: Neo4jOptions = new Neo4jOptions(options)
+      val neo4jOptions = new Neo4jOptions(Map(
+        Neo4jOptions.URL -> "bolt://localhost",
+        QueryType.LABELS.toString.toLowerCase -> "Person",
+        Neo4jOptions.CYPHER_VERSION -> customCypherVersion
+      ))
 
       val query: String = new Neo4jQueryService(
         neo4jOptions,
@@ -204,11 +204,11 @@ class Neo4jQueryServiceTest {
       customCypherVersion: String,
       prefix: String
     ): Unit = {
-      val options: java.util.Map[String, String] = new java.util.HashMap[String, String]()
-      options.put(Neo4jOptions.URL, "bolt://localhost")
-      options.put(QueryType.LABELS.toString.toLowerCase, "Person")
-      options.put(Neo4jOptions.CYPHER_VERSION, customCypherVersion)
-      val neo4jOptions: Neo4jOptions = new Neo4jOptions(options)
+      val neo4jOptions = new Neo4jOptions(Map(
+        Neo4jOptions.URL -> "bolt://localhost",
+        QueryType.LABELS.toString.toLowerCase -> "Person",
+        Neo4jOptions.CYPHER_VERSION -> customCypherVersion
+      ))
 
       val filters: Array[Filter] = Array[Filter](
         EqualTo("name", "John Doe")
@@ -232,11 +232,11 @@ class Neo4jQueryServiceTest {
       customCypherVersion: String,
       prefix: String
     ): Unit = {
-      val options: java.util.Map[String, String] = new java.util.HashMap[String, String]()
-      options.put(Neo4jOptions.URL, "bolt://localhost")
-      options.put(QueryType.LABELS.toString.toLowerCase, "Person")
-      options.put(Neo4jOptions.CYPHER_VERSION, customCypherVersion)
-      val neo4jOptions: Neo4jOptions = new Neo4jOptions(options)
+      val neo4jOptions = new Neo4jOptions(Map(
+        Neo4jOptions.URL -> "bolt://localhost",
+        QueryType.LABELS.toString.toLowerCase -> "Person",
+        Neo4jOptions.CYPHER_VERSION -> customCypherVersion
+      ))
 
       val filters: Array[Filter] = Array[Filter](
         EqualNullSafe("name", "John Doe"),
@@ -267,11 +267,11 @@ class Neo4jQueryServiceTest {
       customCypherVersion: String,
       prefix: String
     ): Unit = {
-      val options: java.util.Map[String, String] = new java.util.HashMap[String, String]()
-      options.put(Neo4jOptions.URL, "bolt://localhost")
-      options.put(QueryType.LABELS.toString.toLowerCase, "Person")
-      options.put(Neo4jOptions.CYPHER_VERSION, customCypherVersion)
-      val neo4jOptions: Neo4jOptions = new Neo4jOptions(options)
+      val neo4jOptions = new Neo4jOptions(Map(
+        Neo4jOptions.URL -> "bolt://localhost",
+        QueryType.LABELS.toString.toLowerCase -> "Person",
+        Neo4jOptions.CYPHER_VERSION -> customCypherVersion
+      ))
 
       val filters: Array[Filter] = Array[Filter](
         EqualNullSafe("name", null),
@@ -299,11 +299,11 @@ class Neo4jQueryServiceTest {
       customCypherVersion: String,
       prefix: String
     ): Unit = {
-      val options: java.util.Map[String, String] = new java.util.HashMap[String, String]()
-      options.put(Neo4jOptions.URL, "bolt://localhost")
-      options.put(QueryType.LABELS.toString.toLowerCase, "Person")
-      options.put(Neo4jOptions.CYPHER_VERSION, customCypherVersion)
-      val neo4jOptions: Neo4jOptions = new Neo4jOptions(options)
+      val neo4jOptions = new Neo4jOptions(Map(
+        Neo4jOptions.URL -> "bolt://localhost",
+        QueryType.LABELS.toString.toLowerCase -> "Person",
+        Neo4jOptions.CYPHER_VERSION -> customCypherVersion
+      ))
 
       val filters: Array[Filter] = Array[Filter](
         StringStartsWith("name", "Person Name"),
@@ -334,14 +334,14 @@ class Neo4jQueryServiceTest {
       customCypherVersion: String,
       prefix: String
     ): Unit = {
-      val options: java.util.Map[String, String] = new java.util.HashMap[String, String]()
-      options.put(Neo4jOptions.URL, "bolt://localhost")
-      options.put("relationship", "KNOWS")
-      options.put("relationship.nodes.map", "false")
-      options.put("relationship.source.labels", "Person")
-      options.put("relationship.target.labels", "Person")
-      options.put(Neo4jOptions.CYPHER_VERSION, customCypherVersion)
-      val neo4jOptions: Neo4jOptions = new Neo4jOptions(options)
+      val neo4jOptions = new Neo4jOptions(Map(
+        Neo4jOptions.URL -> "bolt://localhost",
+        "relationship" -> "KNOWS",
+        "relationship.nodes.map" -> "false",
+        "relationship.source.labels" -> "Person",
+        "relationship.target.labels" -> "Person",
+        Neo4jOptions.CYPHER_VERSION -> customCypherVersion
+      ))
 
       val query: String = new Neo4jQueryService(
         neo4jOptions,
@@ -368,14 +368,14 @@ class Neo4jQueryServiceTest {
       customCypherVersion: String,
       prefix: String
     ): Unit = {
-      val options: java.util.Map[String, String] = new java.util.HashMap[String, String]()
-      options.put(Neo4jOptions.URL, "bolt://localhost")
-      options.put("relationship", "KNOWS")
-      options.put("relationship.nodes.map", "false")
-      options.put("relationship.source.labels", "Person")
-      options.put("relationship.target.labels", "Person")
-      options.put(Neo4jOptions.CYPHER_VERSION, customCypherVersion)
-      val neo4jOptions: Neo4jOptions = new Neo4jOptions(options)
+      val neo4jOptions = new Neo4jOptions(Map(
+        Neo4jOptions.URL -> "bolt://localhost",
+        "relationship" -> "KNOWS",
+        "relationship.nodes.map" -> "false",
+        "relationship.source.labels" -> "Person",
+        "relationship.target.labels" -> "Person",
+        Neo4jOptions.CYPHER_VERSION -> customCypherVersion
+      ))
 
       val query: String = new Neo4jQueryService(
         neo4jOptions,
@@ -402,14 +402,14 @@ class Neo4jQueryServiceTest {
       customCypherVersion: String,
       prefix: String
     ): Unit = {
-      val options: java.util.Map[String, String] = new java.util.HashMap[String, String]()
-      options.put(Neo4jOptions.URL, "bolt://localhost")
-      options.put("relationship", "KNOWS")
-      options.put("relationship.nodes.map", "false")
-      options.put("relationship.source.labels", "Person")
-      options.put("relationship.target.labels", "Person")
-      options.put(Neo4jOptions.CYPHER_VERSION, customCypherVersion)
-      val neo4jOptions: Neo4jOptions = new Neo4jOptions(options)
+      val neo4jOptions = new Neo4jOptions(Map(
+        Neo4jOptions.URL -> "bolt://localhost",
+        "relationship" -> "KNOWS",
+        "relationship.nodes.map" -> "false",
+        "relationship.source.labels" -> "Person",
+        "relationship.target.labels" -> "Person",
+        Neo4jOptions.CYPHER_VERSION -> customCypherVersion
+      ))
 
       val query: String = new Neo4jQueryService(
         neo4jOptions,
@@ -441,14 +441,14 @@ class Neo4jQueryServiceTest {
       customCypherVersion: String,
       prefix: String
     ): Unit = {
-      val options: java.util.Map[String, String] = new java.util.HashMap[String, String]()
-      options.put(Neo4jOptions.URL, "bolt://localhost")
-      options.put("relationship", "KNOWS")
-      options.put("relationship.nodes.map", "false")
-      options.put("relationship.source.labels", "Person")
-      options.put("relationship.target.labels", "Person")
-      options.put(Neo4jOptions.CYPHER_VERSION, customCypherVersion)
-      val neo4jOptions: Neo4jOptions = new Neo4jOptions(options)
+      val neo4jOptions = new Neo4jOptions(Map(
+        Neo4jOptions.URL -> "bolt://localhost",
+        "relationship" -> "KNOWS",
+        "relationship.nodes.map" -> "false",
+        "relationship.source.labels" -> "Person",
+        "relationship.target.labels" -> "Person",
+        Neo4jOptions.CYPHER_VERSION -> customCypherVersion
+      ))
 
       val query: String = new Neo4jQueryService(
         neo4jOptions,
@@ -475,14 +475,14 @@ class Neo4jQueryServiceTest {
       customCypherVersion: String,
       prefix: String
     ): Unit = {
-      val options: java.util.Map[String, String] = new java.util.HashMap[String, String]()
-      options.put(Neo4jOptions.URL, "bolt://localhost")
-      options.put("relationship", "KNOWS")
-      options.put("relationship.nodes.map", "false")
-      options.put("relationship.source.labels", "Person")
-      options.put("relationship.target.labels", "Person")
-      options.put(Neo4jOptions.CYPHER_VERSION, customCypherVersion)
-      val neo4jOptions: Neo4jOptions = new Neo4jOptions(options)
+      val neo4jOptions = new Neo4jOptions(Map(
+        Neo4jOptions.URL -> "bolt://localhost",
+        "relationship" -> "KNOWS",
+        "relationship.nodes.map" -> "false",
+        "relationship.source.labels" -> "Person",
+        "relationship.target.labels" -> "Person",
+        Neo4jOptions.CYPHER_VERSION -> customCypherVersion
+      ))
 
       val filters: Array[Filter] = Array[Filter](
         EqualTo("source.name", "John Doe")
@@ -510,14 +510,14 @@ class Neo4jQueryServiceTest {
       customCypherVersion: String,
       prefix: String
     ): Unit = {
-      val options: java.util.Map[String, String] = new java.util.HashMap[String, String]()
-      options.put(Neo4jOptions.URL, "bolt://localhost")
-      options.put("relationship", "KNOWS")
-      options.put("relationship.nodes.map", "false")
-      options.put("relationship.source.labels", "Person")
-      options.put("relationship.target.labels", "Person")
-      options.put(Neo4jOptions.CYPHER_VERSION, customCypherVersion)
-      val neo4jOptions: Neo4jOptions = new Neo4jOptions(options)
+      val neo4jOptions = new Neo4jOptions(Map(
+        Neo4jOptions.URL -> "bolt://localhost",
+        "relationship" -> "KNOWS",
+        "relationship.nodes.map" -> "false",
+        "relationship.source.labels" -> "Person",
+        "relationship.target.labels" -> "Person",
+        Neo4jOptions.CYPHER_VERSION -> customCypherVersion
+      ))
 
       val filters: Array[Filter] = Array[Filter](
         Or(EqualTo("source.name", "John Doe"), EqualTo("target.name", "John Doe"))
@@ -546,14 +546,14 @@ class Neo4jQueryServiceTest {
       customCypherVersion: String,
       prefix: String
     ): Unit = {
-      val options: java.util.Map[String, String] = new java.util.HashMap[String, String]()
-      options.put(Neo4jOptions.URL, "bolt://localhost")
-      options.put("relationship", "KNOWS")
-      options.put("relationship.nodes.map", "true")
-      options.put("relationship.source.labels", "Person")
-      options.put("relationship.target.labels", "Person")
-      options.put(Neo4jOptions.CYPHER_VERSION, customCypherVersion)
-      val neo4jOptions: Neo4jOptions = new Neo4jOptions(options)
+      val neo4jOptions = new Neo4jOptions(Map(
+        Neo4jOptions.URL -> "bolt://localhost",
+        "relationship" -> "KNOWS",
+        "relationship.nodes.map" -> "true",
+        "relationship.source.labels" -> "Person",
+        "relationship.target.labels" -> "Person",
+        Neo4jOptions.CYPHER_VERSION -> customCypherVersion
+      ))
 
       val filters: Array[Filter] = Array[Filter](
         EqualTo("source.id", "14"),
@@ -586,11 +586,11 @@ class Neo4jQueryServiceTest {
       customCypherVersion: String,
       prefix: String
     ): Unit = {
-      val options: java.util.Map[String, String] = new java.util.HashMap[String, String]()
-      options.put(Neo4jOptions.URL, "bolt://localhost")
-      options.put("labels", "Person")
-      options.put(Neo4jOptions.CYPHER_VERSION, customCypherVersion)
-      val neo4jOptions: Neo4jOptions = new Neo4jOptions(options)
+      val neo4jOptions = new Neo4jOptions(Map(
+        Neo4jOptions.URL -> "bolt://localhost",
+        "labels" -> "Person",
+        Neo4jOptions.CYPHER_VERSION -> customCypherVersion
+      ))
 
       val filters: Array[Filter] = Array[Filter](
         Or(EqualTo("name", "John Doe"), EqualTo("name", "John Scofield")),
@@ -629,14 +629,14 @@ class Neo4jQueryServiceTest {
       customCypherVersion: String,
       prefix: String
     ): Unit = {
-      val options: java.util.Map[String, String] = new java.util.HashMap[String, String]()
-      options.put(Neo4jOptions.URL, "bolt://localhost")
-      options.put("relationship", "KNOWS")
-      options.put("relationship.nodes.map", "true")
-      options.put("relationship.source.labels", "Person")
-      options.put("relationship.target.labels", "Person:Customer")
-      options.put(Neo4jOptions.CYPHER_VERSION, customCypherVersion)
-      val neo4jOptions: Neo4jOptions = new Neo4jOptions(options)
+      val neo4jOptions = new Neo4jOptions(Map(
+        Neo4jOptions.URL -> "bolt://localhost",
+        "relationship" -> "KNOWS",
+        "relationship.nodes.map" -> "true",
+        "relationship.source.labels" -> "Person",
+        "relationship.target.labels" -> "Person:Customer",
+        Neo4jOptions.CYPHER_VERSION -> customCypherVersion
+      ))
 
       val filters: Array[Filter] = Array[Filter](
         Or(
@@ -685,14 +685,14 @@ class Neo4jQueryServiceTest {
       customCypherVersion: String,
       prefix: String
     ): Unit = {
-      val options: java.util.Map[String, String] = new java.util.HashMap[String, String]()
-      options.put(Neo4jOptions.URL, "bolt://localhost")
-      options.put("relationship", "KNOWS")
-      options.put("relationship.nodes.map", "false")
-      options.put("relationship.source.labels", "Person")
-      options.put("relationship.target.labels", "Person:Customer")
-      options.put(Neo4jOptions.CYPHER_VERSION, customCypherVersion)
-      val neo4jOptions: Neo4jOptions = new Neo4jOptions(options)
+      val neo4jOptions = new Neo4jOptions(Map(
+        Neo4jOptions.URL -> "bolt://localhost",
+        "relationship" -> "KNOWS",
+        "relationship.nodes.map" -> "false",
+        "relationship.source.labels" -> "Person",
+        "relationship.target.labels" -> "Person:Customer",
+        Neo4jOptions.CYPHER_VERSION -> customCypherVersion
+      ))
 
       val filters: Array[Filter] = Array[Filter](
         Or(
@@ -741,11 +741,11 @@ class Neo4jQueryServiceTest {
       customCypherVersion: String,
       prefix: String
     ): Unit = {
-      val options: java.util.Map[String, String] = new java.util.HashMap[String, String]()
-      options.put(Neo4jOptions.URL, "bolt://localhost")
-      options.put(QueryType.LABELS.toString.toLowerCase, "Person")
-      options.put(Neo4jOptions.CYPHER_VERSION, customCypherVersion)
-      val neo4jOptions: Neo4jOptions = new Neo4jOptions(options)
+      val neo4jOptions = new Neo4jOptions(Map(
+        Neo4jOptions.URL -> "bolt://localhost",
+        QueryType.LABELS.toString.toLowerCase -> "Person",
+        Neo4jOptions.CYPHER_VERSION -> customCypherVersion
+      ))
 
       val ageField = new DummyNamedReference("age")
       var query: String = new Neo4jQueryService(
@@ -815,14 +815,14 @@ class Neo4jQueryServiceTest {
       customCypherVersion: String,
       prefix: String
     ): Unit = {
-      val options: java.util.Map[String, String] = new java.util.HashMap[String, String]()
-      options.put(Neo4jOptions.URL, "bolt://localhost")
-      options.put("relationship", "BOUGHT")
-      options.put("relationship.nodes.map", "false")
-      options.put("relationship.source.labels", "Person")
-      options.put("relationship.target.labels", "Product")
-      options.put(Neo4jOptions.CYPHER_VERSION, customCypherVersion)
-      val neo4jOptions: Neo4jOptions = new Neo4jOptions(options)
+      val neo4jOptions = new Neo4jOptions(Map(
+        Neo4jOptions.URL -> "bolt://localhost",
+        "relationship" -> "BOUGHT",
+        "relationship.nodes.map" -> "false",
+        "relationship.source.labels" -> "Person",
+        "relationship.target.labels" -> "Product",
+        Neo4jOptions.CYPHER_VERSION -> customCypherVersion
+      ))
 
       val targetPriceField = new DummyNamedReference("`target.price`")
       var query: String = new Neo4jQueryService(
@@ -905,11 +905,11 @@ class Neo4jQueryServiceTest {
       customCypherVersion: String,
       prefix: String
     ): Unit = {
-      val options: java.util.Map[String, String] = new java.util.HashMap[String, String]()
-      options.put(Neo4jOptions.URL, "bolt://localhost")
-      options.put(QueryType.LABELS.toString.toLowerCase, "Person")
-      options.put(Neo4jOptions.CYPHER_VERSION, customCypherVersion)
-      val neo4jOptions: Neo4jOptions = new Neo4jOptions(options)
+      val neo4jOptions = new Neo4jOptions(Map(
+        Neo4jOptions.URL -> "bolt://localhost",
+        QueryType.LABELS.toString.toLowerCase -> "Person",
+        Neo4jOptions.CYPHER_VERSION -> customCypherVersion
+      ))
 
       val query: String = new Neo4jQueryService(
         neo4jOptions,
@@ -943,11 +943,11 @@ class Neo4jQueryServiceTest {
       customCypherVersion: String,
       prefix: String
     ): Unit = {
-      val options: java.util.Map[String, String] = new java.util.HashMap[String, String]()
-      options.put(Neo4jOptions.URL, "bolt://localhost")
-      options.put(QueryType.LABELS.toString.toLowerCase, "Person")
-      options.put(Neo4jOptions.CYPHER_VERSION, customCypherVersion)
-      val neo4jOptions: Neo4jOptions = new Neo4jOptions(options)
+      val neo4jOptions = new Neo4jOptions(Map(
+        Neo4jOptions.URL -> "bolt://localhost",
+        QueryType.LABELS.toString.toLowerCase -> "Person",
+        Neo4jOptions.CYPHER_VERSION -> customCypherVersion
+      ))
 
       val query: String = new Neo4jQueryService(
         neo4jOptions,
@@ -982,14 +982,14 @@ class Neo4jQueryServiceTest {
       customCypherVersion: String,
       prefix: String
     ): Unit = {
-      val options: java.util.Map[String, String] = new java.util.HashMap[String, String]()
-      options.put(Neo4jOptions.URL, "bolt://localhost")
-      options.put("relationship", "KNOWS")
-      options.put("relationship.nodes.map", "false")
-      options.put("relationship.source.labels", "Person")
-      options.put("relationship.target.labels", "Person")
-      options.put(Neo4jOptions.CYPHER_VERSION, customCypherVersion)
-      val neo4jOptions: Neo4jOptions = new Neo4jOptions(options)
+      val neo4jOptions = new Neo4jOptions(Map(
+        Neo4jOptions.URL -> "bolt://localhost",
+        "relationship" -> "KNOWS",
+        "relationship.nodes.map" -> "false",
+        "relationship.source.labels" -> "Person",
+        "relationship.target.labels" -> "Person",
+        Neo4jOptions.CYPHER_VERSION -> customCypherVersion
+      ))
 
       val query: String = new Neo4jQueryService(
         neo4jOptions,
@@ -1029,14 +1029,14 @@ class Neo4jQueryServiceTest {
       customCypherVersion: String,
       prefix: String
     ): Unit = {
-      val options: java.util.Map[String, String] = new java.util.HashMap[String, String]()
-      options.put(Neo4jOptions.URL, "bolt://localhost")
-      options.put("relationship", "KNOWS")
-      options.put("relationship.nodes.map", "false")
-      options.put("relationship.source.labels", "Person")
-      options.put("relationship.target.labels", "Person")
-      options.put(Neo4jOptions.CYPHER_VERSION, customCypherVersion)
-      val neo4jOptions: Neo4jOptions = new Neo4jOptions(options)
+      val neo4jOptions = new Neo4jOptions(Map(
+        Neo4jOptions.URL -> "bolt://localhost",
+        "relationship" -> "KNOWS",
+        "relationship.nodes.map" -> "false",
+        "relationship.source.labels" -> "Person",
+        "relationship.target.labels" -> "Person",
+        Neo4jOptions.CYPHER_VERSION -> customCypherVersion
+      ))
 
       val query: String = new Neo4jQueryService(
         neo4jOptions,
@@ -1079,11 +1079,11 @@ class Neo4jQueryServiceTest {
       customCypherVersion: String,
       prefix: String
     ): Unit = {
-      val options: java.util.Map[String, String] = new java.util.HashMap[String, String]()
-      options.put(Neo4jOptions.URL, "bolt://localhost")
-      options.put(QueryType.QUERY.toString.toLowerCase, "MATCH (p:Person) RETURN p")
-      options.put(Neo4jOptions.CYPHER_VERSION, customCypherVersion)
-      val neo4jOptions: Neo4jOptions = new Neo4jOptions(options)
+      val neo4jOptions = new Neo4jOptions(Map(
+        Neo4jOptions.URL -> "bolt://localhost",
+        QueryType.QUERY.toString.toLowerCase -> "MATCH (p:Person) RETURN p",
+        Neo4jOptions.CYPHER_VERSION -> customCypherVersion
+      ))
 
       val query: String = new Neo4jQueryService(
         neo4jOptions,
@@ -1114,10 +1114,13 @@ class Neo4jQueryServiceTest {
     @ParameterizedTest
     @MethodSource(Array("tuning_parameters"))
     def labels_when_tuning_preamble(tuningOptions: Map[String, String], prefix: String): Unit = {
-      val options: java.util.Map[String, String] = new java.util.HashMap[String, String]()
-      options.put(Neo4jOptions.URL, "bolt://localhost")
-      options.put(QueryType.LABELS.toString.toLowerCase, "Person")
-      val neo4jOptions: Neo4jOptions = new Neo4jOptions(withTuning(options, tuningOptions))
+      val optionsMap = Map(
+        Neo4jOptions.URL -> "bolt://localhost",
+        QueryType.LABELS.toString.toLowerCase -> "Person"
+      )
+
+      val neo4jOptions = new Neo4jOptions(optionsMap ++ tuningOptions)
+
       val readService =
         new Neo4jQueryService(neo4jOptions, plainReadStrategy(neo4j(version(5, 0), COMMUNITY), neo4jOptions))
 
@@ -1128,13 +1131,16 @@ class Neo4jQueryServiceTest {
     @ParameterizedTest
     @MethodSource(Array("tuning_parameters"))
     def relationship_when_tuning_preamble(tuningOptions: Map[String, String], prefix: String): Unit = {
-      val options: java.util.Map[String, String] = new java.util.HashMap[String, String]()
-      options.put(Neo4jOptions.URL, "bolt://localhost")
-      options.put("relationship", "KNOWS")
-      options.put("relationship.nodes.map", "false")
-      options.put("relationship.source.labels", "Person")
-      options.put("relationship.target.labels", "Person")
-      val neo4jOptions: Neo4jOptions = new Neo4jOptions(withTuning(options, tuningOptions))
+      val optionsMap = Map(
+        Neo4jOptions.URL -> "bolt://localhost",
+        "relationship" -> "KNOWS",
+        "relationship.nodes.map" -> "false",
+        "relationship.source.labels" -> "Person",
+        "relationship.target.labels" -> "Person"
+      )
+
+      val neo4jOptions = new Neo4jOptions(optionsMap ++ tuningOptions)
+
       val readService =
         new Neo4jQueryService(neo4jOptions, plainReadStrategy(neo4j(version(5, 0), COMMUNITY), neo4jOptions))
 
@@ -1150,10 +1156,12 @@ class Neo4jQueryServiceTest {
       tuningOptions: Map[String, String],
       ignored: String
     ): Unit = {
-      val options: java.util.Map[String, String] = new java.util.HashMap[String, String]()
-      options.put(Neo4jOptions.URL, "bolt://localhost")
-      options.put(QueryType.QUERY.toString.toLowerCase, "MATCH (o:Object) RETURN o")
-      val neo4jOptions: Neo4jOptions = new Neo4jOptions(withTuning(options, tuningOptions))
+      val optionsMap = Map(
+        Neo4jOptions.URL -> "bolt://localhost",
+        QueryType.QUERY.toString.toLowerCase -> "MATCH (o:Object) RETURN o"
+      )
+
+      val neo4jOptions = new Neo4jOptions(optionsMap ++ tuningOptions)
       val neo4jInfo = neo4j(version(5, 0), COMMUNITY)
 
       val noPreambleReadService =
@@ -1179,11 +1187,13 @@ class Neo4jQueryServiceTest {
       tuningOptions: Map[String, String],
       tuningPrefix: String
     ): Unit = {
-      val options: java.util.Map[String, String] = new java.util.HashMap[String, String]()
-      options.put(Neo4jOptions.URL, "bolt://localhost")
-      options.put(QueryType.QUERY.toString.toLowerCase, "MATCH (o:Object) RETURN o")
-      options.put(Neo4jOptions.CYPHER_VERSION, customCypherVersion)
-      val neo4jOptions: Neo4jOptions = new Neo4jOptions(withTuning(options, tuningOptions))
+      val optionsMap = Map(
+        Neo4jOptions.URL -> "bolt://localhost",
+        QueryType.QUERY.toString.toLowerCase -> "MATCH (o:Object) RETURN o",
+        Neo4jOptions.CYPHER_VERSION -> customCypherVersion
+      )
+
+      val neo4jOptions = new Neo4jOptions(optionsMap ++ tuningOptions)
       val readService = new Neo4jQueryService(neo4jOptions, plainReadStrategy(neo4j, neo4jOptions))
 
       val wantQuery = s"$tuningPrefix\n${cypherVersionPreamble}MATCH (o:Object) RETURN o"
@@ -1199,12 +1209,14 @@ class Neo4jQueryServiceTest {
       tuningOptions: Map[String, String],
       tuningPrefix: String
     ): Unit = {
-      val options: java.util.Map[String, String] = new java.util.HashMap[String, String]()
-      options.put(Neo4jOptions.URL, "bolt://localhost")
-      options.put(QueryType.QUERY.toString.toLowerCase, "MATCH (o:Object) RETURN o")
-      options.put("script", "return 'foo'")
-      options.put(Neo4jOptions.CYPHER_VERSION, customCypherVersion)
-      val neo4jOptions: Neo4jOptions = new Neo4jOptions(withTuning(options, tuningOptions))
+      val optionsMap = Map(
+        Neo4jOptions.URL -> "bolt://localhost",
+        QueryType.QUERY.toString.toLowerCase -> "MATCH (o:Object) RETURN o",
+        "script" -> "return 'foo'",
+        Neo4jOptions.CYPHER_VERSION -> customCypherVersion
+      )
+
+      val neo4jOptions = new Neo4jOptions(optionsMap ++ tuningOptions)
       val versionedReadService = new Neo4jQueryService(neo4jOptions, plainReadStrategy(neo4j, neo4jOptions))
 
       val wantQuery =
@@ -1233,11 +1245,11 @@ class Neo4jQueryServiceTest {
     @ParameterizedTest
     @MethodSource(Array("versions_and_prefixes"))
     def labels_when_multiple_labels(neo4j: Neo4j, customCypherVersion: String, prefix: String): Unit = {
-      val options: java.util.Map[String, String] = new java.util.HashMap[String, String]()
-      options.put(Neo4jOptions.URL, "bolt://localhost")
-      options.put(QueryType.LABELS.toString.toLowerCase, ":Person:Player:Midfield")
-      options.put(Neo4jOptions.CYPHER_VERSION, customCypherVersion)
-      val neo4jOptions: Neo4jOptions = new Neo4jOptions(options)
+      val neo4jOptions = new Neo4jOptions(Map(
+        Neo4jOptions.URL -> "bolt://localhost",
+        QueryType.LABELS.toString.toLowerCase -> ":Person:Player:Midfield",
+        Neo4jOptions.CYPHER_VERSION -> customCypherVersion
+      ))
 
       val query: String =
         new Neo4jQueryService(neo4jOptions, plainWriteStrategy(neo4j, neo4jOptions, SaveMode.Append)).createQuery().trim
@@ -1254,12 +1266,12 @@ class Neo4jQueryServiceTest {
       customCypherVersion: String,
       prefix: String
     ): Unit = {
-      val options: java.util.Map[String, String] = new java.util.HashMap[String, String]()
-      options.put(Neo4jOptions.URL, "bolt://localhost")
-      options.put("labels", "Location")
-      options.put("node.keys", "LocationName:name,LocationType:type,FeatureID:featureId")
-      options.put(Neo4jOptions.CYPHER_VERSION, customCypherVersion)
-      val neo4jOptions: Neo4jOptions = new Neo4jOptions(options)
+      val neo4jOptions = new Neo4jOptions(Map(
+        Neo4jOptions.URL -> "bolt://localhost",
+        "labels" -> "Location",
+        "node.keys" -> "LocationName:name,LocationType:type,FeatureID:featureId",
+        Neo4jOptions.CYPHER_VERSION -> customCypherVersion
+      ))
 
       val query: String =
         new Neo4jQueryService(neo4jOptions, plainWriteStrategy(neo4j, neo4jOptions)).createQuery()
@@ -1279,16 +1291,15 @@ class Neo4jQueryServiceTest {
       customCypherVersion: String,
       prefix: String
     ): Unit = {
-      val options: java.util.Map[String, String] = new java.util.HashMap[String, String]()
-      options.put(Neo4jOptions.URL, "bolt://localhost")
-      options.put("relationship", "BOUGHT")
-      options.put("relationship.source.labels", ":Person")
-      options.put("relationship.source.node.keys", "FirstName:name,LastName:lastName")
-      options.put("relationship.target.labels", ":Product:Merch")
-      options.put("relationship.target.node.keys", "ProductPrice:price,ProductId:id")
-
-      options.put(Neo4jOptions.CYPHER_VERSION, customCypherVersion)
-      val neo4jOptions: Neo4jOptions = new Neo4jOptions(options)
+      val neo4jOptions = new Neo4jOptions(Map(
+        Neo4jOptions.URL -> "bolt://localhost",
+        "relationship" -> "BOUGHT",
+        "relationship.source.labels" -> ":Person",
+        "relationship.source.node.keys" -> "FirstName:name,LastName:lastName",
+        "relationship.target.labels" -> ":Product:Merch",
+        "relationship.target.node.keys" -> "ProductPrice:price,ProductId:id",
+        Neo4jOptions.CYPHER_VERSION -> customCypherVersion
+      ))
 
       val query: String =
         new Neo4jQueryService(neo4jOptions, plainWriteStrategy(neo4j, neo4jOptions)).createQuery()
@@ -1310,18 +1321,17 @@ class Neo4jQueryServiceTest {
       customCypherVersion: String,
       prefix: String
     ): Unit = {
-      val options: java.util.Map[String, String] = new java.util.HashMap[String, String]()
-      options.put(Neo4jOptions.URL, "bolt://localhost")
-      options.put("relationship", "BOUGHT")
-      options.put("relationship.source.labels", "Person")
-      options.put("relationship.source.node.keys", "FirstName:name,LastName:lastName")
-      options.put("relationship.source.save.mode", "Overwrite")
-      options.put("relationship.target.labels", "Product")
-      options.put("relationship.target.node.keys", "ProductPrice:price,ProductId:id")
-      options.put("relationship.target.save.mode", "Match")
-
-      options.put(Neo4jOptions.CYPHER_VERSION, customCypherVersion)
-      val neo4jOptions: Neo4jOptions = new Neo4jOptions(options)
+      val neo4jOptions = new Neo4jOptions(Map(
+        Neo4jOptions.URL -> "bolt://localhost",
+        "relationship" -> "BOUGHT",
+        "relationship.source.labels" -> "Person",
+        "relationship.source.node.keys" -> "FirstName:name,LastName:lastName",
+        "relationship.source.save.mode" -> "Overwrite",
+        "relationship.target.labels" -> "Product",
+        "relationship.target.node.keys" -> "ProductPrice:price,ProductId:id",
+        "relationship.target.save.mode" -> "Match",
+        Neo4jOptions.CYPHER_VERSION -> customCypherVersion
+      ))
 
       val query: String =
         new Neo4jQueryService(neo4jOptions, plainWriteStrategy(neo4j, neo4jOptions)).createQuery()
@@ -1344,18 +1354,17 @@ class Neo4jQueryServiceTest {
       customCypherVersion: String,
       prefix: String
     ): Unit = {
-      val options: java.util.Map[String, String] = new java.util.HashMap[String, String]()
-      options.put(Neo4jOptions.URL, "bolt://localhost")
-      options.put("relationship", "BOUGHT")
-      options.put("relationship.source.labels", "Person")
-      options.put("relationship.source.node.keys", "FirstName:name,LastName:lastName")
-      options.put("relationship.source.save.mode", "Overwrite")
-      options.put("relationship.target.labels", "Product")
-      options.put("relationship.target.node.keys", "ProductPrice:price,ProductId:id")
-      options.put("relationship.target.save.mode", "Overwrite")
-
-      options.put(Neo4jOptions.CYPHER_VERSION, customCypherVersion)
-      val neo4jOptions: Neo4jOptions = new Neo4jOptions(options)
+      val neo4jOptions = new Neo4jOptions(Map(
+        Neo4jOptions.URL -> "bolt://localhost",
+        "relationship" -> "BOUGHT",
+        "relationship.source.labels" -> "Person",
+        "relationship.source.node.keys" -> "FirstName:name,LastName:lastName",
+        "relationship.source.save.mode" -> "Overwrite",
+        "relationship.target.labels" -> "Product",
+        "relationship.target.node.keys" -> "ProductPrice:price,ProductId:id",
+        "relationship.target.save.mode" -> "Overwrite",
+        Neo4jOptions.CYPHER_VERSION -> customCypherVersion
+      ))
 
       val query: String =
         new Neo4jQueryService(neo4jOptions, plainWriteStrategy(neo4j, neo4jOptions)).createQuery()
@@ -1377,18 +1386,17 @@ class Neo4jQueryServiceTest {
       customCypherVersion: String,
       prefix: String
     ): Unit = {
-      val options: java.util.Map[String, String] = new java.util.HashMap[String, String]()
-      options.put(Neo4jOptions.URL, "bolt://localhost")
-      options.put("relationship", "BOUGHT")
-      options.put("relationship.source.labels", "Person")
-      options.put("relationship.source.node.keys", "FirstName:name,LastName:lastName")
-      options.put("relationship.source.save.mode", "Append")
-      options.put("relationship.target.labels", "Product")
-      options.put("relationship.target.node.keys", "ProductPrice:price,ProductId:id")
-      options.put("relationship.target.save.mode", "Overwrite")
-
-      options.put(Neo4jOptions.CYPHER_VERSION, customCypherVersion)
-      val neo4jOptions: Neo4jOptions = new Neo4jOptions(options)
+      val neo4jOptions = new Neo4jOptions(Map(
+        Neo4jOptions.URL -> "bolt://localhost",
+        "relationship" -> "BOUGHT",
+        "relationship.source.labels" -> "Person",
+        "relationship.source.node.keys" -> "FirstName:name,LastName:lastName",
+        "relationship.source.save.mode" -> "Append",
+        "relationship.target.labels" -> "Product",
+        "relationship.target.node.keys" -> "ProductPrice:price,ProductId:id",
+        "relationship.target.save.mode" -> "Overwrite",
+        Neo4jOptions.CYPHER_VERSION -> customCypherVersion
+      ))
 
       val query: String =
         new Neo4jQueryService(neo4jOptions, plainWriteStrategy(neo4j, neo4jOptions, SaveMode.Append)).createQuery()
@@ -1410,21 +1418,20 @@ class Neo4jQueryServiceTest {
       customCypherVersion: String,
       prefix: String
     ): Unit = {
-      val options: java.util.Map[String, String] = new java.util.HashMap[String, String]()
-      options.put(Neo4jOptions.URL, "bolt://localhost")
-      options.put("relationship", "DID BUY")
-      options.put("relationship.save.strategy", "keys")
-      options.put("relationship.source.labels", ":Person:Customer")
-      options.put("relationship.source.save.mode", "Overwrite")
-      options.put("relationship.source.node.keys", "first name,last name")
-      options.put("relationship.target.labels", "Product")
-      options.put("relationship.target.save.mode", "Match")
-      options.put("relationship.target.node.keys", "article number")
-      options.put("relationship.properties", "number of items")
-      options.put("relationship.keys", "transactionId:transaction identifier")
-
-      options.put(Neo4jOptions.CYPHER_VERSION, customCypherVersion)
-      val neo4jOptions: Neo4jOptions = new Neo4jOptions(options)
+      val neo4jOptions = new Neo4jOptions(Map(
+        Neo4jOptions.URL -> "bolt://localhost",
+        "relationship" -> "DID BUY",
+        "relationship.save.strategy" -> "keys",
+        "relationship.source.labels" -> ":Person:Customer",
+        "relationship.source.save.mode" -> "Overwrite",
+        "relationship.source.node.keys" -> "first name,last name",
+        "relationship.target.labels" -> "Product",
+        "relationship.target.save.mode" -> "Match",
+        "relationship.target.node.keys" -> "article number",
+        "relationship.properties" -> "number of items",
+        "relationship.keys" -> "transactionId:transaction identifier",
+        Neo4jOptions.CYPHER_VERSION -> customCypherVersion
+      ))
 
       val query: String =
         new Neo4jQueryService(neo4jOptions, plainWriteStrategy(neo4j, neo4jOptions)).createQuery()
@@ -1443,10 +1450,12 @@ class Neo4jQueryServiceTest {
     @ParameterizedTest
     @MethodSource(Array("tuning_parameters"))
     def labels_when_tuning_parameters(tuningOptions: Map[String, String], prefix: String): Unit = {
-      val options: java.util.Map[String, String] = new java.util.HashMap[String, String]()
-      options.put(Neo4jOptions.URL, "bolt://localhost")
-      options.put(QueryType.LABELS.toString.toLowerCase, "Person")
-      val neo4jOptions: Neo4jOptions = new Neo4jOptions(withTuning(options, tuningOptions))
+      val neo4jOptions = new Neo4jOptions(
+        Map(
+          Neo4jOptions.URL -> "bolt://localhost",
+          QueryType.LABELS.toString.toLowerCase -> "Person"
+        ) ++ tuningOptions
+      )
       val neo4jInfo = neo4j(version(5, 0), COMMUNITY)
 
       val writeService = new Neo4jQueryService(
@@ -1464,24 +1473,27 @@ class Neo4jQueryServiceTest {
       tuningOptions: Map[String, String],
       prefix: String
     ): Unit = {
-      val options: java.util.Map[String, String] = new java.util.HashMap[String, String]()
-      options.put(Neo4jOptions.URL, "bolt://localhost")
-      options.put("relationship", "KNOWS")
-      options.put("relationship.nodes.map", "false")
-      options.put("relationship.source.labels", "Person")
-      options.put("relationship.target.labels", "Person")
-      val neo4jOptions: Neo4jOptions = new Neo4jOptions(withTuning(options, tuningOptions))
+      val neo4jOptions = new Neo4jOptions(
+        Map(
+          Neo4jOptions.URL -> "bolt://localhost",
+          "relationship" -> "KNOWS",
+          "relationship.nodes.map" -> "false",
+          "relationship.source.labels" -> "Person",
+          "relationship.target.labels" -> "Person"
+        ) ++ tuningOptions
+      )
       val neo4jInfo = neo4j(version(5, 0), COMMUNITY)
 
       val writeService = new Neo4jQueryService(
         neo4jOptions,
         new Neo4jQueryWriteStrategy(neo4jInfo, new CypherRenderer(neo4jInfo, neo4jOptions), SaveMode.Overwrite)
       )
-      val wantQuery = """UNWIND $events AS event
-                        |MATCH (source:`Person`)
-                        |MATCH (target:`Person`)
-                        |MERGE (source)-[rel:`KNOWS`]->(target)
-                        |SET rel += event.rel.properties""".stripMargin.replaceAll("\n", " ")
+      val wantQuery =
+        """UNWIND $events AS event
+          |MATCH (source:`Person`)
+          |MATCH (target:`Person`)
+          |MERGE (source)-[rel:`KNOWS`]->(target)
+          |SET rel += event.rel.properties""".stripMargin.replaceAll("\n", " ")
 
       assertThat(writeService.createQuery().trim).isEqualTo(s"$prefix\n$wantQuery".trim)
     }
@@ -1492,10 +1504,12 @@ class Neo4jQueryServiceTest {
       tuningOptions: Map[String, String],
       ignored: String
     ): Unit = {
-      val options: java.util.Map[String, String] = new java.util.HashMap[String, String]()
-      options.put(Neo4jOptions.URL, "bolt://localhost")
-      options.put(QueryType.QUERY.toString.toLowerCase, "MATCH (o:Object) RETURN o")
-      val neo4jOptions: Neo4jOptions = new Neo4jOptions(withTuning(options, tuningOptions))
+      val neo4jOptions = new Neo4jOptions(
+        Map(
+          Neo4jOptions.URL -> "bolt://localhost",
+          QueryType.QUERY.toString.toLowerCase -> "MATCH (o:Object) RETURN o"
+        ) ++ tuningOptions
+      )
       val neo4jInfo = neo4j(version(5, 0), COMMUNITY)
 
       val noPreambleWriteService =
@@ -1517,11 +1531,13 @@ class Neo4jQueryServiceTest {
       tuningOptions: Map[String, String],
       tuningPrefix: String
     ): Unit = {
-      val options: java.util.Map[String, String] = new java.util.HashMap[String, String]()
-      options.put(Neo4jOptions.URL, "bolt://localhost")
-      options.put(QueryType.QUERY.toString.toLowerCase, "MATCH (o:Object) RETURN o")
-      options.put(Neo4jOptions.CYPHER_VERSION, customCypherVersion)
-      val neo4jOptions: Neo4jOptions = new Neo4jOptions(withTuning(options, tuningOptions))
+      val neo4jOptions = new Neo4jOptions(
+        Map(
+          Neo4jOptions.URL -> "bolt://localhost",
+          QueryType.QUERY.toString.toLowerCase -> "MATCH (o:Object) RETURN o",
+          Neo4jOptions.CYPHER_VERSION -> customCypherVersion
+        ) ++ tuningOptions
+      )
 
       val writeService =
         new Neo4jQueryService(neo4jOptions, plainWriteStrategy(neo4j, neo4jOptions))
@@ -1539,12 +1555,14 @@ class Neo4jQueryServiceTest {
       tuningOptions: Map[String, String],
       tuningPrefix: String
     ): Unit = {
-      val options: java.util.Map[String, String] = new java.util.HashMap[String, String]()
-      options.put(Neo4jOptions.URL, "bolt://localhost")
-      options.put(QueryType.QUERY.toString.toLowerCase, "MATCH (o:Object) RETURN o")
-      options.put("script", "return 'foo'")
-      options.put(Neo4jOptions.CYPHER_VERSION, customCypherVersion)
-      val neo4jOptions: Neo4jOptions = new Neo4jOptions(withTuning(options, tuningOptions))
+      val neo4jOptions = new Neo4jOptions(
+        Map(
+          Neo4jOptions.URL -> "bolt://localhost",
+          QueryType.QUERY.toString.toLowerCase -> "MATCH (o:Object) RETURN o",
+          "script" -> "return 'foo'",
+          Neo4jOptions.CYPHER_VERSION -> customCypherVersion
+        ) ++ tuningOptions
+      )
 
       val versionedWriteService =
         new Neo4jQueryService(neo4jOptions, plainWriteStrategy(neo4j, neo4jOptions))
@@ -1572,17 +1590,6 @@ object Neo4jQueryServiceTest {
 
   def version(major: Int, minor: Int): Neo4jVersion = {
     new Neo4jVersion(major, minor, 0)
-  }
-
-  def withTuning(
-    options: java.util.Map[String, String],
-    tuning: Map[String, String]
-  ): java.util.Map[String, String] = {
-    tuning.foreach {
-      case (key, value) =>
-        options.put(key, value)
-    }
-    options
   }
 
   // Parameter methods

--- a/src/test/scala/org/neo4j/spark/service/SchemaServiceTSE.scala
+++ b/src/test/scala/org/neo4j/spark/service/SchemaServiceTSE.scala
@@ -21,9 +21,7 @@ import org.apache.spark.sql.types.StructField
 import org.apache.spark.sql.types.StructType
 import org.junit.jupiter.api.Assertions._
 import org.junit.jupiter.api.BeforeEach
-import org.junit.jupiter.api.MethodOrderer
 import org.junit.jupiter.api.Test
-import org.junit.jupiter.api.TestMethodOrder
 import org.neo4j.driver.TransactionContext
 import org.neo4j.spark.converter.CypherToSparkTypeConverter
 import org.neo4j.spark.testsupport.Closeables.use
@@ -34,8 +32,6 @@ import org.neo4j.spark.util.DriverCache
 import org.neo4j.spark.util.Neo4jOptions
 import org.neo4j.spark.util.Neo4jUtil
 import org.neo4j.spark.util.QueryType
-
-import java.util
 
 class SchemaServiceTSE extends SparkConnectorScalaBaseTSE {
 
@@ -51,9 +47,7 @@ class SchemaServiceTSE extends SparkConnectorScalaBaseTSE {
   @Test
   def testGetSchemaFromNodeBoolean(): Unit = {
     initTest("CREATE (p:Person {is_hero: true})")
-    val options: java.util.Map[String, String] = new util.HashMap[String, String]()
-    options.put(QueryType.LABELS.toString.toLowerCase, "Person")
-
+    val options = Map(QueryType.LABELS.toString -> "Person")
     val schema = getSchema(options)
 
     assertEquals(getExpectedStructType(Seq(StructField("is_hero", DataTypes.BooleanType))), schema)
@@ -62,9 +56,7 @@ class SchemaServiceTSE extends SparkConnectorScalaBaseTSE {
   @Test
   def testGetSchemaFromNodeString(): Unit = {
     initTest("CREATE (p:Person {name: 'John'})")
-    val options: java.util.Map[String, String] = new util.HashMap[String, String]()
-    options.put(QueryType.LABELS.toString.toLowerCase, "Person")
-
+    val options = Map(QueryType.LABELS.toString -> "Person")
     val schema = getSchema(options)
 
     assertEquals(getExpectedStructType(Seq(StructField("name", DataTypes.StringType))), schema)
@@ -73,9 +65,7 @@ class SchemaServiceTSE extends SparkConnectorScalaBaseTSE {
   @Test
   def testGetSchemaFromNodeLong(): Unit = {
     initTest("CREATE (p:Person {age: 93})")
-    val options: java.util.Map[String, String] = new util.HashMap[String, String]()
-    options.put(QueryType.LABELS.toString.toLowerCase, "Person")
-
+    val options = Map(QueryType.LABELS.toString -> "Person")
     val schema = getSchema(options)
 
     assertEquals(getExpectedStructType(Seq(StructField("age", DataTypes.LongType))), schema)
@@ -84,9 +74,7 @@ class SchemaServiceTSE extends SparkConnectorScalaBaseTSE {
   @Test
   def testGetSchemaFromNodeDouble(): Unit = {
     initTest("CREATE (p:Person {ratio: 43.120})")
-    val options: java.util.Map[String, String] = new util.HashMap[String, String]()
-    options.put(QueryType.LABELS.toString.toLowerCase, "Person")
-
+    val options = Map(QueryType.LABELS.toString -> "Person")
     val schema = getSchema(options)
 
     assertEquals(getExpectedStructType(Seq(StructField("ratio", DataTypes.DoubleType))), schema)
@@ -95,9 +83,7 @@ class SchemaServiceTSE extends SparkConnectorScalaBaseTSE {
   @Test
   def testGetSchemaFromNodePoint2D(): Unit = {
     initTest("CREATE (p:Person {location: point({x: 12.32, y: 49.32})})")
-    val options: java.util.Map[String, String] = new util.HashMap[String, String]()
-    options.put(QueryType.LABELS.toString.toLowerCase, "Person")
-
+    val options = Map(QueryType.LABELS.toString -> "Person")
     val schema = getSchema(options)
 
     assertEquals(getExpectedStructType(Seq(StructField("location", CypherToSparkTypeConverter.pointType))), schema)
@@ -106,9 +92,7 @@ class SchemaServiceTSE extends SparkConnectorScalaBaseTSE {
   @Test
   def testGetSchemaFromDate(): Unit = {
     initTest("CREATE (p:Person {born_on: date('1998-01-05')})")
-    val options: java.util.Map[String, String] = new util.HashMap[String, String]()
-    options.put(QueryType.LABELS.toString.toLowerCase, "Person")
-
+    val options = Map(QueryType.LABELS.toString -> "Person")
     val schema = getSchema(options)
 
     assertEquals(getExpectedStructType(Seq(StructField("born_on", DataTypes.DateType))), schema)
@@ -117,9 +101,7 @@ class SchemaServiceTSE extends SparkConnectorScalaBaseTSE {
   @Test
   def testGetSchemaFromDateTime(): Unit = {
     initTest("CREATE (p:Person {arrived_at: datetime('1998-01-05')})")
-    val options: java.util.Map[String, String] = new util.HashMap[String, String]()
-    options.put(QueryType.LABELS.toString.toLowerCase, "Person")
-
+    val options = Map(QueryType.LABELS.toString -> "Person")
     val schema = getSchema(options)
 
     assertEquals(getExpectedStructType(Seq(StructField("arrived_at", DataTypes.TimestampType))), schema)
@@ -128,9 +110,7 @@ class SchemaServiceTSE extends SparkConnectorScalaBaseTSE {
   @Test
   def testGetSchemaFromTime(): Unit = {
     initTest("CREATE (p:Person {arrived_at: time('125035.556+0100')})")
-    val options: java.util.Map[String, String] = new util.HashMap[String, String]()
-    options.put(QueryType.LABELS.toString.toLowerCase, "Person")
-
+    val options = Map(QueryType.LABELS.toString -> "Person")
     val schema = getSchema(options)
 
     assertEquals(getExpectedStructType(Seq(StructField("arrived_at", CypherToSparkTypeConverter.timeType))), schema)
@@ -139,9 +119,7 @@ class SchemaServiceTSE extends SparkConnectorScalaBaseTSE {
   @Test
   def testGetSchemaFromStringArray(): Unit = {
     initTest("CREATE (p:Person {names: ['John', 'Doe']})")
-    val options: java.util.Map[String, String] = new util.HashMap[String, String]()
-    options.put(QueryType.LABELS.toString.toLowerCase, "Person")
-
+    val options = Map(QueryType.LABELS.toString -> "Person")
     val schema = getSchema(options)
 
     assertEquals(
@@ -153,9 +131,7 @@ class SchemaServiceTSE extends SparkConnectorScalaBaseTSE {
   @Test
   def testGetSchemaFromDateArray(): Unit = {
     initTest("CREATE (p:Person {names: [date('2019-11-19'), date('2019-11-20')]})")
-    val options: java.util.Map[String, String] = new util.HashMap[String, String]()
-    options.put(QueryType.LABELS.toString.toLowerCase, "Person")
-
+    val options = Map(QueryType.LABELS.toString -> "Person")
     val schema = getSchema(options)
 
     assertEquals(
@@ -167,9 +143,7 @@ class SchemaServiceTSE extends SparkConnectorScalaBaseTSE {
   @Test
   def testGetSchemaFromTimestampArray(): Unit = {
     initTest("CREATE (p:Person {dates: [datetime('2019-11-19'), datetime('2019-11-20')]})")
-    val options: java.util.Map[String, String] = new util.HashMap[String, String]()
-    options.put(QueryType.LABELS.toString.toLowerCase, "Person")
-
+    val options = Map(QueryType.LABELS.toString -> "Person")
     val schema = getSchema(options)
 
     assertEquals(
@@ -181,9 +155,7 @@ class SchemaServiceTSE extends SparkConnectorScalaBaseTSE {
   @Test
   def testGetSchemaFromTimeArray(): Unit = {
     initTest("CREATE (p:Person {dates: [time('125035.556+0100'), time('125125.556+0100')]})")
-    val options: java.util.Map[String, String] = new util.HashMap[String, String]()
-    options.put(QueryType.LABELS.toString.toLowerCase, "Person")
-
+    val options = Map(QueryType.LABELS.toString -> "Person")
     val schema = getSchema(options)
 
     assertEquals(
@@ -195,9 +167,7 @@ class SchemaServiceTSE extends SparkConnectorScalaBaseTSE {
   @Test
   def testGetSchemaFromIntegerArray(): Unit = {
     initTest("CREATE (p:Person {ages: [42, 101]})")
-    val options: java.util.Map[String, String] = new util.HashMap[String, String]()
-    options.put(QueryType.LABELS.toString.toLowerCase, "Person")
-
+    val options = Map(QueryType.LABELS.toString -> "Person")
     val schema = getSchema(options)
 
     assertEquals(getExpectedStructType(Seq(StructField("ages", DataTypes.createArrayType(DataTypes.LongType)))), schema)
@@ -212,10 +182,7 @@ class SchemaServiceTSE extends SparkConnectorScalaBaseTSE {
         (p3:Person {age: 25, location: point({latitude: 12.12, longitude: 31.13})})
     """
     )
-
-    val options: java.util.Map[String, String] = new util.HashMap[String, String]()
-    options.put(QueryType.LABELS.toString.toLowerCase, "Person")
-
+    val options = Map(QueryType.LABELS.toString -> "Person")
     val schema = getSchema(options)
 
     assertEquals(
@@ -241,9 +208,9 @@ class SchemaServiceTSE extends SparkConnectorScalaBaseTSE {
       .executeWrite((tx: TransactionContext) => tx.run(query).consume())
   }
 
-  private def getSchema(options: java.util.Map[String, String]): StructType = {
-    options.put(Neo4jOptions.URL, SparkConnectorScalaSuiteIT.server.getBoltUrl)
-    val neo4jOptions: Neo4jOptions = new Neo4jOptions(options)
+  private def getSchema(options: Map[String, String]): StructType = {
+    val urlMapping = Neo4jOptions.URL -> SparkConnectorScalaSuiteIT.server.getBoltUrl
+    val neo4jOptions: Neo4jOptions = new Neo4jOptions(options + urlMapping)
 
     val driverCache = new DriverCache(neo4jOptions.connection)
     val schemaService: SchemaService = new SchemaService(neo4j, neo4jOptions, driverCache)

--- a/src/test/scala/org/neo4j/spark/service/SchemaServiceTSE.scala
+++ b/src/test/scala/org/neo4j/spark/service/SchemaServiceTSE.scala
@@ -47,7 +47,7 @@ class SchemaServiceTSE extends SparkConnectorScalaBaseTSE {
   @Test
   def testGetSchemaFromNodeBoolean(): Unit = {
     initTest("CREATE (p:Person {is_hero: true})")
-    val options = Map(QueryType.LABELS.toString -> "Person")
+    val options = Map(QueryType.LABELS.toString.toLowerCase -> "Person")
     val schema = getSchema(options)
 
     assertEquals(getExpectedStructType(Seq(StructField("is_hero", DataTypes.BooleanType))), schema)
@@ -56,7 +56,7 @@ class SchemaServiceTSE extends SparkConnectorScalaBaseTSE {
   @Test
   def testGetSchemaFromNodeString(): Unit = {
     initTest("CREATE (p:Person {name: 'John'})")
-    val options = Map(QueryType.LABELS.toString -> "Person")
+    val options = Map(QueryType.LABELS.toString.toLowerCase -> "Person")
     val schema = getSchema(options)
 
     assertEquals(getExpectedStructType(Seq(StructField("name", DataTypes.StringType))), schema)
@@ -65,7 +65,7 @@ class SchemaServiceTSE extends SparkConnectorScalaBaseTSE {
   @Test
   def testGetSchemaFromNodeLong(): Unit = {
     initTest("CREATE (p:Person {age: 93})")
-    val options = Map(QueryType.LABELS.toString -> "Person")
+    val options = Map(QueryType.LABELS.toString.toLowerCase -> "Person")
     val schema = getSchema(options)
 
     assertEquals(getExpectedStructType(Seq(StructField("age", DataTypes.LongType))), schema)
@@ -74,7 +74,7 @@ class SchemaServiceTSE extends SparkConnectorScalaBaseTSE {
   @Test
   def testGetSchemaFromNodeDouble(): Unit = {
     initTest("CREATE (p:Person {ratio: 43.120})")
-    val options = Map(QueryType.LABELS.toString -> "Person")
+    val options = Map(QueryType.LABELS.toString.toLowerCase -> "Person")
     val schema = getSchema(options)
 
     assertEquals(getExpectedStructType(Seq(StructField("ratio", DataTypes.DoubleType))), schema)
@@ -83,7 +83,7 @@ class SchemaServiceTSE extends SparkConnectorScalaBaseTSE {
   @Test
   def testGetSchemaFromNodePoint2D(): Unit = {
     initTest("CREATE (p:Person {location: point({x: 12.32, y: 49.32})})")
-    val options = Map(QueryType.LABELS.toString -> "Person")
+    val options = Map(QueryType.LABELS.toString.toLowerCase -> "Person")
     val schema = getSchema(options)
 
     assertEquals(getExpectedStructType(Seq(StructField("location", CypherToSparkTypeConverter.pointType))), schema)
@@ -92,7 +92,7 @@ class SchemaServiceTSE extends SparkConnectorScalaBaseTSE {
   @Test
   def testGetSchemaFromDate(): Unit = {
     initTest("CREATE (p:Person {born_on: date('1998-01-05')})")
-    val options = Map(QueryType.LABELS.toString -> "Person")
+    val options = Map(QueryType.LABELS.toString.toLowerCase -> "Person")
     val schema = getSchema(options)
 
     assertEquals(getExpectedStructType(Seq(StructField("born_on", DataTypes.DateType))), schema)
@@ -101,7 +101,7 @@ class SchemaServiceTSE extends SparkConnectorScalaBaseTSE {
   @Test
   def testGetSchemaFromDateTime(): Unit = {
     initTest("CREATE (p:Person {arrived_at: datetime('1998-01-05')})")
-    val options = Map(QueryType.LABELS.toString -> "Person")
+    val options = Map(QueryType.LABELS.toString.toLowerCase -> "Person")
     val schema = getSchema(options)
 
     assertEquals(getExpectedStructType(Seq(StructField("arrived_at", DataTypes.TimestampType))), schema)
@@ -110,7 +110,7 @@ class SchemaServiceTSE extends SparkConnectorScalaBaseTSE {
   @Test
   def testGetSchemaFromTime(): Unit = {
     initTest("CREATE (p:Person {arrived_at: time('125035.556+0100')})")
-    val options = Map(QueryType.LABELS.toString -> "Person")
+    val options = Map(QueryType.LABELS.toString.toLowerCase -> "Person")
     val schema = getSchema(options)
 
     assertEquals(getExpectedStructType(Seq(StructField("arrived_at", CypherToSparkTypeConverter.timeType))), schema)
@@ -119,7 +119,7 @@ class SchemaServiceTSE extends SparkConnectorScalaBaseTSE {
   @Test
   def testGetSchemaFromStringArray(): Unit = {
     initTest("CREATE (p:Person {names: ['John', 'Doe']})")
-    val options = Map(QueryType.LABELS.toString -> "Person")
+    val options = Map(QueryType.LABELS.toString.toLowerCase -> "Person")
     val schema = getSchema(options)
 
     assertEquals(
@@ -131,7 +131,7 @@ class SchemaServiceTSE extends SparkConnectorScalaBaseTSE {
   @Test
   def testGetSchemaFromDateArray(): Unit = {
     initTest("CREATE (p:Person {names: [date('2019-11-19'), date('2019-11-20')]})")
-    val options = Map(QueryType.LABELS.toString -> "Person")
+    val options = Map(QueryType.LABELS.toString.toLowerCase -> "Person")
     val schema = getSchema(options)
 
     assertEquals(
@@ -143,7 +143,7 @@ class SchemaServiceTSE extends SparkConnectorScalaBaseTSE {
   @Test
   def testGetSchemaFromTimestampArray(): Unit = {
     initTest("CREATE (p:Person {dates: [datetime('2019-11-19'), datetime('2019-11-20')]})")
-    val options = Map(QueryType.LABELS.toString -> "Person")
+    val options = Map(QueryType.LABELS.toString.toLowerCase -> "Person")
     val schema = getSchema(options)
 
     assertEquals(
@@ -155,7 +155,7 @@ class SchemaServiceTSE extends SparkConnectorScalaBaseTSE {
   @Test
   def testGetSchemaFromTimeArray(): Unit = {
     initTest("CREATE (p:Person {dates: [time('125035.556+0100'), time('125125.556+0100')]})")
-    val options = Map(QueryType.LABELS.toString -> "Person")
+    val options = Map(QueryType.LABELS.toString.toLowerCase -> "Person")
     val schema = getSchema(options)
 
     assertEquals(
@@ -167,7 +167,7 @@ class SchemaServiceTSE extends SparkConnectorScalaBaseTSE {
   @Test
   def testGetSchemaFromIntegerArray(): Unit = {
     initTest("CREATE (p:Person {ages: [42, 101]})")
-    val options = Map(QueryType.LABELS.toString -> "Person")
+    val options = Map(QueryType.LABELS.toString.toLowerCase -> "Person")
     val schema = getSchema(options)
 
     assertEquals(getExpectedStructType(Seq(StructField("ages", DataTypes.createArrayType(DataTypes.LongType)))), schema)
@@ -182,7 +182,7 @@ class SchemaServiceTSE extends SparkConnectorScalaBaseTSE {
         (p3:Person {age: 25, location: point({latitude: 12.12, longitude: 31.13})})
     """
     )
-    val options = Map(QueryType.LABELS.toString -> "Person")
+    val options = Map(QueryType.LABELS.toString.toLowerCase -> "Person")
     val schema = getSchema(options)
 
     assertEquals(
@@ -209,8 +209,8 @@ class SchemaServiceTSE extends SparkConnectorScalaBaseTSE {
   }
 
   private def getSchema(options: Map[String, String]): StructType = {
-    val urlMapping = Neo4jOptions.URL -> SparkConnectorScalaSuiteIT.server.getBoltUrl
-    val neo4jOptions: Neo4jOptions = new Neo4jOptions(options + urlMapping)
+    val neo4jOptions: Neo4jOptions =
+      new Neo4jOptions(options + (Neo4jOptions.URL -> SparkConnectorScalaSuiteIT.server.getBoltUrl))
 
     val driverCache = new DriverCache(neo4jOptions.connection)
     val schemaService: SchemaService = new SchemaService(neo4j, neo4jOptions, driverCache)

--- a/src/test/scala/org/neo4j/spark/service/SchemaServiceTest.scala
+++ b/src/test/scala/org/neo4j/spark/service/SchemaServiceTest.scala
@@ -30,20 +30,18 @@ import org.neo4j.spark.util.Neo4jOptions
 
 import java.util.Collections
 
-import scala.jdk.CollectionConverters.MapHasAsJava
-
 class SchemaServiceTest {
 
   @Test
   def does_not_overflow_when_partition_size_is_over_max_value_of_32bit_integers(): Unit = {
     // note: _ cannot be used to separate digit groups, as this requires Scala 2.13+
-    val opts = options(
+    val options = new Neo4jOptions(Map(
       "url" -> "bolt://example.com",
       "partitions" -> 2.toString,
       "query.count" -> (2L * 2147483648L).toString, // 2 * (Integer.MAX_VALUE + 1)
       "query" -> "MERGE (:Node)"
-    )
-    val schemaService = new SchemaService(neo4j(), opts, mock(classOf[DriverCache], RETURNS_DEEP_STUBS))
+    ))
+    val schemaService = new SchemaService(neo4j(), options, mock(classOf[DriverCache], RETURNS_DEEP_STUBS))
 
     val pages = schemaService.skipLimitFromPartition(Some(TopN(1024)))
 
@@ -51,12 +49,6 @@ class SchemaServiceTest {
     assertEquals(List(0, 2147483648L), pages.map(_.skip).toList)
     assertEquals(List(2147483648L, 2147483648L), pages.map(_.topN.limit).toList)
     assertEquals(List(0, 0), pages.map(_.topN.orders.size).toList)
-  }
-
-  private def options(kv: (String, String)*): Neo4jOptions = {
-    new Neo4jOptions(
-      kv.toMap.asJava
-    )
   }
 
   private def neo4j(): Neo4j = {

--- a/src/test/scala/org/neo4j/spark/service/SchemaServiceWithApocTSE.scala
+++ b/src/test/scala/org/neo4j/spark/service/SchemaServiceWithApocTSE.scala
@@ -52,7 +52,7 @@ class SchemaServiceWithApocTSE extends SparkConnectorScalaBaseWithApocTSE {
   @Test
   def testGetSchemaFromNodeBoolean(): Unit = {
     initTest("CREATE (p:Person {is_hero: true})")
-    val options = Map(QueryType.LABELS.toString -> "Person")
+    val options = Map(QueryType.LABELS.toString.toLowerCase -> "Person")
     val schema = getSchema(options)
 
     assertEquals(getExpectedStructType(Seq(StructField("is_hero", DataTypes.BooleanType))), schema)
@@ -61,7 +61,7 @@ class SchemaServiceWithApocTSE extends SparkConnectorScalaBaseWithApocTSE {
   @Test
   def testGetSchemaFromNodeString(): Unit = {
     initTest("CREATE (p:Person {name: 'John'})")
-    val options = Map(QueryType.LABELS.toString -> "Person")
+    val options = Map(QueryType.LABELS.toString.toLowerCase -> "Person")
     val schema = getSchema(options)
 
     assertEquals(getExpectedStructType(Seq(StructField("name", DataTypes.StringType))), schema)
@@ -70,7 +70,7 @@ class SchemaServiceWithApocTSE extends SparkConnectorScalaBaseWithApocTSE {
   @Test
   def testGetSchemaFromNodeLong(): Unit = {
     initTest("CREATE (p:Person {age: 93})")
-    val options = Map(QueryType.LABELS.toString -> "Person")
+    val options = Map(QueryType.LABELS.toString.toLowerCase -> "Person")
     val schema = getSchema(options)
 
     assertEquals(getExpectedStructType(Seq(StructField("age", DataTypes.LongType))), schema)
@@ -79,7 +79,7 @@ class SchemaServiceWithApocTSE extends SparkConnectorScalaBaseWithApocTSE {
   @Test
   def testGetSchemaFromNodeDouble(): Unit = {
     initTest("CREATE (p:Person {ratio: 43.120})")
-    val options = Map(QueryType.LABELS.toString -> "Person")
+    val options = Map(QueryType.LABELS.toString.toLowerCase -> "Person")
     val schema = getSchema(options)
 
     assertEquals(getExpectedStructType(Seq(StructField("ratio", DataTypes.DoubleType))), schema)
@@ -88,7 +88,7 @@ class SchemaServiceWithApocTSE extends SparkConnectorScalaBaseWithApocTSE {
   @Test
   def testGetSchemaFromNodePoint2D(): Unit = {
     initTest("CREATE (p:Person {location: point({x: 12.32, y: 49.32})})")
-    val options = Map(QueryType.LABELS.toString -> "Person")
+    val options = Map(QueryType.LABELS.toString.toLowerCase -> "Person")
     val schema = getSchema(options)
 
     assertEquals(getExpectedStructType(Seq(StructField("location", CypherToSparkTypeConverter.pointType))), schema)
@@ -97,7 +97,7 @@ class SchemaServiceWithApocTSE extends SparkConnectorScalaBaseWithApocTSE {
   @Test
   def testGetSchemaFromDate(): Unit = {
     initTest("CREATE (p:Person {born_on: date('1998-01-05')})")
-    val options = Map(QueryType.LABELS.toString -> "Person")
+    val options = Map(QueryType.LABELS.toString.toLowerCase -> "Person")
     val schema = getSchema(options)
 
     assertEquals(getExpectedStructType(Seq(StructField("born_on", DataTypes.DateType))), schema)
@@ -106,7 +106,7 @@ class SchemaServiceWithApocTSE extends SparkConnectorScalaBaseWithApocTSE {
   @Test
   def testGetSchemaFromDateTime(): Unit = {
     initTest("CREATE (p:Person {arrived_at: datetime('1998-01-05')})")
-    val options = Map(QueryType.LABELS.toString -> "Person")
+    val options = Map(QueryType.LABELS.toString.toLowerCase -> "Person")
     val schema = getSchema(options)
 
     assertEquals(getExpectedStructType(Seq(StructField("arrived_at", DataTypes.TimestampType))), schema)
@@ -115,7 +115,7 @@ class SchemaServiceWithApocTSE extends SparkConnectorScalaBaseWithApocTSE {
   @Test
   def testGetSchemaFromTime(): Unit = {
     initTest("CREATE (p:Person {arrived_at: time('125035.556+0100')})")
-    val options = Map(QueryType.LABELS.toString -> "Person")
+    val options = Map(QueryType.LABELS.toString.toLowerCase -> "Person")
     val schema = getSchema(options)
 
     assertEquals(getExpectedStructType(Seq(StructField("arrived_at", CypherToSparkTypeConverter.timeType))), schema)
@@ -124,7 +124,7 @@ class SchemaServiceWithApocTSE extends SparkConnectorScalaBaseWithApocTSE {
   @Test
   def testGetSchemaFromStringArray(): Unit = {
     initTest("CREATE (p:Person {names: ['John', 'Doe']})")
-    val options = Map(QueryType.LABELS.toString -> "Person")
+    val options = Map(QueryType.LABELS.toString.toLowerCase -> "Person")
     val schema = getSchema(options)
 
     assertEquals(
@@ -136,7 +136,7 @@ class SchemaServiceWithApocTSE extends SparkConnectorScalaBaseWithApocTSE {
   @Test
   def testGetSchemaFromDateArray(): Unit = {
     initTest("CREATE (p:Person {names: [date('2019-11-19'), date('2019-11-20')]})")
-    val options = Map(QueryType.LABELS.toString -> "Person")
+    val options = Map(QueryType.LABELS.toString.toLowerCase -> "Person")
     val schema = getSchema(options)
 
     assertEquals(
@@ -148,7 +148,7 @@ class SchemaServiceWithApocTSE extends SparkConnectorScalaBaseWithApocTSE {
   @Test
   def testGetSchemaFromTimestampArray(): Unit = {
     initTest("CREATE (p:Person {dates: [datetime('2019-11-19'), datetime('2019-11-20')]})")
-    val options = Map(QueryType.LABELS.toString -> "Person")
+    val options = Map(QueryType.LABELS.toString.toLowerCase -> "Person")
     val schema = getSchema(options)
 
     assertEquals(
@@ -160,7 +160,7 @@ class SchemaServiceWithApocTSE extends SparkConnectorScalaBaseWithApocTSE {
   @Test
   def testGetSchemaFromTimeArray(): Unit = {
     initTest("CREATE (p:Person {dates: [time('125035.556+0100'), time('125125.556+0100')]})")
-    val options = Map(QueryType.LABELS.toString -> "Person")
+    val options = Map(QueryType.LABELS.toString.toLowerCase -> "Person")
     val schema = getSchema(options)
 
     assertEquals(
@@ -172,7 +172,7 @@ class SchemaServiceWithApocTSE extends SparkConnectorScalaBaseWithApocTSE {
   @Test
   def testGetSchemaFromIntegerArray(): Unit = {
     initTest("CREATE (p:Person {ages: [42, 101]})")
-    val options = Map(QueryType.LABELS.toString -> "Person")
+    val options = Map(QueryType.LABELS.toString.toLowerCase -> "Person")
     val schema = getSchema(options)
 
     assertEquals(getExpectedStructType(Seq(StructField("ages", DataTypes.createArrayType(DataTypes.LongType)))), schema)
@@ -187,7 +187,7 @@ class SchemaServiceWithApocTSE extends SparkConnectorScalaBaseWithApocTSE {
         (p3:Person {age: 25, location: point({latitude: 12.12, longitude: 31.13})})
     """
     )
-    val options = Map(QueryType.LABELS.toString -> "Person")
+    val options = Map(QueryType.LABELS.toString.toLowerCase -> "Person")
     val schema = getSchema(options)
 
     assertEquals(

--- a/src/test/scala/org/neo4j/spark/service/SchemaServiceWithApocTSE.scala
+++ b/src/test/scala/org/neo4j/spark/service/SchemaServiceWithApocTSE.scala
@@ -214,8 +214,8 @@ class SchemaServiceWithApocTSE extends SparkConnectorScalaBaseWithApocTSE {
   }
 
   private def getSchema(options: Map[String, String]): StructType = {
-    val urlMapping = Neo4jOptions.URL -> SparkConnectorScalaSuiteWithApocIT.server.getBoltUrl
-    val neo4jOptions: Neo4jOptions = new Neo4jOptions(options + urlMapping)
+    val neo4jOptions: Neo4jOptions =
+      new Neo4jOptions(options + (Neo4jOptions.URL -> SparkConnectorScalaSuiteWithApocIT.server.getBoltUrl))
 
     val driverCache = new DriverCache(neo4jOptions.connection)
     val neo4j = new Neo4j(

--- a/src/test/scala/org/neo4j/spark/service/SchemaServiceWithApocTSE.scala
+++ b/src/test/scala/org/neo4j/spark/service/SchemaServiceWithApocTSE.scala
@@ -21,9 +21,7 @@ import org.apache.spark.sql.types.StructField
 import org.apache.spark.sql.types.StructType
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.BeforeEach
-import org.junit.jupiter.api.MethodOrderer
 import org.junit.jupiter.api.Test
-import org.junit.jupiter.api.TestMethodOrder
 import org.neo4j.caniuse.Neo4j
 import org.neo4j.caniuse.Neo4jDeploymentType
 import org.neo4j.caniuse.Neo4jEdition
@@ -38,7 +36,6 @@ import org.neo4j.spark.util.Neo4jOptions
 import org.neo4j.spark.util.Neo4jUtil
 import org.neo4j.spark.util.QueryType
 
-import java.util
 import java.util.Collections
 
 class SchemaServiceWithApocTSE extends SparkConnectorScalaBaseWithApocTSE {
@@ -55,9 +52,7 @@ class SchemaServiceWithApocTSE extends SparkConnectorScalaBaseWithApocTSE {
   @Test
   def testGetSchemaFromNodeBoolean(): Unit = {
     initTest("CREATE (p:Person {is_hero: true})")
-    val options: java.util.Map[String, String] = new util.HashMap[String, String]()
-    options.put(QueryType.LABELS.toString.toLowerCase, "Person")
-
+    val options = Map(QueryType.LABELS.toString -> "Person")
     val schema = getSchema(options)
 
     assertEquals(getExpectedStructType(Seq(StructField("is_hero", DataTypes.BooleanType))), schema)
@@ -66,9 +61,7 @@ class SchemaServiceWithApocTSE extends SparkConnectorScalaBaseWithApocTSE {
   @Test
   def testGetSchemaFromNodeString(): Unit = {
     initTest("CREATE (p:Person {name: 'John'})")
-    val options: java.util.Map[String, String] = new util.HashMap[String, String]()
-    options.put(QueryType.LABELS.toString.toLowerCase, "Person")
-
+    val options = Map(QueryType.LABELS.toString -> "Person")
     val schema = getSchema(options)
 
     assertEquals(getExpectedStructType(Seq(StructField("name", DataTypes.StringType))), schema)
@@ -77,9 +70,7 @@ class SchemaServiceWithApocTSE extends SparkConnectorScalaBaseWithApocTSE {
   @Test
   def testGetSchemaFromNodeLong(): Unit = {
     initTest("CREATE (p:Person {age: 93})")
-    val options: java.util.Map[String, String] = new util.HashMap[String, String]()
-    options.put(QueryType.LABELS.toString.toLowerCase, "Person")
-
+    val options = Map(QueryType.LABELS.toString -> "Person")
     val schema = getSchema(options)
 
     assertEquals(getExpectedStructType(Seq(StructField("age", DataTypes.LongType))), schema)
@@ -88,9 +79,7 @@ class SchemaServiceWithApocTSE extends SparkConnectorScalaBaseWithApocTSE {
   @Test
   def testGetSchemaFromNodeDouble(): Unit = {
     initTest("CREATE (p:Person {ratio: 43.120})")
-    val options: java.util.Map[String, String] = new util.HashMap[String, String]()
-    options.put(QueryType.LABELS.toString.toLowerCase, "Person")
-
+    val options = Map(QueryType.LABELS.toString -> "Person")
     val schema = getSchema(options)
 
     assertEquals(getExpectedStructType(Seq(StructField("ratio", DataTypes.DoubleType))), schema)
@@ -99,9 +88,7 @@ class SchemaServiceWithApocTSE extends SparkConnectorScalaBaseWithApocTSE {
   @Test
   def testGetSchemaFromNodePoint2D(): Unit = {
     initTest("CREATE (p:Person {location: point({x: 12.32, y: 49.32})})")
-    val options: java.util.Map[String, String] = new util.HashMap[String, String]()
-    options.put(QueryType.LABELS.toString.toLowerCase, "Person")
-
+    val options = Map(QueryType.LABELS.toString -> "Person")
     val schema = getSchema(options)
 
     assertEquals(getExpectedStructType(Seq(StructField("location", CypherToSparkTypeConverter.pointType))), schema)
@@ -110,9 +97,7 @@ class SchemaServiceWithApocTSE extends SparkConnectorScalaBaseWithApocTSE {
   @Test
   def testGetSchemaFromDate(): Unit = {
     initTest("CREATE (p:Person {born_on: date('1998-01-05')})")
-    val options: java.util.Map[String, String] = new util.HashMap[String, String]()
-    options.put(QueryType.LABELS.toString.toLowerCase, "Person")
-
+    val options = Map(QueryType.LABELS.toString -> "Person")
     val schema = getSchema(options)
 
     assertEquals(getExpectedStructType(Seq(StructField("born_on", DataTypes.DateType))), schema)
@@ -121,9 +106,7 @@ class SchemaServiceWithApocTSE extends SparkConnectorScalaBaseWithApocTSE {
   @Test
   def testGetSchemaFromDateTime(): Unit = {
     initTest("CREATE (p:Person {arrived_at: datetime('1998-01-05')})")
-    val options: java.util.Map[String, String] = new util.HashMap[String, String]()
-    options.put(QueryType.LABELS.toString.toLowerCase, "Person")
-
+    val options = Map(QueryType.LABELS.toString -> "Person")
     val schema = getSchema(options)
 
     assertEquals(getExpectedStructType(Seq(StructField("arrived_at", DataTypes.TimestampType))), schema)
@@ -132,9 +115,7 @@ class SchemaServiceWithApocTSE extends SparkConnectorScalaBaseWithApocTSE {
   @Test
   def testGetSchemaFromTime(): Unit = {
     initTest("CREATE (p:Person {arrived_at: time('125035.556+0100')})")
-    val options: java.util.Map[String, String] = new util.HashMap[String, String]()
-    options.put(QueryType.LABELS.toString.toLowerCase, "Person")
-
+    val options = Map(QueryType.LABELS.toString -> "Person")
     val schema = getSchema(options)
 
     assertEquals(getExpectedStructType(Seq(StructField("arrived_at", CypherToSparkTypeConverter.timeType))), schema)
@@ -143,9 +124,7 @@ class SchemaServiceWithApocTSE extends SparkConnectorScalaBaseWithApocTSE {
   @Test
   def testGetSchemaFromStringArray(): Unit = {
     initTest("CREATE (p:Person {names: ['John', 'Doe']})")
-    val options: java.util.Map[String, String] = new util.HashMap[String, String]()
-    options.put(QueryType.LABELS.toString.toLowerCase, "Person")
-
+    val options = Map(QueryType.LABELS.toString -> "Person")
     val schema = getSchema(options)
 
     assertEquals(
@@ -157,9 +136,7 @@ class SchemaServiceWithApocTSE extends SparkConnectorScalaBaseWithApocTSE {
   @Test
   def testGetSchemaFromDateArray(): Unit = {
     initTest("CREATE (p:Person {names: [date('2019-11-19'), date('2019-11-20')]})")
-    val options: java.util.Map[String, String] = new util.HashMap[String, String]()
-    options.put(QueryType.LABELS.toString.toLowerCase, "Person")
-
+    val options = Map(QueryType.LABELS.toString -> "Person")
     val schema = getSchema(options)
 
     assertEquals(
@@ -171,9 +148,7 @@ class SchemaServiceWithApocTSE extends SparkConnectorScalaBaseWithApocTSE {
   @Test
   def testGetSchemaFromTimestampArray(): Unit = {
     initTest("CREATE (p:Person {dates: [datetime('2019-11-19'), datetime('2019-11-20')]})")
-    val options: java.util.Map[String, String] = new util.HashMap[String, String]()
-    options.put(QueryType.LABELS.toString.toLowerCase, "Person")
-
+    val options = Map(QueryType.LABELS.toString -> "Person")
     val schema = getSchema(options)
 
     assertEquals(
@@ -185,9 +160,7 @@ class SchemaServiceWithApocTSE extends SparkConnectorScalaBaseWithApocTSE {
   @Test
   def testGetSchemaFromTimeArray(): Unit = {
     initTest("CREATE (p:Person {dates: [time('125035.556+0100'), time('125125.556+0100')]})")
-    val options: java.util.Map[String, String] = new util.HashMap[String, String]()
-    options.put(QueryType.LABELS.toString.toLowerCase, "Person")
-
+    val options = Map(QueryType.LABELS.toString -> "Person")
     val schema = getSchema(options)
 
     assertEquals(
@@ -199,9 +172,7 @@ class SchemaServiceWithApocTSE extends SparkConnectorScalaBaseWithApocTSE {
   @Test
   def testGetSchemaFromIntegerArray(): Unit = {
     initTest("CREATE (p:Person {ages: [42, 101]})")
-    val options: java.util.Map[String, String] = new util.HashMap[String, String]()
-    options.put(QueryType.LABELS.toString.toLowerCase, "Person")
-
+    val options = Map(QueryType.LABELS.toString -> "Person")
     val schema = getSchema(options)
 
     assertEquals(getExpectedStructType(Seq(StructField("ages", DataTypes.createArrayType(DataTypes.LongType)))), schema)
@@ -216,10 +187,7 @@ class SchemaServiceWithApocTSE extends SparkConnectorScalaBaseWithApocTSE {
         (p3:Person {age: 25, location: point({latitude: 12.12, longitude: 31.13})})
     """
     )
-
-    val options: java.util.Map[String, String] = new util.HashMap[String, String]()
-    options.put(QueryType.LABELS.toString.toLowerCase, "Person")
-
+    val options = Map(QueryType.LABELS.toString -> "Person")
     val schema = getSchema(options)
 
     assertEquals(
@@ -245,9 +213,9 @@ class SchemaServiceWithApocTSE extends SparkConnectorScalaBaseWithApocTSE {
       .executeWrite((tx: TransactionContext) => tx.run(query).consume())
   }
 
-  private def getSchema(options: java.util.Map[String, String]): StructType = {
-    options.put(Neo4jOptions.URL, SparkConnectorScalaSuiteWithApocIT.server.getBoltUrl)
-    val neo4jOptions: Neo4jOptions = new Neo4jOptions(options)
+  private def getSchema(options: Map[String, String]): StructType = {
+    val urlMapping = Neo4jOptions.URL -> SparkConnectorScalaSuiteWithApocIT.server.getBoltUrl
+    val neo4jOptions: Neo4jOptions = new Neo4jOptions(options + urlMapping)
 
     val driverCache = new DriverCache(neo4jOptions.connection)
     val neo4j = new Neo4j(

--- a/src/test/scala/org/neo4j/spark/util/Neo4jOptionsIT.scala
+++ b/src/test/scala/org/neo4j/spark/util/Neo4jOptionsIT.scala
@@ -17,7 +17,6 @@
 package org.neo4j.spark.util
 
 import org.assertj.core.api.Assertions.assertThat
-import org.junit.jupiter.api.Assertions._
 import org.junit.jupiter.api.Disabled
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.util.ClearSystemProperty
@@ -26,20 +25,19 @@ import org.neo4j.spark.testsupport.Closeables.use
 import org.neo4j.spark.testsupport.SparkConnectorScalaSuiteIT
 import org.neo4j.spark.testsupport.SparkConnectorScalaSuiteIT.server
 
+import scala.jdk.CollectionConverters.MapHasAsScala
+
 class Neo4jOptionsIT extends SparkConnectorScalaSuiteIT {
 
   @Test
   @ClearSystemProperty(key = "strict.cypher")
   def creates_regular_driver(): Unit = {
-    val options: java.util.Map[String, String] = new java.util.HashMap[String, String]()
-    options.put(Neo4jOptions.URL, server.getBoltUrl)
-    options.put(Neo4jOptions.AUTH_TYPE, "none")
-
+    val options = Map(Neo4jOptions.URL -> server.getBoltUrl, Neo4jOptions.AUTH_TYPE -> "none")
     val neo4jOptions = new Neo4jOptions(options)
 
     use(neo4jOptions.connection.createDriver()) { driver =>
       assertThat(driver)
-        .isNotNull()
+        .isNotNull
         .isNotInstanceOf(classOf[StrictDriver])
       use(driver.session()) { session =>
         assertThat(session.run("RETURN 1").single().get(0).asInt()).isEqualTo(1)
@@ -50,10 +48,7 @@ class Neo4jOptionsIT extends SparkConnectorScalaSuiteIT {
   @Test
   @SetSystemProperty(key = "strict.cypher", value = "true")
   def creates_strict_driver(): Unit = {
-    val options: java.util.Map[String, String] = new java.util.HashMap[String, String]()
-    options.put(Neo4jOptions.URL, server.getBoltUrl)
-    options.put(Neo4jOptions.AUTH_TYPE, "none")
-
+    val options = Map(Neo4jOptions.URL -> server.getBoltUrl, Neo4jOptions.AUTH_TYPE -> "none")
     val neo4jOptions = new Neo4jOptions(options)
 
     use(neo4jOptions.connection.createDriver()) { driver =>
@@ -71,7 +66,7 @@ class Neo4jOptionsIT extends SparkConnectorScalaSuiteIT {
     )
     options.put(Neo4jOptions.AUTH_TYPE, "none")
 
-    val neo4jOptions = new Neo4jOptions(options)
+    val neo4jOptions = new Neo4jOptions(options.asScala.toMap)
 
     use(neo4jOptions.connection.createDriver()) { driver =>
       assertThat(driver).isNotNull()

--- a/src/test/scala/org/neo4j/spark/util/Neo4jOptionsTest.scala
+++ b/src/test/scala/org/neo4j/spark/util/Neo4jOptionsTest.scala
@@ -17,9 +17,7 @@
 package org.neo4j.spark.util
 
 import org.assertj.core.api.Assertions.assertThat
-import org.assertj.core.api.Assertions.assertThatCode
 import org.assertj.core.api.Assertions.assertThatExceptionOfType
-import org.assertj.core.api.Assertions.assertThatThrownBy
 import org.junit.jupiter.api.Test
 import org.neo4j.driver.AccessMode
 import org.neo4j.driver.Value
@@ -36,8 +34,7 @@ class Neo4jOptionsTest {
 
   @Test
   def requires_url(): Unit = {
-    val options = new java.util.HashMap[String, String]()
-    options.put(QueryType.QUERY.toString.toLowerCase, "Person")
+    val options = Map(QueryType.QUERY.toString -> "Person")
 
     assertThatExceptionOfType(classOf[IllegalArgumentException])
       .isThrownBy(() => new Neo4jOptions(options)).withMessage("Parameter 'url' is required")
@@ -45,38 +42,35 @@ class Neo4jOptionsTest {
 
   @Test
   def supports_relationship_table_name(): Unit = {
-    val options = new java.util.HashMap[String, String]()
-    options.put(Neo4jOptions.URL, "bolt://localhost")
-    options.put(QueryType.RELATIONSHIP.toString.toLowerCase, "KNOWS")
-    options.put(Neo4jOptions.RELATIONSHIP_SOURCE_LABELS, "Person")
-    options.put(Neo4jOptions.RELATIONSHIP_TARGET_LABELS, "Answer")
-
-    val neo4jOptions = new Neo4jOptions(options)
+    val neo4jOptions = new Neo4jOptions(Map(
+      Neo4jOptions.URL -> "bolt://localhost",
+      QueryType.RELATIONSHIP.toString.toLowerCase -> "KNOWS",
+      Neo4jOptions.RELATIONSHIP_SOURCE_LABELS -> "Person",
+      Neo4jOptions.RELATIONSHIP_TARGET_LABELS -> "Answer"
+    ))
 
     assertThat(neo4jOptions.getTableName).isEqualTo("table_Person_KNOWS_Answer")
   }
 
   @Test
   def supports_labels_table_name(): Unit = {
-    val options = new java.util.HashMap[String, String]()
-    options.put(Neo4jOptions.URL, "bolt://localhost")
-    options.put("labels", "Person:Admin")
-
-    val neo4jOptions = new Neo4jOptions(options)
+    val neo4jOptions = new Neo4jOptions(Map(
+      Neo4jOptions.URL -> "bolt://localhost",
+      "labels" -> "Person:Admin"
+    ))
 
     assertThat(neo4jOptions.getTableName).isEqualTo("table_Person-Admin")
   }
 
   @Test
   def supports_relationship_node_modes_are_case_insensitive(): Unit = {
-    val options = new java.util.HashMap[String, String]()
-    options.put(Neo4jOptions.URL, "bolt://localhost")
-    options.put(QueryType.RELATIONSHIP.toString.toLowerCase, "KNOWS")
-    options.put(Neo4jOptions.RELATIONSHIP_SAVE_STRATEGY, "nAtIve")
-    options.put(Neo4jOptions.RELATIONSHIP_SOURCE_SAVE_MODE, "Errorifexists")
-    options.put(Neo4jOptions.RELATIONSHIP_TARGET_SAVE_MODE, "overwrite")
-
-    val neo4jOptions = new Neo4jOptions(options)
+    val neo4jOptions = new Neo4jOptions(Map(
+      Neo4jOptions.URL -> "bolt://localhost",
+      QueryType.RELATIONSHIP.toString.toLowerCase -> "KNOWS",
+      Neo4jOptions.RELATIONSHIP_SAVE_STRATEGY -> "nAtIve",
+      Neo4jOptions.RELATIONSHIP_SOURCE_SAVE_MODE -> "Errorifexists",
+      Neo4jOptions.RELATIONSHIP_TARGET_SAVE_MODE -> "overwrite"
+    ))
 
     assertThat(neo4jOptions.relationshipMetadata.saveStrategy).isEqualTo(RelationshipSaveStrategy.NATIVE)
     assertThat(neo4jOptions.relationshipMetadata.sourceSaveMode).isEqualTo(NodeSaveMode.ErrorIfExists)
@@ -85,10 +79,11 @@ class Neo4jOptionsTest {
 
   @Test
   def supports_relationship_write_strategy_is_not_present_should_throw_exception(): Unit = {
-    val options = new java.util.HashMap[String, String]()
-    options.put(Neo4jOptions.URL, "bolt://localhost")
-    options.put(QueryType.LABELS.toString.toLowerCase, "PERSON")
-    options.put("relationship.save.strategy", "nope")
+    val options = Map(
+      Neo4jOptions.URL -> "bolt://localhost",
+      QueryType.LABELS.toString -> "PERSON",
+      "relationship.save.strategy" -> "nope"
+    )
 
     assertThatExceptionOfType(classOf[NoSuchElementException])
       .isThrownBy(() => new Neo4jOptions(options))
@@ -98,11 +93,10 @@ class Neo4jOptionsTest {
   @Test
   def supports_query_should_have_query_type(): Unit = {
     val query: String = "MATCH n RETURN n"
-    val options = new java.util.HashMap[String, String]()
-    options.put(Neo4jOptions.URL, "bolt://localhost")
-    options.put(QueryType.QUERY.toString.toLowerCase, query)
-
-    val neo4jOptions = new Neo4jOptions(options)
+    val neo4jOptions = new Neo4jOptions(Map(
+      Neo4jOptions.URL -> "bolt://localhost",
+      QueryType.QUERY.toString.toLowerCase -> query
+    ))
 
     assertThat(neo4jOptions.query.queryType).isEqualTo(QueryType.QUERY)
     assertThat(neo4jOptions.query.value).isEqualTo(query)
@@ -111,11 +105,10 @@ class Neo4jOptionsTest {
   @Test
   def supports_node_should_have_label_type(): Unit = {
     val label: String = "Person"
-    val options = new java.util.HashMap[String, String]()
-    options.put(Neo4jOptions.URL, "bolt://localhost")
-    options.put(QueryType.LABELS.toString.toLowerCase, label)
-
-    val neo4jOptions = new Neo4jOptions(options)
+    val neo4jOptions = new Neo4jOptions(Map(
+      Neo4jOptions.URL -> "bolt://localhost",
+      QueryType.LABELS.toString.toLowerCase -> label
+    ))
 
     assertThat(neo4jOptions.query.queryType).isEqualTo(QueryType.LABELS)
     assertThat(neo4jOptions.query.value).isEqualTo(label)
@@ -124,11 +117,10 @@ class Neo4jOptionsTest {
   @Test
   def supports_relationship_should_have_relationship_type(): Unit = {
     val relationship: String = "KNOWS"
-    val options = new java.util.HashMap[String, String]()
-    options.put(Neo4jOptions.URL, "bolt://localhost")
-    options.put(QueryType.LABELS.toString.toLowerCase, relationship)
-
-    val neo4jOptions = new Neo4jOptions(options)
+    val neo4jOptions = new Neo4jOptions(Map(
+      Neo4jOptions.URL -> "bolt://localhost",
+      QueryType.LABELS.toString.toLowerCase -> relationship
+    ))
 
     assertThat(neo4jOptions.query.queryType).isEqualTo(QueryType.LABELS)
     assertThat(neo4jOptions.query.value).isEqualTo(relationship)
@@ -136,22 +128,20 @@ class Neo4jOptionsTest {
 
   @Test
   def supports_push_down_column_is_disabled(): Unit = {
-    val options = new java.util.HashMap[String, String]()
-    options.put(Neo4jOptions.URL, "bolt://localhost")
-    options.put("pushdown.columns.enabled", "false")
-
-    val neo4jOptions = new Neo4jOptions(options)
+    val neo4jOptions = new Neo4jOptions(Map(
+      Neo4jOptions.URL -> "bolt://localhost",
+      "pushdown.columns.enabled" -> "false"
+    ))
 
     assertThat(neo4jOptions.pushdownColumnsEnabled).isFalse
   }
 
   @Test
   def supports_driver_defaults(): Unit = {
-    val options = new java.util.HashMap[String, String]()
-    options.put(Neo4jOptions.URL, "bolt://localhost")
-    options.put(QueryType.QUERY.toString.toLowerCase, "MATCH n RETURN n")
-
-    val neo4jOptions = new Neo4jOptions(options)
+    val neo4jOptions = new Neo4jOptions(Map(
+      Neo4jOptions.URL -> "bolt://localhost",
+      QueryType.QUERY.toString.toLowerCase -> "MATCH n RETURN n"
+    ))
 
     assertThat(neo4jOptions.session.database).isEqualTo("")
     assertThat(neo4jOptions.session.accessMode).isEqualTo(AccessMode.READ)
@@ -172,11 +162,10 @@ class Neo4jOptionsTest {
 
   @Test
   def supports_apoc_configuration(): Unit = {
-    val options = new java.util.HashMap[String, String]()
-    options.put("apoc.meta.nodeTypeProperties", """{"nodeLabels": ["Label"], "mandatory": false}""")
-    options.put(Neo4jOptions.URL, "bolt://localhost")
-
-    val neo4jOptions = new Neo4jOptions(options)
+    val neo4jOptions = new Neo4jOptions(Map(
+      "apoc.meta.nodeTypeProperties" -> """{"nodeLabels": ["Label"], "mandatory": false}""",
+      Neo4jOptions.URL -> "bolt://localhost"
+    ))
 
     val expected = Map("apoc.meta.nodeTypeProperties" -> Map(
       "nodeLabels" -> Seq("Label").asJava,
@@ -188,21 +177,20 @@ class Neo4jOptionsTest {
 
   @Test
   def supports_null_property(): Unit = {
-    val options = new java.util.HashMap[String, String]()
-    options.put("relationship.properties", null)
-    options.put(Neo4jOptions.URL, "bolt://localhost")
-
-    val neo4jOptions = new Neo4jOptions(options)
+    val neo4jOptions = new Neo4jOptions(Map(
+      "relationship.properties" -> null,
+      Neo4jOptions.URL -> "bolt://localhost"
+    ))
 
     assertThat(None).isEqualTo(neo4jOptions.relationshipMetadata.properties)
   }
 
   @Test
   def supports_multiple_urls(): Unit = {
-    val options = new java.util.HashMap[String, String]()
-    options.put(Neo4jOptions.URL, "neo4j://localhost, neo4j://foo.bar:7687, neo4j://foo.bar.baz:7783")
+    val neo4jOptions = new Neo4jOptions(Map(
+      Neo4jOptions.URL -> "neo4j://localhost, neo4j://foo.bar:7687, neo4j://foo.bar.baz:7783"
+    ))
 
-    val neo4jOptions = new Neo4jOptions(options)
     val (baseUrl, resolvers) = neo4jOptions.connection.connectionUrls
 
     assertThat(baseUrl).isEqualTo(URI.create("neo4j://localhost"))
@@ -211,13 +199,12 @@ class Neo4jOptionsTest {
 
   @Test
   def supports_gds_properties(): Unit = {
-    val options = new java.util.HashMap[String, String]()
-    options.put(Neo4jOptions.URL, "neo4j://localhost,neo4j://foo.bar,neo4j://foo.bar.baz:7783")
-    options.put("gds", "gds.pageRank.stream")
-    options.put("gds.graphName", "myGraph")
-    options.put("gds.configuration.concurrency", "2")
-
-    val neo4jOptions = new Neo4jOptions(options)
+    val neo4jOptions = new Neo4jOptions(Map(
+      Neo4jOptions.URL -> "neo4j://localhost,neo4j://foo.bar,neo4j://foo.bar.baz:7783",
+      "gds" -> "gds.pageRank.stream",
+      "gds.graphName" -> "myGraph",
+      "gds.configuration.concurrency" -> "2"
+    ))
 
     assertThat(neo4jOptions.query.queryType).isEqualTo(QueryType.GDS)
     assertThat(neo4jOptions.query.value).isEqualTo("gds.pageRank.stream")
@@ -231,11 +218,10 @@ class Neo4jOptionsTest {
 
   @Test
   def supports_transaction_timeout(): Unit = {
-    val rawOptions = new java.util.HashMap[String, String]()
-    rawOptions.put(Neo4jOptions.URL, "neo4j://localhost,neo4j://foo.bar,neo4j://foo.bar.baz:7783")
-    rawOptions.put("db.transaction.timeout", "1000")
-
-    val neo4jOptions = new Neo4jOptions(rawOptions)
+    val neo4jOptions = new Neo4jOptions(Map(
+      Neo4jOptions.URL -> "neo4j://localhost,neo4j://foo.bar,neo4j://foo.bar.baz:7783",
+      "db.transaction.timeout" -> "1000"
+    ))
 
     val transactionConfig = neo4jOptions.toNeo4jTransactionConfig
     assertThat(transactionConfig.timeout()).isEqualTo(Duration.ofMillis(1000))
@@ -243,10 +229,9 @@ class Neo4jOptionsTest {
 
   @Test
   def supports_default_transaction_timeout(): Unit = {
-    val rawOptions = new java.util.HashMap[String, String]()
-    rawOptions.put(Neo4jOptions.URL, "neo4j://localhost,neo4j://foo.bar,neo4j://foo.bar.baz:7783")
-
-    val neo4jOptions = new Neo4jOptions(rawOptions)
+    val neo4jOptions = new Neo4jOptions(Map(
+      Neo4jOptions.URL -> "neo4j://localhost,neo4j://foo.bar,neo4j://foo.bar.baz:7783"
+    ))
 
     val transactionConfig = neo4jOptions.toNeo4jTransactionConfig
 
@@ -255,15 +240,15 @@ class Neo4jOptionsTest {
 
   @Test
   def supports_transaction_metadata(): Unit = {
-    val rawOptions = new java.util.HashMap[String, String]()
-    rawOptions.put(Neo4jOptions.URL, "neo4j://localhost,neo4j://foo.bar,neo4j://foo.bar.baz:7783")
-    rawOptions.put("db.transaction.metadata.foo", "bar")
-    rawOptions.put("db.transaction.metadata.bar", "true")
-    rawOptions.put("db.transaction.metadata.qix", "42")
-    rawOptions.put("db.transaction.metadata.my.thing", "23.0")
-    rawOptions.put("db.transaction.metadata.json_array_treated_as_string", "[true,43]")
-    rawOptions.put("db.transaction.metadata.json_map_treated_as_string", """{"map": false}""")
-    val neo4jOptions = new Neo4jOptions(rawOptions)
+    val neo4jOptions = new Neo4jOptions(Map(
+      Neo4jOptions.URL -> "neo4j://localhost,neo4j://foo.bar,neo4j://foo.bar.baz:7783",
+      "db.transaction.metadata.foo" -> "bar",
+      "db.transaction.metadata.bar" -> "true",
+      "db.transaction.metadata.qix" -> "42",
+      "db.transaction.metadata.my.thing" -> "23.0",
+      "db.transaction.metadata.json_array_treated_as_string" -> "[true,43]",
+      "db.transaction.metadata.json_map_treated_as_string" -> """{"map": false}"""
+    ))
 
     val transactionConfig = neo4jOptions.toNeo4jTransactionConfig
 

--- a/src/test/scala/org/neo4j/spark/util/StrictDriverTest.scala
+++ b/src/test/scala/org/neo4j/spark/util/StrictDriverTest.scala
@@ -114,11 +114,11 @@ class StrictDriverTest {
   }
 
   private def neo4jDriverOptions(port: Int): Neo4jDriverOptions = {
-    val options = new util.HashMap[String, String]
-    options.put(Neo4jOptions.URL, s"bolt://localhost:$port")
-    options.put(Neo4jOptions.AUTH_TYPE, "none")
-    options.put(org.neo4j.spark.util.QueryType.QUERY.toString.toLowerCase, "RETURN 1")
-    new Neo4jOptions(options).connection
+    new Neo4jOptions(Map(
+      Neo4jOptions.URL -> s"bolt://localhost:$port",
+      Neo4jOptions.AUTH_TYPE -> "none",
+      org.neo4j.spark.util.QueryType.QUERY.toString.toLowerCase -> "RETURN 1"
+    )).connection
   }
 }
 

--- a/src/test/scala/org/neo4j/spark/util/ValidationsIT.scala
+++ b/src/test/scala/org/neo4j/spark/util/ValidationsIT.scala
@@ -28,10 +28,11 @@ class ValidationsIT extends SparkConnectorScalaSuiteIT {
   @Test
   def testReadQueryShouldBeSyntacticallyInvalid(): Unit = {
     // given
-    val readOpts: java.util.Map[String, String] = new java.util.HashMap[String, String]()
     val query = "MATCH (f{) RETURN f"
-    readOpts.put(Neo4jOptions.URL, SparkConnectorScalaSuiteIT.server.getBoltUrl)
-    readOpts.put("query", query)
+    val readOpts = Map(
+      Neo4jOptions.URL -> SparkConnectorScalaSuiteIT.server.getBoltUrl,
+      "query" -> query
+    )
 
     // when & then
     val exception = assertThrows(
@@ -54,9 +55,10 @@ class ValidationsIT extends SparkConnectorScalaSuiteIT {
   def testReadQueryShouldBeSemanticallyInvalid(): Unit = {
     // given
     val query = "MERGE (n:TestNode{id: 1}) RETURN n"
-    val readOpts: java.util.Map[String, String] = new java.util.HashMap[String, String]()
-    readOpts.put(Neo4jOptions.URL, SparkConnectorScalaSuiteIT.server.getBoltUrl)
-    readOpts.put("query", query)
+    val readOpts = Map(
+      Neo4jOptions.URL -> SparkConnectorScalaSuiteIT.server.getBoltUrl,
+      "query" -> query
+    )
 
     // when & then
     val exception = assertThrows(
@@ -76,10 +78,11 @@ class ValidationsIT extends SparkConnectorScalaSuiteIT {
   def testReadQueryCountBeSyntacticallyInvalid(): Unit = {
     // given
     val query = "MATCH (f{) RETURN f"
-    val readOpts: java.util.Map[String, String] = new java.util.HashMap[String, String]()
-    readOpts.put(Neo4jOptions.URL, SparkConnectorScalaSuiteIT.server.getBoltUrl)
-    readOpts.put("query", "MATCH (f) RETURN f")
-    readOpts.put("query.count", query)
+    val readOpts = Map(
+      Neo4jOptions.URL -> SparkConnectorScalaSuiteIT.server.getBoltUrl,
+      "query" -> "MATCH (f) RETURN f",
+      "query.count" -> query
+    )
 
     // when & then
     val exception = assertThrows(
@@ -101,10 +104,11 @@ class ValidationsIT extends SparkConnectorScalaSuiteIT {
   @Test
   def testScriptQueryCountShouldContainAnInvalidQuery(): Unit = {
     // given
-    val readOpts: java.util.Map[String, String] = new java.util.HashMap[String, String]()
-    readOpts.put(Neo4jOptions.URL, SparkConnectorScalaSuiteIT.server.getBoltUrl)
-    readOpts.put("query", "MATCH (f) RETURN f")
-    readOpts.put("script", "RETURN 1 AS one; RETUR 2 AS two; RETURN 3 AS three")
+    val readOpts = Map(
+      Neo4jOptions.URL -> SparkConnectorScalaSuiteIT.server.getBoltUrl,
+      "query" -> "MATCH (f) RETURN f",
+      "script" -> "RETURN 1 AS one; RETUR 2 AS two; RETURN 3 AS three"
+    )
 
     // when & then
     val exception = assertThrows(
@@ -137,10 +141,11 @@ class ValidationsIT extends SparkConnectorScalaSuiteIT {
   def testWriteQueryShouldBeSyntacticallyInvalid(): Unit = {
     // given
     val query = "MERGE (f{) RETURN f"
-    val writeOpts: java.util.Map[String, String] = new java.util.HashMap[String, String]()
-    writeOpts.put(Neo4jOptions.URL, SparkConnectorScalaSuiteIT.server.getBoltUrl)
-    writeOpts.put(Neo4jOptions.ACCESS_MODE, AccessMode.WRITE.toString)
-    writeOpts.put("query", query)
+    val writeOpts = Map(
+      Neo4jOptions.URL -> SparkConnectorScalaSuiteIT.server.getBoltUrl,
+      Neo4jOptions.ACCESS_MODE -> AccessMode.WRITE.toString,
+      "query" -> query
+    )
 
     // when & then
     val exception = assertThrows(
@@ -163,10 +168,11 @@ class ValidationsIT extends SparkConnectorScalaSuiteIT {
   def testWriteQueryShouldBeSemanticallyInvalid(): Unit = {
     // given
     val query = "MATCH (n:TestNode{id: 1}) RETURN n"
-    val writeOpts: java.util.Map[String, String] = new java.util.HashMap[String, String]()
-    writeOpts.put(Neo4jOptions.URL, SparkConnectorScalaSuiteIT.server.getBoltUrl)
-    writeOpts.put(Neo4jOptions.ACCESS_MODE, AccessMode.WRITE.toString)
-    writeOpts.put("query", query)
+    val writeOpts = Map(
+      Neo4jOptions.URL -> SparkConnectorScalaSuiteIT.server.getBoltUrl,
+      Neo4jOptions.ACCESS_MODE -> AccessMode.WRITE.toString,
+      "query" -> query
+    )
 
     // when & then
     val exception = assertThrows(


### PR DESCRIPTION
Swaps from java.util.Map to Map in `Neo4jOptions`.

Reasoning that test cases should be easier to write with declarative
creating maps rather that procedurally creating maps.

The past way of doing it created lots of cases where we wrote Java-like
code in our Scala bits. Ultimately aesthetic refactor. However we do
see simpler test case setups imo