### PR TITLE
build: avoid native netty bindings in tests

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -440,7 +440,8 @@
                         </includes>
                         <forkCount>1</forkCount>
                         <reuseForks>false</reuseForks>
-                        <argLine>${test.jvm.args}</argLine>
+                        <!-- Avoid Netty 4.2 native transport which causes hangs in local tests. -->
+                        <argLine>${test.jvm.args} -Dio.netty.transport.noNative=true</argLine>
                         <useModulePath>false</useModulePath>
                     </configuration>
                     <executions>
@@ -499,7 +500,8 @@
                     <artifactId>maven-surefire-plugin</artifactId>
                     <version>${maven-surefire-plugin.version}</version>
                     <configuration>
-                        <argLine>${test.jvm.args}</argLine>
+                        <!-- Avoid Netty 4.2 native transport which causes hangs in local tests. -->
+                        <argLine>${test.jvm.args} -Dio.netty.transport.noNative=true</argLine>
                     </configuration>
                 </plugin>
                 <plugin>


### PR DESCRIPTION
Spark 4.1 gave us Netty 4.2, which may use Linux native transports such
as io_uring when available. On some Linux kernels this can hang during
Neo4j Java Driver shutdown in integration tests.

Technically we have no reason to rely on native transports in our test
suite. We are not testing Netty's native transport behaviour.

This PR brings in a test flag for surefire/failsafe which will disable
native Netty transports and instead fall back to use the JVM/JDK NIO
transport. This change only affects test-time and not the published
connector.