### PR TITLE
feat: add GDS usage data per transaction

### DIFF
--- a/src/main/scala/org/neo4j/spark/util/Neo4jOptions.scala
+++ b/src/main/scala/org/neo4j/spark/util/Neo4jOptions.scala
@@ -330,7 +330,7 @@ class Neo4jOptions(private val options: Map[String, String]) extends Serializabl
       builder.withTimeout(duration)
     }
 
-    val txMetadata = extractNeo4jTransactionMetadata()
+    val txMetadata = extractConfiguredTransactionMetadata()
     if (query.queryType == QueryType.GDS) {
       txMetadata.put(GDS_TELEMETRY_ACTION, query.value)
     }
@@ -351,7 +351,7 @@ class Neo4jOptions(private val options: Map[String, String]) extends Serializabl
       .toNestedDeserializedJavaMap
   )
 
-  private def extractNeo4jTransactionMetadata(): util.Map[String, Any] =
+  private def extractConfiguredTransactionMetadata(): util.Map[String, Any] =
     options
       .view
       .filterKeys(k => k.startsWith(TX_METADATA_OPTION_PREFIX))

--- a/src/main/scala/org/neo4j/spark/util/Neo4jOptions.scala
+++ b/src/main/scala/org/neo4j/spark/util/Neo4jOptions.scala
@@ -324,7 +324,6 @@ class Neo4jOptions(private val options: Map[String, String]) extends Serializabl
 
   def toNeo4jTransactionConfig: TransactionConfig = {
     val timeout = getParameter(TRANSACTION_TIMEOUT_MSECS, DEFAULT_TRANSACTION_TIMEOUT)
-
     val builder = TransactionConfig.builder()
     if (timeout != null) {
       val duration = Duration.ofMillis(timeout.toInt)
@@ -332,9 +331,15 @@ class Neo4jOptions(private val options: Map[String, String]) extends Serializabl
     }
 
     val txMetadata = extractNeo4jTransactionMetadata()
+    if (query.queryType == QueryType.GDS) {
+      txMetadata.put(GDS_TELEMETRY_ACTION, query.value)
+      txMetadata.put(GDS_TELEMETRY_NAME, gdsMetadata.parameters.getOrDefault("graphName", "_"))
+    }
+
     if (!txMetadata.isEmpty) {
       builder.withMetadata(txMetadata)
     }
+
     builder.build()
   }
 
