### PR TITLE
chore: remove remaining warnings

### DIFF
--- a/LICENSES.txt
+++ b/LICENSES.txt
@@ -239,6 +239,7 @@ Apache Software License, Version 2.0
 ------------------------------------------------------------------------------
 MIT License
   SLF4J API Module
+  SLF4J JDK Platform Logging Integration
 ------------------------------------------------------------------------------
 
 The MIT License

--- a/NOTICE.txt
+++ b/NOTICE.txt
@@ -48,6 +48,7 @@ Apache Software License, Version 2.0
 
 MIT License
   SLF4J API Module
+  SLF4J JDK Platform Logging Integration
 
 MIT No Attribution License
   reactive-streams

--- a/pom.xml
+++ b/pom.xml
@@ -70,7 +70,8 @@
         <sortpom-maven-plugin.version>4.0.0</sortpom-maven-plugin.version>
         <spark.version>4.1.2</spark.version>
         <spotless-maven-plugin.version>3.7.0</spotless-maven-plugin.version>
-        <test.jvm.args>-XX:+IgnoreUnrecognizedVMOptions
+        <test.jvm.args>
+            -XX:+IgnoreUnrecognizedVMOptions
             --add-opens=java.base/java.lang=ALL-UNNAMED
             --add-opens=java.base/java.lang.invoke=ALL-UNNAMED
             --add-opens=java.base/java.lang.reflect=ALL-UNNAMED
@@ -85,7 +86,14 @@
             --add-opens=java.base/sun.security.action=ALL-UNNAMED
             --add-opens=java.base/sun.util.calendar=ALL-UNNAMED
             --add-opens=java.security.jgss/sun.security.krb5=ALL-UNNAMED
