### PR TITLE
test: also refactor the disabled test cases

### DIFF
--- a/src/test/scala/org/neo4j/spark/cypher/CypherPreambleTest.scala
+++ b/src/test/scala/org/neo4j/spark/cypher/CypherPreambleTest.scala
@@ -26,7 +26,6 @@ import org.neo4j.spark.util.Neo4jOptions
 
 import java.util.stream.Stream
 
-import scala.jdk.CollectionConverters.MapHasAsScala
 import scala.jdk.CollectionConverters.SeqHasAsJava
 
 private case class TuningTestCase(

--- a/src/test/scala/org/neo4j/spark/service/AuthenticationTest.scala
+++ b/src/test/scala/org/neo4j/spark/service/AuthenticationTest.scala
@@ -18,7 +18,7 @@ package org.neo4j.spark.service
 
 import org.junit.jupiter.api.Test
 import org.mockito.ArgumentCaptor
-import org.mockito.ArgumentMatchers._
+import org.mockito.ArgumentMatchers.any
 import org.mockito.Mockito
 import org.mockito.Mockito.times
 import org.neo4j.driver.AuthToken
@@ -32,9 +32,6 @@ import org.neo4j.spark.util.Neo4jOptions
 import org.testcontainers.shaded.com.google.common.io.BaseEncoding
 
 import java.net.URI
-import java.util
-
-import scala.jdk.CollectionConverters.MapHasAsScala
 
 class AuthenticationTest {
 

--- a/src/test/scala/org/neo4j/spark/service/SchemaServiceTSE.scala
+++ b/src/test/scala/org/neo4j/spark/service/SchemaServiceTSE.scala
@@ -19,7 +19,7 @@ package org.neo4j.spark.service
 import org.apache.spark.sql.types.DataTypes
 import org.apache.spark.sql.types.StructField
 import org.apache.spark.sql.types.StructType
-import org.junit.jupiter.api.Assertions._
+import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 import org.neo4j.driver.TransactionContext

--- a/src/test/scala/org/neo4j/spark/util/Neo4jOptionsIT.scala
+++ b/src/test/scala/org/neo4j/spark/util/Neo4jOptionsIT.scala
@@ -25,15 +25,15 @@ import org.neo4j.spark.testsupport.Closeables.use
 import org.neo4j.spark.testsupport.SparkConnectorScalaSuiteIT
 import org.neo4j.spark.testsupport.SparkConnectorScalaSuiteIT.server
 
-import scala.jdk.CollectionConverters.MapHasAsScala
-
 class Neo4jOptionsIT extends SparkConnectorScalaSuiteIT {
 
   @Test
   @ClearSystemProperty(key = "strict.cypher")
   def creates_regular_driver(): Unit = {
-    val options = Map(Neo4jOptions.URL -> server.getBoltUrl, Neo4jOptions.AUTH_TYPE -> "none")
-    val neo4jOptions = new Neo4jOptions(options)
+    val neo4jOptions = new Neo4jOptions(Map(
+      Neo4jOptions.URL -> server.getBoltUrl,
+      Neo4jOptions.AUTH_TYPE -> "none"
+    ))
 
     use(neo4jOptions.connection.createDriver()) { driver =>
       assertThat(driver)
@@ -48,8 +48,10 @@ class Neo4jOptionsIT extends SparkConnectorScalaSuiteIT {
   @Test
   @SetSystemProperty(key = "strict.cypher", value = "true")
   def creates_strict_driver(): Unit = {
-    val options = Map(Neo4jOptions.URL -> server.getBoltUrl, Neo4jOptions.AUTH_TYPE -> "none")
-    val neo4jOptions = new Neo4jOptions(options)
+    val neo4jOptions = new Neo4jOptions(Map(
+      Neo4jOptions.URL -> server.getBoltUrl,
+      Neo4jOptions.AUTH_TYPE -> "none"
+    ))
 
     use(neo4jOptions.connection.createDriver()) { driver =>
       assertThat(driver).isInstanceOf(classOf[StrictDriver])
@@ -59,14 +61,10 @@ class Neo4jOptionsIT extends SparkConnectorScalaSuiteIT {
   @Test
   @Disabled("This requires a fix on driver, ignoring until it is implemented")
   def creates_driver_with_resolver(): Unit = {
-    val options: java.util.Map[String, String] = new java.util.HashMap[String, String]()
-    options.put(
-      Neo4jOptions.URL,
-      s"neo4j://localhost.localdomain:8888, bolt://localhost.localdomain:9999, ${server.getBoltUrl}"
-    )
-    options.put(Neo4jOptions.AUTH_TYPE, "none")
-
-    val neo4jOptions = new Neo4jOptions(options.asScala.toMap)
+    val neo4jOptions = new Neo4jOptions(Map(
+      Neo4jOptions.AUTH_TYPE -> "none",
+      Neo4jOptions.URL -> s"neo4j://localhost.localdomain:8888, bolt://localhost.localdomain:9999, ${server.getBoltUrl}"
+    ))
 
     use(neo4jOptions.connection.createDriver()) { driver =>
       assertThat(driver).isNotNull()

--- a/src/test/scala/org/neo4j/spark/util/ValidationsIT.scala
+++ b/src/test/scala/org/neo4j/spark/util/ValidationsIT.scala
@@ -17,7 +17,11 @@
 package org.neo4j.spark.util
 
 import org.apache.spark.sql.SparkSession
-import org.junit.jupiter.api.Assertions._
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertFalse
+import org.junit.jupiter.api.Assertions.assertThrows
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.Assertions.fail
 import org.junit.jupiter.api.Test
 import org.neo4j.driver.AccessMode
 import org.neo4j.spark.testsupport.SparkConnectorScalaSuiteIT


### PR DESCRIPTION
this is a follow-up from #991 where even the disabled test
cases gets refactored to use scala maps.

also removed unused imports.