### PR TITLE
feat: preserve user-defined query's original return order

### DIFF
--- a/src/main/scala/org/neo4j/spark/cypher/AutomaticAliaser.scala
+++ b/src/main/scala/org/neo4j/spark/cypher/AutomaticAliaser.scala
@@ -16,6 +16,9 @@
  */
 package org.neo4j.spark.cypher
 
+import org.neo4j.cypherdsl.core.AliasedExpression
+import org.neo4j.cypherdsl.core.Asterisk
+import org.neo4j.cypherdsl.core.Clauses
 import org.neo4j.cypherdsl.core.Expression
 import org.neo4j.cypherdsl.core.FunctionInvocation
 import org.neo4j.cypherdsl.core.ListExpression
@@ -24,6 +27,7 @@ import org.neo4j.cypherdsl.core.Literal
 import org.neo4j.cypherdsl.core.MapExpression
 import org.neo4j.cypherdsl.core.Parameter
 import org.neo4j.cypherdsl.core.Property
+import org.neo4j.cypherdsl.core.SymbolicName
 import org.neo4j.cypherdsl.core.ast.Visitable
 import org.neo4j.cypherdsl.core.renderer.Configuration
 import org.neo4j.cypherdsl.core.renderer.GeneralizedRenderer
@@ -33,22 +37,47 @@ import org.neo4j.cypherdsl.parser.ExpressionCreatedEventType.ON_RETURN_ITEM
 import org.neo4j.cypherdsl.parser.Options
 import org.neo4j.spark.cypher.AutomaticAliaser.defaultRenderer
 