-            -Djdk.reflect.useDirectMethodHandle=false</test.jvm.args>
+            -Djdk.reflect.useDirectMethodHandle=false
+            <!-- Avoid Netty 4.2 native transport which causes hangs in local tests. -->
+            -Dio.netty.transport.noNative=true
+            <!-- Manually register Mockito as an agent (dynamic agent loading is [going to be] prohibited -->
+            -javaagent:${org.mockito:mockito-core:jar}
+            <!-- Disable CDS because Mockito's Java agent appends to the bootstrap classpath. -->
+            -Xshare:off
+        </test.jvm.args>
         <testcontainers.version>2.0.5</testcontainers.version>
     </properties>
     <dependencyManagement>
@@ -440,8 +448,7 @@
                         </includes>
                         <forkCount>1</forkCount>
                         <reuseForks>false</reuseForks>
-                        <!-- Avoid Netty 4.2 native transport which causes hangs in local tests. -->
-                        <argLine>${test.jvm.args} -Dio.netty.transport.noNative=true</argLine>
+                        <argLine>${test.jvm.args}</argLine>
                         <useModulePath>false</useModulePath>
                     </configuration>
                     <executions>
@@ -500,8 +507,7 @@
                     <artifactId>maven-surefire-plugin</artifactId>
                     <version>${maven-surefire-plugin.version}</version>
                     <configuration>
-                        <!-- Avoid Netty 4.2 native transport which causes hangs in local tests. -->
-                        <argLine>${test.jvm.args} -Dio.netty.transport.noNative=true</argLine>
+                        <argLine>${test.jvm.args}</argLine>
                     </configuration>
                 </plugin>
                 <plugin>
@@ -661,6 +667,17 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-source-plugin</artifactId>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-dependency-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <goals>
+                            <goal>properties</goal>
+                        </goals>
+                    </execution>
+                </executions>
             </plugin>
         </plugins>
     </build>

--- a/pom.xml
+++ b/pom.xml
@@ -554,7 +554,6 @@
                             <descriptorRef>jar-with-dependencies</descriptorRef>
                         </descriptorRefs>
                         <finalName>${project.build.finalName}</finalName>
-                        <appendAssemblyId>false</appendAssemblyId>
                     </configuration>
                     <executions>
                         <execution>
@@ -562,6 +561,24 @@
                                 <goal>single</goal>
                             </goals>
                             <phase>package</phase>
+                        </execution>
+                    </executions>
+                </plugin>
+                <plugin>
+                    <groupId>com.coderplus.maven.plugins</groupId>
+                    <artifactId>copy-rename-maven-plugin</artifactId>
+                    <version>1.0</version>
+                    <executions>
+                        <execution>
+                            <id>copy-file</id>
+                            <goals>
+                                <goal>rename</goal>
+                            </goals>
+                            <phase>package</phase>
+                            <configuration>
+                                <sourceFile>${project.build.directory}/${project.build.finalName}-jar-with-dependencies.jar</sourceFile>
+                                <destinationFile>${project.build.directory}/${project.build.finalName}.jar</destinationFile>
+                            </configuration>
                         </execution>
                     </executions>
                 </plugin>
@@ -651,6 +668,10 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-assembly-plugin</artifactId>
+            </plugin>
+            <plugin>
+                <groupId>com.coderplus.maven.plugins</groupId>
+                <artifactId>copy-rename-maven-plugin</artifactId>
             </plugin>
             <plugin>
                 <groupId>com.diffplug.spotless</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -46,6 +46,7 @@
         <license-maven-plugin.version>5.0.0</license-maven-plugin.version>
         <licensing-maven-plugin.version>1.7.12</licensing-maven-plugin.version>
         <licensing.prepend.text>/license/neo4j_apache_v2/notice.txt</licensing.prepend.text>
+        <log4j.version>2.24.3</log4j.version>
         <maven-clean-plugin.version>3.5.0</maven-clean-plugin.version>
         <maven-compiler-plugin.version>3.15.0</maven-compiler-plugin.version>
         <maven-dependency-plugin.version>3.11.0</maven-dependency-plugin.version>
@@ -227,6 +228,19 @@
             <artifactId>commons-authn-provided</artifactId>
             <version>${connectors-commons.version}</version>
             <scope>runtime</scope>
+        </dependency>
+        <dependency>
+            <!-- required for Java driver logging configuration -->
+            <groupId>org.apache.logging.log4j</groupId>
+            <artifactId>log4j-jpl</artifactId>
+            <version>${log4j.version}</version>
+            <scope>test</scope>
+            <exclusions>
+                <exclusion>
+                    <groupId>org.apache.logging.log4j</groupId>
+                    <artifactId>log4j-api</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
         <dependency>
             <groupId>org.assertj</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -40,7 +40,6 @@
         <cypherdsl.version>2025.3.0</cypherdsl.version>
         <driver.version>6.2.0</driver.version>
         <java.version>17</java.version>
-        <!-- 3.4.3.Final is the latest jboss-logging version compatible with java 8 -->
         <jboss-logging.version>3.6.3.Final</jboss-logging.version>
         <junit.version>6.1.0</junit.version>
         <license-maven-plugin.version>5.0.0</license-maven-plugin.version>
@@ -230,17 +229,24 @@
             <scope>runtime</scope>
         </dependency>
         <dependency>
-            <!-- required for Java driver logging configuration -->
+            <!-- bridges Neo4j Java driver's Java Platform Logging API to SLF4J -->
+            <groupId>org.slf4j</groupId>
+            <artifactId>slf4j-jdk-platform-logging</artifactId>
+            <version>${slf4j-api.version}</version>
+            <scope>runtime</scope>
+        </dependency>
+        <dependency>
             <groupId>org.apache.logging.log4j</groupId>
-            <artifactId>log4j-jpl</artifactId>
+            <artifactId>log4j-core</artifactId>
             <version>${log4j.version}</version>
             <scope>test</scope>
-            <exclusions>
-                <exclusion>
-                    <groupId>org.apache.logging.log4j</groupId>
-                    <artifactId>log4j-api</artifactId>
-                </exclusion>
-            </exclusions>
+        </dependency>
+        <dependency>
+            <!-- bridges SLF4J to Log4j (for tests) -->
+            <groupId>org.apache.logging.log4j</groupId>
+            <artifactId>log4j-slf4j2-impl</artifactId>
+            <version>${log4j.version}</version>
+            <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>org.assertj</groupId>

--- a/src/main/scala/org/neo4j/spark/util/Neo4jOptions.scala
+++ b/src/main/scala/org/neo4j/spark/util/Neo4jOptions.scala
@@ -38,7 +38,6 @@ import java.util.concurrent.CompletableFuture
 import java.util.concurrent.CompletionStage
 import java.util.concurrent.TimeUnit
 
-import scala.annotation.nowarn
 import scala.jdk.CollectionConverters.IteratorHasAsScala
 import scala.jdk.CollectionConverters.MapHasAsJava
 import scala.jdk.CollectionConverters.MapHasAsScala
@@ -511,11 +510,9 @@ case class Neo4jDriverOptions(
     }
   }
 