@@ -730,6 +735,8 @@ object Neo4jOptions {
 
   // GDS
   private val GDS_OPTION_PREFIX = "gds."
+  val GDS_TELEMETRY_ACTION = "gds.telemetry.action"
+  val GDS_TELEMETRY_NAME = "gds.telemetry.name"
 
   // Streaming
   val STREAMING_PROPERTY_NAME = "streaming.property.name"

--- a/src/main/scala/org/neo4j/spark/util/Neo4jOptions.scala
+++ b/src/main/scala/org/neo4j/spark/util/Neo4jOptions.scala
@@ -333,7 +333,7 @@ class Neo4jOptions(private val options: Map[String, String]) extends Serializabl
     val txMetadata = extractNeo4jTransactionMetadata()
     if (query.queryType == QueryType.GDS) {
       txMetadata.put(GDS_TELEMETRY_ACTION, query.value)
-      txMetadata.put(GDS_TELEMETRY_NAME, gdsMetadata.parameters.getOrDefault("graphName", "_"))
+      txMetadata.put(GDS_TELEMETRY_GRAPH_NAME, gdsMetadata.parameters.getOrDefault("graphName", "_"))
     }
 
     if (!txMetadata.isEmpty) {
@@ -736,7 +736,7 @@ object Neo4jOptions {
   // GDS
   private val GDS_OPTION_PREFIX = "gds."
   val GDS_TELEMETRY_ACTION = "gds.telemetry.action"
-  val GDS_TELEMETRY_NAME = "gds.telemetry.name"
+  val GDS_TELEMETRY_GRAPH_NAME = "gds.telemetry.graph_name"
 
   // Streaming
   val STREAMING_PROPERTY_NAME = "streaming.property.name"

--- a/src/main/scala/org/neo4j/spark/util/Neo4jOptions.scala
+++ b/src/main/scala/org/neo4j/spark/util/Neo4jOptions.scala
@@ -333,7 +333,6 @@ class Neo4jOptions(private val options: Map[String, String]) extends Serializabl
     val txMetadata = extractNeo4jTransactionMetadata()
     if (query.queryType == QueryType.GDS) {
       txMetadata.put(GDS_TELEMETRY_ACTION, query.value)
-      txMetadata.put(GDS_TELEMETRY_GRAPH_NAME, gdsMetadata.parameters.getOrDefault("graphName", "_"))
     }
 
     if (!txMetadata.isEmpty) {
@@ -736,7 +735,6 @@ object Neo4jOptions {
   // GDS
   private val GDS_OPTION_PREFIX = "gds."
   val GDS_TELEMETRY_ACTION = "gds.telemetry.action"
-  val GDS_TELEMETRY_GRAPH_NAME = "gds.telemetry.graph_name"
 
   // Streaming
   val STREAMING_PROPERTY_NAME = "streaming.property.name"

--- a/src/test/scala/org/neo4j/spark/util/Neo4jOptionsTest.scala
+++ b/src/test/scala/org/neo4j/spark/util/Neo4jOptionsTest.scala
@@ -25,6 +25,8 @@ import org.neo4j.driver.AccessMode
 import org.neo4j.driver.Value
 import org.neo4j.driver.net.ServerAddress
 import org.neo4j.spark.util.MapConverter.toScala
+import org.neo4j.spark.util.Neo4jOptions.GDS_TELEMETRY_ACTION
+import org.neo4j.spark.util.Neo4jOptions.GDS_TELEMETRY_NAME
 
 import java.net.URI
 import java.time.Duration
@@ -270,6 +272,36 @@ class Neo4jOptionsTest {
       "json_array_treated_as_string" -> "[true,43]",
       "json_map_treated_as_string" -> """{"map":false}"""
     ))
+  }
+
+  @Test
+  def populates_gds_telemetry_in_transaction_metadata(): Unit = {
+    val expectedValue = "Any value really, as this is primarily a test for existence."
+
+    val neo4jOptions = new Neo4jOptions(Map(
+      Neo4jOptions.URL -> "neo4j://localhost,neo4j://foo.bar,neo4j://foo.bar.baz:7783",
+      "gds" -> expectedValue
+    ))
+
+    val transactionMetadata = neo4jOptions.toNeo4jTransactionConfig.metadata()
+
+    assertThat(transactionMetadata.get(GDS_TELEMETRY_ACTION).asString()).isEqualTo(expectedValue)
+    assertThat(transactionMetadata.get(GDS_TELEMETRY_NAME)).isNotNull
+  }
+
+  @ParameterizedTest
+  @ValueSource(strings = Array("labels", "relationship", "query"))
+  def no_gds_telemetry_in_transaction_metadata_when_not_gds(queryType: String): Unit = {
+
+    val neo4jOptions = new Neo4jOptions(Map(
+      Neo4jOptions.URL -> "neo4j://localhost,neo4j://foo.bar,neo4j://foo.bar.baz:7783",
+      queryType -> "_"
+    ))
+
+    val transactionMetadata = neo4jOptions.toNeo4jTransactionConfig.metadata()
+
+    assertThat(transactionMetadata.get(GDS_TELEMETRY_ACTION)).isNull()
+    assertThat(transactionMetadata.get(GDS_TELEMETRY_NAME)).isNull()
   }
 
   @Test

--- a/src/test/scala/org/neo4j/spark/util/Neo4jOptionsTest.scala
+++ b/src/test/scala/org/neo4j/spark/util/Neo4jOptionsTest.scala
@@ -26,7 +26,6 @@ import org.neo4j.driver.Value
 import org.neo4j.driver.net.ServerAddress
 import org.neo4j.spark.util.MapConverter.toScala
 import org.neo4j.spark.util.Neo4jOptions.GDS_TELEMETRY_ACTION
-import org.neo4j.spark.util.Neo4jOptions.GDS_TELEMETRY_NAME
 
 import java.net.URI
 import java.time.Duration
@@ -286,7 +285,6 @@ class Neo4jOptionsTest {
     val transactionMetadata = neo4jOptions.toNeo4jTransactionConfig.metadata()
 
     assertThat(transactionMetadata.get(GDS_TELEMETRY_ACTION).asString()).isEqualTo(expectedValue)
-    assertThat(transactionMetadata.get(GDS_TELEMETRY_NAME)).isNotNull
   }
 
   @ParameterizedTest
@@ -301,7 +299,6 @@ class Neo4jOptionsTest {
     val transactionMetadata = neo4jOptions.toNeo4jTransactionConfig.metadata()
 
     assertThat(transactionMetadata.get(GDS_TELEMETRY_ACTION)).isNull()
-    assertThat(transactionMetadata.get(GDS_TELEMETRY_NAME)).isNull()
   }
 
   @Test


### PR DESCRIPTION
In order for us to get statistics on how and if GDS are being used from
the spark connector we need at least some clues of what is going on.

This PR will bring in light telemetry for GDS queryTypes