-class AutomaticAliaser(private val fragmentRenderer: GeneralizedRenderer = defaultRenderer()) {
+import scala.jdk.CollectionConverters.CollectionHasAsScala
 
-  def aliasResults(query: String): String = {
-    val statement: Visitable = CypherParser.parse(query, renderingOptions())
-    fragmentRenderer.render(statement)
+private[cypher] class AutomaticAliaser(private val fragmentRenderer: GeneralizedRenderer = defaultRenderer()) {
+
+  /**
+   * This aliases the results of a query if necessary.
+   * For instance, <pre><code>MATCH (n) RETURN n.foo</pre></code>
+   * gets replaced with
+   * <pre><code>MATCH (n) RETURN n.foo AS &#96;n.foo&#96;</pre></code>
+   * @param query the original query
+   * @return the same query, with aliased returned columns if necessary
+   */
+  def aliasResults(query: String): AliasedQuery = {
+    val returnFields = new ReturnFields()
+    val statement: Visitable = CypherParser.parse(query, renderingOptions(returnFields))
+    AliasedQuery(fragmentRenderer.render(statement), returnFields.fields)
   }
 
-  private def renderingOptions() =
-    Options.newOptions.withCallback(
-      ON_RETURN_ITEM,
-      classOf[Expression],
-      alias _
-    ).build
+  private def renderingOptions(returnFields: ReturnFields) =
+    Options.newOptions
+      .withCallback(
+        ON_RETURN_ITEM,
+        classOf[Expression],
+        alias _
+      )
+      // parse & extract return fields, last return clause wins (ie overwrites ReturnFields)
+      .withReturnClauseFactory(returnDefinition => {
+        returnFields.update(returnDefinition.getExpressions.asScala.toSeq)
+        Clauses.returning(
+          returnDefinition.isDistinct,
+          returnDefinition.getExpressions,
+          returnDefinition.getOptionalSortItems,
+          returnDefinition.getOptionalSkip,
+          returnDefinition.getOptionalLimit
+        )
+      })
+      .build
 
   private def alias(expression: Expression): Expression =
     expression match {
+      case asterisk: Asterisk                     => asterisk
       case literal: Literal[_]                    => literal.as(fragmentRenderer.render(literal))
       case param: Parameter[_]                    => param.as(fragmentRenderer.render(param))
       case listExpression: ListExpression         => listExpression.as(fragmentRenderer.render(listExpression))
@@ -58,7 +87,27 @@ class AutomaticAliaser(private val fragmentRenderer: GeneralizedRenderer = defau
       case property: Property                     => property.as(fragmentRenderer.render(property))
       case _                                      => expression
     }
+
+  private class ReturnFields {
+    private var names: Seq[String] = Seq.empty
+
+    def fields: Seq[String] = names
+
+    def update(expressions: Seq[Expression]): Unit = {
+      names = expressions.map(returnFieldName)
+    }
+
+    private def returnFieldName(expression: Expression): String =
+      expression match {
+        case _: Asterisk                => "*"
+        case aliased: AliasedExpression => aliased.getAlias
+        case name: SymbolicName         => name.getValue
+        case other                      => fragmentRenderer.render(other)
+      }
+  }
 }
+
+private[cypher] case class AliasedQuery(query: String, returnedFields: Seq[String])
 
 private object AutomaticAliaser {
 

--- a/src/main/scala/org/neo4j/spark/cypher/QueryEmbedder.scala
+++ b/src/main/scala/org/neo4j/spark/cypher/QueryEmbedder.scala
@@ -1,0 +1,46 @@
+/*
+ * Copyright (c) "Neo4j"
+ * Neo4j Sweden AB [https://neo4j.com]
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.neo4j.spark.cypher
+
+import org.neo4j.cypherdsl.core.Cypher
+import org.neo4j.cypherdsl.core.Cypher.callRawCypher
+import org.neo4j.cypherdsl.core.Expression
+import org.neo4j.cypherdsl.core.ResultStatement
+import org.neo4j.cypherdsl.core.StatementBuilder
+
+class QueryEmbedder {
+
+  private val aliaser = new AutomaticAliaser()
+
+  /**
+   * This embeds the provided query as a CALL subquery
+   * @param originalQuery the original query
+   * @param scriptResult the script result, if any
+   * @return
+   */
+  def embed(originalQuery: String, scriptResult: String): StatementBuilder.BuildableStatement[ResultStatement] = {
+    val query = aliaser.aliasResults(originalQuery) // unaliased results are not allowed in subqueries
+    callRawCypher(s"$scriptResult${query.query}")
+      .returning(returnItems(query): _*)
+  }
+
+  private def returnItems(query: AliasedQuery): Seq[Expression] =
+    query.returnedFields.map {
+      case "*"  => Cypher.asterisk()
+      case name => Cypher.name(name)
+    }
+}

--- a/src/main/scala/org/neo4j/spark/reader/BasePartitionReader.scala
+++ b/src/main/scala/org/neo4j/spark/reader/BasePartitionReader.scala
@@ -26,8 +26,8 @@ import org.neo4j.driver.Record
 import org.neo4j.driver.Session
 import org.neo4j.driver.Transaction
 import org.neo4j.driver.Values
-import org.neo4j.spark.cypher.AutomaticAliaser
 import org.neo4j.spark.cypher.CypherRenderer
+import org.neo4j.spark.cypher.QueryEmbedder
 import org.neo4j.spark.service._
 import org.neo4j.spark.util.DriverCache
 import org.neo4j.spark.util.Neo4jOptions
@@ -154,7 +154,7 @@ abstract class BasePartitionReader(
       new Neo4jQueryReadStrategy(
         neo4j,
         new CypherRenderer(neo4j, options),
-        new AutomaticAliaser(),
+        new QueryEmbedder(),
         filters,
         partitionSkipLimit,
         requiredColumns.fieldNames.toIndexedSeq,

--- a/src/main/scala/org/neo4j/spark/service/Neo4jQueryService.scala
+++ b/src/main/scala/org/neo4j/spark/service/Neo4jQueryService.scala
@@ -34,9 +34,9 @@ import org.neo4j.cypherdsl.core.renderer.Renderer
 import org.neo4j.cypherdsl.parser.CypherParser
 import org.neo4j.cypherdsl.parser.ExpressionCreatedEventType
 import org.neo4j.cypherdsl.parser.Options
-import org.neo4j.spark.cypher.AutomaticAliaser
 import org.neo4j.spark.cypher.CypherPreamble.fullPreamble
 import org.neo4j.spark.cypher.CypherRenderer
+import org.neo4j.spark.cypher.QueryEmbedder
 import org.neo4j.spark.service.Neo4jQueryStrategy.VARIABLE_EVENT
 import org.neo4j.spark.service.Neo4jQueryStrategy.eventProperties
 import org.neo4j.spark.service.Neo4jQueryStrategy.relEventProperties
@@ -199,7 +199,7 @@ class Neo4jQueryWriteStrategy(
 class Neo4jQueryReadStrategy(
   private val neo4j: Neo4j,
   private val renderer: CypherRenderer,
-  private val aliaser: AutomaticAliaser,
+  private val queryEmbedder: QueryEmbedder,
   private val filters: Array[Filter] = Array.empty[Filter],
   private val partitionPagination: PartitionPagination = PartitionPagination.EMPTY,
   private val requiredColumns: Seq[String] = Seq.empty,
@@ -212,10 +212,8 @@ class Neo4jQueryReadStrategy(
 
   override def createStatementForQuery(options: Neo4jOptions): String = {
     val scriptResult = scriptResultClause(options)
-    val query = aliaser.aliasResults(options.query.value)
     var statement: StatementBuilder.BuildableStatement[ResultStatement] =
-      callRawCypher(s"$scriptResult${query}")
-        .returning(Cypher.asterisk())
+      queryEmbedder.embed(options.query.value, scriptResult)
     if (partitionPagination.topN.orders.nonEmpty) {
       statement = statement
         .asInstanceOf[StatementBuilder.TerminalExposesOrderBy]

--- a/src/main/scala/org/neo4j/spark/service/SchemaService.scala
+++ b/src/main/scala/org/neo4j/spark/service/SchemaService.scala
@@ -36,9 +36,9 @@ import org.neo4j.driver.summary
 import org.neo4j.spark.config.TopN
 import org.neo4j.spark.converter.CypherToSparkTypeConverter
 import org.neo4j.spark.converter.SparkToCypherTypeConverter
-import org.neo4j.spark.cypher.AutomaticAliaser
 import org.neo4j.spark.cypher.CypherPreamble.fullPreamble
 import org.neo4j.spark.cypher.CypherRenderer
+import org.neo4j.spark.cypher.QueryEmbedder
 import org.neo4j.spark.service.SchemaService.normalizedClassName
 import org.neo4j.spark.service.SchemaService.normalizedClassNameFromGraphEntity
 import org.neo4j.spark.util.Neo4jImplicits.CypherImplicits
@@ -72,7 +72,13 @@ class SchemaService(
   private val renderer = new CypherRenderer(neo4j, options)
 
   private val queryReadStrategy =
-    new Neo4jQueryReadStrategy(neo4j, renderer, new AutomaticAliaser(), filters, withPreamble = false)
+    new Neo4jQueryReadStrategy(
+      neo4j,
+      renderer,
+      new QueryEmbedder(),
+      filters,
+      withPreamble = false
+    )
 
   private val session: Session = driverCache.getOrCreate().session(options.session.toNeo4jSession())
 

--- a/src/main/scala/org/neo4j/spark/streaming/BaseStreamingPartitionReader.scala
+++ b/src/main/scala/org/neo4j/spark/streaming/BaseStreamingPartitionReader.scala
@@ -23,9 +23,9 @@ import org.apache.spark.sql.sources.LessThanOrEqual
 import org.apache.spark.sql.types.StructType
 import org.neo4j.caniuse.Neo4j
 import org.neo4j.cypherdsl.core.Cypher
-import org.neo4j.spark.cypher.AutomaticAliaser
 import org.neo4j.spark.cypher.CypherPreamble.fullPreamble
 import org.neo4j.spark.cypher.CypherRenderer
+import org.neo4j.spark.cypher.QueryEmbedder
 import org.neo4j.spark.reader.BasePartitionReader
 import org.neo4j.spark.service.Neo4jQueryReadStrategy
 import org.neo4j.spark.service.Neo4jQueryService
@@ -103,7 +103,7 @@ class BaseStreamingPartitionReader(
           new Neo4jQueryReadStrategy(
             neo4j,
             new CypherRenderer(neo4j, options),
-            new AutomaticAliaser(),
+            new QueryEmbedder(),
             filters,
             partitionSkipLimit,
             requiredColumns.fieldNames.toIndexedSeq,

--- a/src/test/scala/org/neo4j/spark/GraphDataScienceIT.scala
+++ b/src/test/scala/org/neo4j/spark/GraphDataScienceIT.scala
@@ -40,8 +40,8 @@ import org.junit.jupiter.params.provider.MethodSource
 import org.neo4j.caniuse.Neo4j
 import org.neo4j.caniuse.Neo4jDetector
 import org.neo4j.driver.Driver
-import org.neo4j.spark.cypher.AutomaticAliaser
 import org.neo4j.spark.cypher.CypherRenderer
+import org.neo4j.spark.cypher.QueryEmbedder
 import org.neo4j.spark.service.Neo4jQueryReadStrategy
 import org.neo4j.spark.service.Neo4jQueryService
 import org.neo4j.spark.service.PartitionPagination
@@ -317,7 +317,7 @@ class GraphDataScienceIT {
       new Neo4jQueryReadStrategy(
         neo4j,
         new CypherRenderer(neo4j, neo4jOptions),
-        new AutomaticAliaser(),
+        new QueryEmbedder(),
         Array.empty,
         PartitionPagination.EMPTY,
         List(
@@ -367,7 +367,7 @@ class GraphDataScienceIT {
         new Neo4jQueryReadStrategy(
           neo4j,
           new CypherRenderer(neo4j, neo4jOptions),
-          new AutomaticAliaser(),
+          new QueryEmbedder(),
           Array.empty,
           PartitionPagination.EMPTY,
           List(

--- a/src/test/scala/org/neo4j/spark/cypher/AutomaticAliaserTest.scala
+++ b/src/test/scala/org/neo4j/spark/cypher/AutomaticAliaserTest.scala
@@ -31,22 +31,35 @@ import java.util.stream.Stream;
 class AutomaticAliaserTest {
 
   @ParameterizedTest
-  @MethodSource(Array("alias_cases"))
+  @MethodSource(Array("alias_result_cases"))
   def aliases_query(initialQuery: String, expectedQuery: String): Unit = {
-    val query = new AutomaticAliaser().aliasResults(initialQuery)
+    val query = new AutomaticAliaser().aliasResults(initialQuery).query
 
     assertThat(query).isEqualTo(expectedQuery)
   }
 
   @ParameterizedTest
-  @MethodSource(Array("preserve_cases"))
+  @MethodSource(Array("preserve_result_cases"))
   def preserves_query(query: String): Unit = {
-    val result = new AutomaticAliaser().aliasResults(query)
+    val result = new AutomaticAliaser().aliasResults(query).query
 
     assertThat(result).isEqualTo(query)
   }
 
-  private def alias_cases(): Stream[Arguments] = {
+  @ParameterizedTest
+  @MethodSource(Array("return_field_cases"))
+  def detects_return_fields(
+    initialQuery: String,
+    expectedQuery: String,
+    expectedFields: Seq[String]
+  ): Unit = {
+    val result = new AutomaticAliaser().aliasResults(initialQuery)
+
+    assertThat(result.query).isEqualTo(expectedQuery)
+    assertThat(result.returnedFields).isEqualTo(expectedFields)
+  }
+
+  private def alias_result_cases(): Stream[Arguments] = {
     Stream.of(
       argumentSet(
         "unaliased number literal",
@@ -106,7 +119,7 @@ class AutomaticAliaserTest {
     )
   }
 
-  private def preserve_cases(): Stream[Arguments] = {
+  private def preserve_result_cases(): Stream[Arguments] = {
     Stream.of(
       argumentSet(
         "whole node",
@@ -163,6 +176,35 @@ class AutomaticAliaserTest {
       argumentSet(
         "aliased indexed array access",
         "UNWIND [['foo']] AS array RETURN array[0] AS foo"
+      )
+    )
+  }
+
+  private def return_field_cases(): Stream[Arguments] = {
+    Stream.of(
+      argumentSet(
+        "outer aliased return after scoped subquery",
+        "MATCH (n) CALL (n) { MATCH (n)-[:THINGY]->(m) RETURN m,n } RETURN n AS foo, m AS bar",
+        "MATCH (n) CALL (*) {MATCH (n)-[:THINGY]->(m) RETURN m, n} RETURN n AS foo, m AS bar",
+        Seq("foo", "bar")
+      ),
+      argumentSet(
+        "aliased expression return",
+        "MATCH (n) RETURN n.foo, n.bar AS bar",
+        "MATCH (n) RETURN n.foo AS `n.foo`, n.bar AS bar",
+        Seq("n.foo", "bar")
+      ),
+      argumentSet(
+        "return all",
+        "MATCH (n) RETURN *",
+        "MATCH (n) RETURN *",
+        Seq("*")
+      ),
+      argumentSet(
+        "return all and aliases",
+        "MATCH (n) RETURN *, n AS m",
+        "MATCH (n) RETURN *, n AS m",
+        Seq("*", "m")
       )
     )
   }

--- a/src/test/scala/org/neo4j/spark/cypher/QueryEmbedderIT.scala
+++ b/src/test/scala/org/neo4j/spark/cypher/QueryEmbedderIT.scala
@@ -23,13 +23,13 @@ import org.assertj.core.api.Assertions.assertThatObject
 import org.assertj.core.api.Assertions.assertThatThrownBy
 import org.junit.jupiter.api.AfterEach
 import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.TestInstance
 import org.junit.jupiter.api.TestInstance.Lifecycle.PER_CLASS
 import org.junit.jupiter.params.ParameterizedTest
 import org.junit.jupiter.params.provider.Arguments
 import org.junit.jupiter.params.provider.Arguments.argumentSet
 import org.junit.jupiter.params.provider.MethodSource
-import org.neo4j.cypherdsl.core.Cypher
 import org.neo4j.cypherdsl.core.Cypher.asterisk
 import org.neo4j.cypherdsl.core.Cypher.callRawCypher
 import org.neo4j.driver.Driver
@@ -47,7 +47,7 @@ import scala.jdk.CollectionConverters.MapHasAsJava
 
 @Testcontainers
 @TestInstance(PER_CLASS)
-class AutomaticAliaserIT {
+class QueryEmbedderIT {
 
   @Container
   private val container = new Neo4jContainer(TestUtil.neo4jImage())
@@ -56,7 +56,7 @@ class AutomaticAliaserIT {
 
   private var driver: Option[Driver] = None
 
-  private val aliaser = new AutomaticAliaser()
+  private val embedder = new QueryEmbedder()
 
   @BeforeEach
   def prepare(): Unit = {
@@ -70,87 +70,76 @@ class AutomaticAliaserIT {
     driver.foreach(_.close())
   }
 
-  @ParameterizedTest
-  @MethodSource(Array("alias_cases"))
-  def aliases_query_for_subquery_embedding(subquery: String, params: Map[String, AnyRef]): Unit = {
+  @Test
+  def aliases_query_before_embedding_as_call_subquery(): Unit = {
     assertThat(driver.isDefined).isTrue
     val renderer = container.cypherRenderer()
-    val unaliasedQueryStatement = callRawCypher(subquery).returning(asterisk()).build()
-    // see https://neo4j.com/docs/status-codes/current/errors/gql-errors/42N21/
+    val query = "MATCH (o:Object) RETURN 42, false, o.name, o.brother"
+    val unaliasedQueryStatement = callRawCypher(query).returning(asterisk()).build()
     verifyQueryFailsWithAliasingError(renderer.render(unaliasedQueryStatement))
 
-    val aliasedQueryStatement = callRawCypher(aliaser.aliasResults(subquery)).returning(asterisk()).build()
+    val embeddedQuery = embedder.embed(query, "").build()
 
+    assertThat(embeddedQuery.getCypher).isEqualTo(
+      "CALL () {MATCH (o:Object) RETURN 42 AS `42`, false AS false, o.name AS `o.name`, o.brother AS `o.brother`} RETURN `42`, false, `o.name`, `o.brother`"
+    )
+    assertThatCode(() => driver.get.executableQuery(renderer.render(embeddedQuery)).execute())
+      .doesNotThrowAnyException()
+  }
+
+  @ParameterizedTest
+  @MethodSource(Array("embed_cases"))
+  def embeds_query_as_call_subquery(
+    query: String,
+    scriptResult: String,
+    params: Map[String, AnyRef],
+    expectedEmbeddedQuery: String
+  ): Unit = {
+    assertThat(driver.isDefined).isTrue
+
+    val embeddedQuery = embedder.embed(query, scriptResult).build()
+
+    val renderer = container.cypherRenderer()
+    assertThat(embeddedQuery.getCypher).isEqualTo(expectedEmbeddedQuery)
     assertThatCode(() =>
-      driver.get.executableQuery(renderer.render(aliasedQueryStatement))
+      driver.get.executableQuery(renderer.render(embeddedQuery))
         .withParameters(params.asJava)
         .execute()
     )
       .doesNotThrowAnyException()
   }
 
-  private def alias_cases(): Stream[Arguments] = {
-    {
-      Stream.of(
-        argumentSet(
-          "unaliased number literal",
-          "RETURN 42",
-          Map[String, AnyRef]()
-        ),
-        argumentSet(
-          "unaliased boolean literal",
-          "RETURN false",
-          Map[String, AnyRef]()
-        ),
-        argumentSet(
-          "unaliased string literal",
-          "RETURN 'foo'",
-          Map[String, AnyRef]()
-        ),
-        argumentSet(
-          "unaliased array literal",
-          "RETURN ['foo']",
-          Map[String, AnyRef]()
-        ),
-        argumentSet(
-          "unaliased map literal",
-          "RETURN {foo: 'bar'}",
-          Map[String, AnyRef]()
-        ),
-        argumentSet(
-          "unaliased parameter",
-          "RETURN $foo",
-          Map[String, AnyRef]("foo" -> "")
-        ),
-        argumentSet(
-          "unaliased function call",
-          "UNWIND [1, 2, 3] AS x RETURN avg(x)",
-          Map[String, AnyRef]()
-        ),
-        argumentSet(
-          "unaliased node property",
-          "MATCH (n:Person) RETURN n.bar",
-          Map[String, AnyRef]()
-        ),
-        argumentSet(
-          "unaliased relationship property",
-          "MATCH ()-[r:LINKS]->() RETURN r.bar",
-          Map[String, AnyRef]()
-        ),
-        argumentSet(
-          "unaliased field access",
-          "UNWIND [{foo: 'bar'}] AS object RETURN object.foo",
-          Map[String, AnyRef]()
-        ),
-        argumentSet(
-          "unaliased indexed array access",
-          "UNWIND [['foo']] AS array RETURN array[0]",
-          Map[String, AnyRef]()
-        )
+  private def embed_cases(): Stream[Arguments] =
+    Stream.of(
+      argumentSet(
+        "preserves return all",
+        "MATCH (o:Object) RETURN *",
+        "",
+        Map[String, AnyRef](),
+        "CALL () {MATCH (o:Object) RETURN *} RETURN *"
+      ),
+      argumentSet(
+        "embeds with script result",
+        "MATCH (o:Object) RETURN o",
+        "WITH $scriptResult AS scriptResult ",
+        Map[String, AnyRef]("scriptResult" -> ""),
+        "CALL () {WITH $scriptResult AS scriptResult MATCH (o:Object) RETURN o} RETURN o"
+      ),
+      argumentSet(
+        "keeps ordering through nested call",
+        "MATCH (n) CALL (n) { RETURN 1 AS a, 2 AS b } RETURN b AS x, a AS y",
+        "",
+        Map[String, AnyRef](),
+        "CALL () {MATCH (n) CALL (*) {RETURN 1 AS a, 2 AS b} RETURN b AS x, a AS y} RETURN x, y"
+      ),
+      argumentSet(
+        "preserves order after asterisk",
+        "WITH 42 as y RETURN *, y AS x",
+        "",
+        Map[String, AnyRef](),
+        "CALL () {WITH 42 AS y RETURN *, y AS x} RETURN *, x"
       )
-    }
-
-  }
+    )
 
   private def verifyQueryFailsWithAliasingError(query: String): Unit = {
     assertThatThrownBy(() => driver.get.executableQuery(query).execute())

--- a/src/test/scala/org/neo4j/spark/cypher/QueryEmbedderTest.scala
+++ b/src/test/scala/org/neo4j/spark/cypher/QueryEmbedderTest.scala
@@ -1,0 +1,81 @@
+/*
+ * Copyright (c) "Neo4j"
+ * Neo4j Sweden AB [https://neo4j.com]
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.neo4j.spark.cypher
+
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.TestInstance
+import org.junit.jupiter.api.TestInstance.Lifecycle
+import org.junit.jupiter.params.ParameterizedTest
+import org.junit.jupiter.params.provider.Arguments
+import org.junit.jupiter.params.provider.Arguments.argumentSet
+import org.junit.jupiter.params.provider.MethodSource
+
+import java.util.stream.Stream
+
+@TestInstance(Lifecycle.PER_CLASS)
+class QueryEmbedderTest {
+
+  private val embedder = new QueryEmbedder()
+
+  @ParameterizedTest
+  @MethodSource(Array("embed_cases"))
+  def embeds_user_defined_query(query: String, scriptResult: String, expected: String): Unit = {
+    val result = embedder.embed(query, scriptResult).build().getCypher
+
+    assertThat(result).isEqualTo(expected)
+  }
+
+  private def embed_cases(): Stream[Arguments] =
+    Stream.of(
+      argumentSet(
+        "returns automatically aliased fields",
+        "MATCH (o:Object) RETURN o.name",
+        "",
+        "CALL () {MATCH (o:Object) RETURN o.name AS `o.name`} RETURN `o.name`"
+      ),
+      argumentSet(
+        "preserves return all",
+        "MATCH (o:Object) RETURN *",
+        "",
+        "CALL () {MATCH (o:Object) RETURN *} RETURN *"
+      ),
+      argumentSet(
+        "embeds script result prelude",
+        "MATCH (o:Object) RETURN o",
+        "WITH $scriptResult AS scriptResult ",
+        "CALL () {WITH $scriptResult AS scriptResult MATCH (o:Object) RETURN o} RETURN o"
+      ),
+      argumentSet(
+        "uses final return order from nested call",
+        "MATCH (n) CALL (n) { RETURN 1 AS a, 2 AS b } RETURN b AS x, a AS y",
+        "",
+        "CALL () {MATCH (n) CALL (*) {RETURN 1 AS a, 2 AS b} RETURN b AS x, a AS y} RETURN x, y"
+      ),
+      argumentSet(
+        "uses final return names from deeper nested call",
+        "CALL { CALL { RETURN 1 AS a, 2 AS b } RETURN b AS c, a AS d } RETURN d AS x, c AS y",
+        "",
+        "CALL () {CALL () {CALL () {RETURN 1 AS a, 2 AS b} RETURN b AS c, a AS d} RETURN d AS x, c AS y} RETURN x, y"
+      ),
+      argumentSet(
+        "preserves order after asterisk",
+        "WITH 42 as y RETURN *, y AS x",
+        "",
+        "CALL () {WITH 42 AS y RETURN *, y AS x} RETURN *, x"
+      )
+    )
+}

--- a/src/test/scala/org/neo4j/spark/service/Neo4jQueryServiceTest.scala
+++ b/src/test/scala/org/neo4j/spark/service/Neo4jQueryServiceTest.scala
@@ -41,8 +41,8 @@ import org.neo4j.caniuse.Neo4jEdition.COMMUNITY
 import org.neo4j.caniuse.Neo4jEdition.ENTERPRISE
 import org.neo4j.caniuse.Neo4jVersion
 import org.neo4j.spark.config.TopN
-import org.neo4j.spark.cypher.AutomaticAliaser
 import org.neo4j.spark.cypher.CypherRenderer
+import org.neo4j.spark.cypher.QueryEmbedder
 import org.neo4j.spark.util.DummyNamedReference
 import org.neo4j.spark.util.Neo4jImplicits.CypherImplicits
 import org.neo4j.spark.util.Neo4jOptions
@@ -112,7 +112,7 @@ class Neo4jQueryServiceTest {
         new Neo4jQueryReadStrategy(
           neo4j,
           new CypherRenderer(neo4j, neo4jOptions),
-          new AutomaticAliaser(),
+          new QueryEmbedder(),
           partitionPagination = PartitionPagination(0, 0, TopN(100))
         )
       ).createQuery()
@@ -138,7 +138,7 @@ class Neo4jQueryServiceTest {
         new Neo4jQueryReadStrategy(
           neo4j,
           new CypherRenderer(neo4j, neo4jOptions),
-          new AutomaticAliaser(),
+          new QueryEmbedder(),
           Array.empty[Filter],
           PartitionPagination.EMPTY,
           Seq("name")
@@ -166,7 +166,7 @@ class Neo4jQueryServiceTest {
         new Neo4jQueryReadStrategy(
           neo4j,
           new CypherRenderer(neo4j, neo4jOptions),
-          new AutomaticAliaser(),
+          new QueryEmbedder(),
           Array.empty[Filter],
           PartitionPagination.EMPTY,
           List("name", "bornDate")
@@ -194,7 +194,7 @@ class Neo4jQueryServiceTest {
         new Neo4jQueryReadStrategy(
           neo4j,
           new CypherRenderer(neo4j, neo4jOptions),
-          new AutomaticAliaser(),
+          new QueryEmbedder(),
           Array.empty[Filter],
           PartitionPagination.EMPTY,
           List("<elementId>")
@@ -224,7 +224,12 @@ class Neo4jQueryServiceTest {
       val query: String =
         new Neo4jQueryService(
           neo4jOptions,
-          new Neo4jQueryReadStrategy(neo4j, new CypherRenderer(neo4j, neo4jOptions), new AutomaticAliaser(), filters)
+          new Neo4jQueryReadStrategy(
+            neo4j,
+            new CypherRenderer(neo4j, neo4jOptions),
+            new QueryEmbedder(),
+            filters
+          )
         ).createQuery()
 
       val paramName = "$" + "name".toParameterName("John Doe")
@@ -253,7 +258,12 @@ class Neo4jQueryServiceTest {
       val query: String =
         new Neo4jQueryService(
           neo4jOptions,
-          new Neo4jQueryReadStrategy(neo4j, new CypherRenderer(neo4j, neo4jOptions), new AutomaticAliaser(), filters)
+          new Neo4jQueryReadStrategy(
+            neo4j,
+            new CypherRenderer(neo4j, neo4jOptions),
+            new QueryEmbedder(),
+            filters
+          )
         ).createQuery()
 
       val nameParameterName = "$" + "name".toParameterName("John Doe")
@@ -288,7 +298,12 @@ class Neo4jQueryServiceTest {
       val query: String =
         new Neo4jQueryService(
           neo4jOptions,
-          new Neo4jQueryReadStrategy(neo4j, new CypherRenderer(neo4j, neo4jOptions), new AutomaticAliaser(), filters)
+          new Neo4jQueryReadStrategy(
+            neo4j,
+            new CypherRenderer(neo4j, neo4jOptions),
+            new QueryEmbedder(),
+            filters
+          )
         ).createQuery()
 
       val nameParameterName = "$" + "name".toParameterName(null)
@@ -320,7 +335,12 @@ class Neo4jQueryServiceTest {
       val query: String =
         new Neo4jQueryService(
           neo4jOptions,
-          new Neo4jQueryReadStrategy(neo4j, new CypherRenderer(neo4j, neo4jOptions), new AutomaticAliaser(), filters)
+          new Neo4jQueryReadStrategy(
+            neo4j,
+            new CypherRenderer(neo4j, neo4jOptions),
+            new QueryEmbedder(),
+            filters
+          )
         ).createQuery()
 
       val nameOneParameterName = "$" + "name".toParameterName("Person Name")
@@ -355,7 +375,7 @@ class Neo4jQueryServiceTest {
         new Neo4jQueryReadStrategy(
           neo4j,
           new CypherRenderer(neo4j, neo4jOptions),
-          new AutomaticAliaser(),
+          new QueryEmbedder(),
           Array.empty[Filter],
           PartitionPagination.EMPTY,
           List("source.name")
@@ -390,7 +410,7 @@ class Neo4jQueryServiceTest {
         new Neo4jQueryReadStrategy(
           neo4j,
           new CypherRenderer(neo4j, neo4jOptions),
-          new AutomaticAliaser(),
+          new QueryEmbedder(),
           Array.empty[Filter],
           PartitionPagination.EMPTY,
           List("source.name", "<source.elementId>")
@@ -425,7 +445,7 @@ class Neo4jQueryServiceTest {
         new Neo4jQueryReadStrategy(
           neo4j,
           new CypherRenderer(neo4j, neo4jOptions),
-          new AutomaticAliaser(),
+          new QueryEmbedder(),
           Array.empty[Filter],
           PartitionPagination(0, 0, TopN(limit = 100)),
           List("source.name", "<source.elementId>")
@@ -465,7 +485,7 @@ class Neo4jQueryServiceTest {
         new Neo4jQueryReadStrategy(
           neo4j,
           new CypherRenderer(neo4j, neo4jOptions),
-          new AutomaticAliaser(),
+          new QueryEmbedder(),
           Array.empty[Filter],
           PartitionPagination.EMPTY,
           List("source.name", "source.id", "rel.someprops", "target.date")
@@ -502,7 +522,12 @@ class Neo4jQueryServiceTest {
       val query: String =
         new Neo4jQueryService(
           neo4jOptions,
-          new Neo4jQueryReadStrategy(neo4j, new CypherRenderer(neo4j, neo4jOptions), new AutomaticAliaser(), filters)
+          new Neo4jQueryReadStrategy(
+            neo4j,
+            new CypherRenderer(neo4j, neo4jOptions),
+            new QueryEmbedder(),
+            filters
+          )
         ).createQuery()
 
       val parameterName = "$" + "source.name".toParameterName("John Doe")
@@ -537,7 +562,12 @@ class Neo4jQueryServiceTest {
       val query: String =
         new Neo4jQueryService(
           neo4jOptions,
-          new Neo4jQueryReadStrategy(neo4j, new CypherRenderer(neo4j, neo4jOptions), new AutomaticAliaser(), filters)
+          new Neo4jQueryReadStrategy(
+            neo4j,
+            new CypherRenderer(neo4j, neo4jOptions),
+            new QueryEmbedder(),
+            filters
+          )
         ).createQuery()
 
       val paramOneName = "$" + "source.name".toParameterName("John Doe")
@@ -574,7 +604,12 @@ class Neo4jQueryServiceTest {
       val query: String =
         new Neo4jQueryService(
           neo4jOptions,
-          new Neo4jQueryReadStrategy(neo4j, new CypherRenderer(neo4j, neo4jOptions), new AutomaticAliaser(), filters)
+          new Neo4jQueryReadStrategy(
+            neo4j,
+            new CypherRenderer(neo4j, neo4jOptions),
+            new QueryEmbedder(),
+            filters
+          )
         ).createQuery()
 
       val sourceIdParameterName = "$" + "source.id".toParameterName(14)
@@ -612,7 +647,12 @@ class Neo4jQueryServiceTest {
       val query: String =
         new Neo4jQueryService(
           neo4jOptions,
-          new Neo4jQueryReadStrategy(neo4j, new CypherRenderer(neo4j, neo4jOptions), new AutomaticAliaser(), filters)
+          new Neo4jQueryReadStrategy(
+            neo4j,
+            new CypherRenderer(neo4j, neo4jOptions),
+            new QueryEmbedder(),
+            filters
+          )
         ).createQuery()
 
       val parameterNames: Map[String, String] = HashMap(
@@ -661,7 +701,12 @@ class Neo4jQueryServiceTest {
       val query: String =
         new Neo4jQueryService(
           neo4jOptions,
-          new Neo4jQueryReadStrategy(neo4j, new CypherRenderer(neo4j, neo4jOptions), new AutomaticAliaser(), filters)
+          new Neo4jQueryReadStrategy(
+            neo4j,
+            new CypherRenderer(neo4j, neo4jOptions),
+            new QueryEmbedder(),
+            filters
+          )
         ).createQuery()
 
       val parameterNames = Map(
@@ -717,7 +762,12 @@ class Neo4jQueryServiceTest {
       val query: String =
         new Neo4jQueryService(
           neo4jOptions,
-          new Neo4jQueryReadStrategy(neo4j, new CypherRenderer(neo4j, neo4jOptions), new AutomaticAliaser(), filters)
+          new Neo4jQueryReadStrategy(
+            neo4j,
+            new CypherRenderer(neo4j, neo4jOptions),
+            new QueryEmbedder(),
+            filters
+          )
         ).createQuery()
 
       val parameterNames = Map(
@@ -764,7 +814,7 @@ class Neo4jQueryServiceTest {
         new Neo4jQueryReadStrategy(
           neo4j,
           new CypherRenderer(neo4j, neo4jOptions),
-          new AutomaticAliaser(),
+          new QueryEmbedder(),
           Array.empty[Filter],
           PartitionPagination.EMPTY,
           Seq("name", "SUM(DISTINCT age)", "SUM(age)"),
@@ -785,7 +835,7 @@ class Neo4jQueryServiceTest {
         new Neo4jQueryReadStrategy(
           neo4j,
           new CypherRenderer(neo4j, neo4jOptions),
-          new AutomaticAliaser(),
+          new QueryEmbedder(),
           Array.empty[Filter],
           PartitionPagination.EMPTY,
           Seq("name", "COUNT(DISTINCT name)", "COUNT(name)"),
@@ -805,7 +855,7 @@ class Neo4jQueryServiceTest {
         new Neo4jQueryReadStrategy(
           neo4j,
           new CypherRenderer(neo4j, neo4jOptions),
-          new AutomaticAliaser(),
+          new QueryEmbedder(),
           Array.empty[Filter],
           PartitionPagination.EMPTY,
           Seq("name", "MAX(age)", "MIN(age)"),
@@ -844,7 +894,7 @@ class Neo4jQueryServiceTest {
         new Neo4jQueryReadStrategy(
           neo4j,
           new CypherRenderer(neo4j, neo4jOptions),
-          new AutomaticAliaser(),
+          new QueryEmbedder(),
           Array.empty,
           PartitionPagination.EMPTY,
           List("source.fullName", "SUM(DISTINCT `target.price`)", "SUM(`target.price`)"),
@@ -870,7 +920,7 @@ class Neo4jQueryServiceTest {
         new Neo4jQueryReadStrategy(
           neo4j,
           new CypherRenderer(neo4j, neo4jOptions),
-          new AutomaticAliaser(),
+          new QueryEmbedder(),
           Array.empty,
           PartitionPagination.EMPTY,
           List("source.fullName", "COUNT(DISTINCT `target.id`)", "COUNT(`target.id`)"),
@@ -894,7 +944,7 @@ class Neo4jQueryServiceTest {
         new Neo4jQueryReadStrategy(
           neo4j,
           new CypherRenderer(neo4j, neo4jOptions),
-          new AutomaticAliaser(),
+          new QueryEmbedder(),
           Array.empty,
           PartitionPagination.EMPTY,
           List("source.fullName", "MAX(`target.price`)", "MIN(`target.price`)"),
@@ -933,7 +983,7 @@ class Neo4jQueryServiceTest {
         new Neo4jQueryReadStrategy(
           neo4j,
           new CypherRenderer(neo4j, neo4jOptions),
-          new AutomaticAliaser(),
+          new QueryEmbedder(),
           partitionPagination = PartitionPagination(
             0,
             0,
@@ -972,7 +1022,7 @@ class Neo4jQueryServiceTest {
         new Neo4jQueryReadStrategy(
           neo4j,
           new CypherRenderer(neo4j, neo4jOptions),
-          new AutomaticAliaser(),
+          new QueryEmbedder(),
           requiredColumns = Array("name").toIndexedSeq,
           partitionPagination = PartitionPagination(
             0,
@@ -1015,7 +1065,7 @@ class Neo4jQueryServiceTest {
         new Neo4jQueryReadStrategy(
           neo4j,
           new CypherRenderer(neo4j, neo4jOptions),
-          new AutomaticAliaser(),
+          new QueryEmbedder(),
           Array.empty[Filter],
           PartitionPagination(
             0,
@@ -1063,7 +1113,7 @@ class Neo4jQueryServiceTest {
         new Neo4jQueryReadStrategy(
           neo4j,
           new CypherRenderer(neo4j, neo4jOptions),
-          new AutomaticAliaser(),
+          new QueryEmbedder(),
           Array.empty[Filter],
           PartitionPagination(
             0,
@@ -1111,7 +1161,7 @@ class Neo4jQueryServiceTest {
         new Neo4jQueryReadStrategy(
           neo4j,
           new CypherRenderer(neo4j, neo4jOptions),
-          new AutomaticAliaser(),
+          new QueryEmbedder(),
           Array.empty[Filter],
           PartitionPagination(
             0,
@@ -1135,7 +1185,7 @@ class Neo4jQueryServiceTest {
       assertThat(
         query
       ).isEqualTo(
-        s"${prefix}CALL$callParens{MATCH (p:Person) RETURN p} RETURN * ORDER BY name DESC SKIP 0 LIMIT 24"
+        s"${prefix}CALL$callParens{MATCH (p:Person) RETURN p} RETURN p ORDER BY name DESC SKIP 0 LIMIT 24"
       )
     }
 
@@ -1198,12 +1248,12 @@ class Neo4jQueryServiceTest {
           new Neo4jQueryReadStrategy(
             neo4jInfo,
             new CypherRenderer(neo4jInfo, neo4jOptions),
-            new AutomaticAliaser(),
+            new QueryEmbedder(),
             withPreamble = false
           )
         )
 
-      assertThat(noPreambleReadService.createQuery().trim).isEqualTo("CALL {MATCH (o:Object) RETURN o} RETURN *")
+      assertThat(noPreambleReadService.createQuery().trim).isEqualTo("CALL {MATCH (o:Object) RETURN o} RETURN o")
     }
 
     @ParameterizedTest
@@ -1227,7 +1277,7 @@ class Neo4jQueryServiceTest {
       val callParens =
         if (CanIUse.canIUse(Cypher.callSubqueryWithVariableScopeClause()).withNeo4j(neo4j)) " () " else " "
       val wantQuery =
-        s"$tuningPrefix\n${cypherVersionPreamble}CALL$callParens{MATCH (o:Object) RETURN o} RETURN *"
+        s"$tuningPrefix\n${cypherVersionPreamble}CALL$callParens{MATCH (o:Object) RETURN o} RETURN o"
       assertThat(readService.createQuery().trim).isEqualTo(wantQuery.trim)
     }
 
@@ -1253,13 +1303,17 @@ class Neo4jQueryServiceTest {
       val callParens =
         if (CanIUse.canIUse(Cypher.callSubqueryWithVariableScopeClause()).withNeo4j(neo4j)) " () " else " "
       val wantQuery =
-        s"$tuningPrefix\n${cypherVersionPreamble}CALL$callParens{WITH $$scriptResult AS scriptResult MATCH (o:Object) RETURN o} RETURN *"
+        s"$tuningPrefix\n${cypherVersionPreamble}CALL$callParens{WITH $$scriptResult AS scriptResult MATCH (o:Object) RETURN o} RETURN o"
 
       assertThat(versionedReadService.createQuery().trim).isEqualTo(wantQuery.trim)
     }
 
     private def plainReadStrategy(neo4j: Neo4j, neo4jOptions: Neo4jOptions): Neo4jQueryReadStrategy =
-      new Neo4jQueryReadStrategy(neo4j, new CypherRenderer(neo4j, neo4jOptions), new AutomaticAliaser())
+      new Neo4jQueryReadStrategy(
+        neo4j,
+        new CypherRenderer(neo4j, neo4jOptions),
+        new QueryEmbedder()
+      )
   }
 
   @Nested


### PR DESCRIPTION
The order needs to be preserved as Spark allows users to access DataFrame columns by index.

AutomaticAliaser evolves to not only alias result columns but also extract information of the last RETURN clause.

A new utility called QueryEmbedder leverages that extracted information to create the embedding query's RETURN clause to preserve the order of the original user-defined query.