-  @nowarn("cat=deprecation")
   private def toDriverConfig: Config = {
     val builder = Config.builder()
       .withUserAgent(s"neo4j-${Neo4jUtil.connectorEnv}-connector/${Neo4jUtil.connectorVersion}")
-      .withLogging(Logging.slf4j())
       .withMinimumNotificationSeverity(minNotificationSeverity)
 
     if (lifetime > -1) builder.withMaxConnectionLifetime(lifetime, TimeUnit.MILLISECONDS)

--- a/src/test/resources/log4j2.properties
+++ b/src/test/resources/log4j2.properties
@@ -5,8 +5,8 @@ appender.console.layout.type=PatternLayout
 appender.console.layout.pattern=%d{HH:mm:ss.SSS} [%t] %-5level %logger %X{source_type} - %msg%n
 
 logger.neo4j.name=org.neo4j
-logger.neo4j.level=debug
+logger.neo4j.level=off
 
-rootLogger.level=info
+rootLogger.level=off
 rootLogger.appenderRefs=stdout
 rootLogger.appenderRef.stdout.ref=STDOUT_TXT

--- a/src/test/resources/simplelogger.properties
+++ b/src/test/resources/simplelogger.properties
@@ -1,3 +1,0 @@
-org.slf4j.simpleLogger.defaultLogLevel=error
-org.slf4j.simpleLogger.showDateTime=true
-org.slf4j.simpleLogger.dateTimeFormat=yyyy-MM-dd'T'HH:mm:ss.SSS

--- a/src/test/scala/org/neo4j/spark/DataSourceWriterTSE.scala
+++ b/src/test/scala/org/neo4j/spark/DataSourceWriterTSE.scala
@@ -190,7 +190,6 @@ class DataSourceWriterTSE extends SparkConnectorScalaBaseTSE {
       ss.read.format(classOf[DataSource].getName)
         .option("url", SparkConnectorScalaSuiteIT.server.getBoltUrl)
         .load()
-        .show() // we need the action to be able to trigger the exception because of the changes in Spark 3
     } catch {
       case e: IllegalArgumentException =>
         assertEquals("No valid option found. One of `GDS`, `LABELS`, `QUERY`, `RELATIONSHIP` is required", e.getMessage)
@@ -1275,7 +1274,6 @@ class DataSourceWriterTSE extends SparkConnectorScalaBaseTSE {
       options + ("relationship.properties" -> "experience, rating:avgRating, instrument")
     })
 
-    resultDf.show(false)
     assertEquals(4, resultDf.count())
 
     val res = resultDf.orderBy("`source.name`").collectAsList()
@@ -1369,7 +1367,6 @@ class DataSourceWriterTSE extends SparkConnectorScalaBaseTSE {
       options + ("relationship.properties" -> "")
     })
 
-    resultDf.show(false)
     assertEquals(4, resultDf.count())
 
     val res = resultDf.orderBy("`source.name`").collectAsList()
@@ -1491,7 +1488,6 @@ class DataSourceWriterTSE extends SparkConnectorScalaBaseTSE {
   def `should write relations with KEYS mode with default properties`(): Unit = {
     val resultDf = writeKeyModeRelationshipWriteDataSet()
 
-    resultDf.show(false)
     assertEquals(4, resultDf.count())
 
     val res = resultDf.orderBy("`source.name`").collectAsList()

--- a/src/test/scala/org/neo4j/spark/DataSourceWriterTSE.scala
+++ b/src/test/scala/org/neo4j/spark/DataSourceWriterTSE.scala
@@ -29,7 +29,6 @@ import org.apache.spark.sql.types.DayTimeIntervalType
 import org.apache.spark.sql.types.DecimalType
 import org.apache.spark.sql.types.YearMonthIntervalType
 import org.junit.jupiter.api.Assertions._
-import org.junit.jupiter.api.Disabled
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.function.Executable
 import org.junit.jupiter.params.ParameterizedTest
@@ -1000,7 +999,6 @@ class DataSourceWriterTSE extends SparkConnectorScalaBaseTSE {
   }
 
   @Test
-  @Disabled("This won't work right now because we can't know if we are in a Write or Read context")
   def `should throw an exception for a read only query`(): Unit = {
     val ds = (1 to 100).map(i => Person("Andrea " + i, "Santurbano " + i, 36, null)).toDS()
 
@@ -1014,7 +1012,9 @@ class DataSourceWriterTSE extends SparkConnectorScalaBaseTSE {
         .save() // we need the action to be able to trigger the exception because of the changes in Spark 3
     } catch {
       case illegalArgumentException: IllegalArgumentException =>
-        assertTrue(illegalArgumentException.getMessage.equals("Please provide a valid WRITE query"))
+        assertTrue(illegalArgumentException.getMessage.equals(
+          "Invalid query `MATCH (r:Read) RETURN r` because the accepted types are [WRITE_ONLY, READ_WRITE], but the actual type is READ_ONLY"
+        ))
       case t: Throwable => fail(
           s"should be thrown a ${classOf[IllegalArgumentException].getName}, but it's ${t.getClass.getSimpleName}: ${t.getMessage}"
         )
@@ -1230,40 +1230,6 @@ class DataSourceWriterTSE extends SparkConnectorScalaBaseTSE {
 
     // TODO: When re-writing in assertj just use a should throw assertable
     assertTrue(didThrow, s"should throw ${classOf[IllegalArgumentException].getName}, but nothing was thrown")
-  }
-
-  @Test
-  @Disabled("trying to recreate the deadlock issue")
-  def `should give better errors if transaction fails`(): Unit = {
-    val df = List.fill(200)(("John Bonham", "Drums")).toDF("name", "instrument")
-
-    df.write
-      .format(classOf[DataSource].getName)
-      .mode(SaveMode.Overwrite)
-      .option("url", SparkConnectorScalaSuiteIT.server.getBoltUrl)
-      .option("relationship", "PLAYS")
-      .option("relationship.source.save.mode", "Overwrite")
-      .option("relationship.target.save.mode", "Overwrite")
-      .option("relationship.source.labels", ":Musician")
-      .option("relationship.source.node.keys", "name:name")
-      .option("relationship.target.labels", ":Instrument")
-      .option("relationship.target.node.keys", "instrument:name")
-      .save()
-
-    df.write
-      .format(classOf[DataSource].getName)
-      .mode(SaveMode.Overwrite)
-      .option("url", SparkConnectorScalaSuiteIT.server.getBoltUrl)
-      .option("transaction.retries", 0)
-      .option("partitions", "10")
-      .option("relationship", "PLAYS")
-      .option("relationship.source.save.mode", "Overwrite")
-      .option("relationship.target.save.mode", "Overwrite")
-      .option("relationship.source.labels", ":Musician")
-      .option("relationship.source.node.keys", "name:name")
-      .option("relationship.target.labels", ":Instrument")
-      .option("relationship.target.node.keys", "instrument:name")
-      .save()
   }
 
   def writeKeyModeRelationshipWriteDataSet(

--- a/src/test/scala/org/neo4j/spark/GraphDataScienceIT.scala
+++ b/src/test/scala/org/neo4j/spark/GraphDataScienceIT.scala
@@ -139,7 +139,7 @@ class GraphDataScienceIT {
         spark.read.format(classOf[DataSource].getName)
           .options(testCase.options)
           .load()
-          .show(false)
+          .count()
       })
       .withMessage(testCase.error)
   }
@@ -253,7 +253,7 @@ class GraphDataScienceIT {
       .option("gds.nodeProjection.Person.properties", "['age','lotteryNumbers','embedding']")
       .option("gds.relationshipProjection", "*")
       .load()
-      .show(false)
+      .count()
 
     val df = spark.read.format(classOf[DataSource].getName)
       .option("gds", "gds.knn.stream")
@@ -435,7 +435,7 @@ class GraphDataScienceIT {
       .option("gds.relationshipProjection", "LINKS")
       .option("gds.configuration.relationshipProperties", "weight")
       .load()
-      .show(false)
+      .count()
   }
 
   private def initForHits(): Unit = {
@@ -478,7 +478,7 @@ class GraphDataScienceIT {
       .option("gds.nodeProjection", "Website")
       .option("gds.relationshipProjection.LINK.indexInverse", "true")
       .load()
-      .show(false)
+      .count()
   }
 
   private def initForYens(): Unit = {
@@ -508,7 +508,7 @@ class GraphDataScienceIT {
       .option("gds.relationshipProjection", "ROAD")
       .option("gds.configuration.relationshipProperties", "cost")
       .load()
-      .show(false)
+      .count()
   }
 }
 

--- a/src/test/scala/org/neo4j/spark/ReadIT.scala
+++ b/src/test/scala/org/neo4j/spark/ReadIT.scala
@@ -103,7 +103,6 @@ class ReadIT {
       .isThrownBy(() => {
         spark.read.format(classOf[DataSource].getName)
           .load()
-          .show() // show is needed to trigger the exception because of changes in Spark 3
       })
       .withMessage("No valid option found. One of `GDS`, `LABELS`, `QUERY`, `RELATIONSHIP` is required")
   }
@@ -116,7 +115,6 @@ class ReadIT {
           .option("labels", "Person")
           .option("relationship", "KNOWS")
           .load()
-          .show() // show is needed to trigger the exception because of changes in Spark 3
       })
       .withMessage("You need to specify just one of these options: 'gds', 'labels', 'query', 'relationship'")
   }
@@ -129,7 +127,6 @@ class ReadIT {
           .option("labels", "Person")
           .option(Neo4jOptions.CYPHER_VERSION, "2.3")
           .load()
-          .show()
       })
       .withMessage("The provided cypher version '2.3' is not valid.")
   }
@@ -1849,7 +1846,7 @@ class ReadIT {
             .option("query", s"MATCH (n:Label) RETURN elementId(n) as id $limitKeyword 100")
             // generated query would yield 42I63 because of misplaced LIMIT in strict mode
             .load()
-            .show() // show is needed to trigger the exception because of changes in Spark 3
+            .count()
         })
         .withMessage("SKIP/LIMIT are not allowed at the end of the query")
     }

--- a/src/test/scala/org/neo4j/spark/ReauthenticationIT.scala
+++ b/src/test/scala/org/neo4j/spark/ReauthenticationIT.scala
@@ -144,7 +144,10 @@ class ReauthenticationIT extends SparkConnectorScalaSuiteIT {
 
     var driver: Driver = null
     try {
-      driver = GraphDatabase.driver(NEO4J.getBoltUrl, AuthTokens.basic("neo4j", NEO4J.getAdminPassword))
+      driver = GraphDatabase.driver(
+        NEO4J.getBoltUrl,
+        AuthTokens.basic("neo4j", NEO4J.getAdminPassword)
+      )
       driver.session().run(" CREATE (n:Test {field: 42}) CREATE (t:Test {field: 45})").consume()
     } finally {
       driver.close()

--- a/src/test/scala/org/neo4j/spark/SparkConnectorAuraTest.scala
+++ b/src/test/scala/org/neo4j/spark/SparkConnectorAuraTest.scala
@@ -48,7 +48,10 @@ object SparkConnectorAuraTest {
         .set("spark.driver.host", "127.0.0.1"))
       .getOrCreate()
 
-    neo4j = GraphDatabase.driver(url.get, AuthTokens.basic(username.get, password.get))
+    neo4j = GraphDatabase.driver(
+      url.get,
+      AuthTokens.basic(username.get, password.get)
+    )
   }
 
   @AfterAll


### PR DESCRIPTION
Manually register Mockito agent to remove the agent auto-registration warning.

Reconfigure assembly plugin to rid of its warnings.

Mute test logs and remove unneeded outputs.