### PR TITLE
feat: add GDS usage data per transaction

### DIFF
--- a/common/src/main/scala/org/neo4j/spark/util/Neo4jOptions.scala
+++ b/common/src/main/scala/org/neo4j/spark/util/Neo4jOptions.scala
@@ -381,6 +381,10 @@ class Neo4jOptions(private val options: java.util.Map[String, String]) extends S
       builder.withTimeout(duration)
     }
 
+    if (query.queryType == QueryType.GDS) {
+      builder.withMetadata(new util.HashMap[String, AnyRef](Map(GDS_TELEMETRY_ACTION -> query.value).asJava))
+    }
+
     builder.build()
   }
 
@@ -656,6 +660,7 @@ object Neo4jOptions {
   val TRANSACTION_RETRIES = "transaction.retries"
   val TRANSACTION_RETRY_TIMEOUT = "transaction.retry.timeout"
   val TRANSACTION_CODES_FAIL = "transaction.codes.fail"
+  val GDS_TELEMETRY_ACTION = "gds.telemetry.action"
 
   // Streaming
   val STREAMING_PROPERTY_NAME = "streaming.property.name"

--- a/common/src/test/scala/org/neo4j/spark/util/Neo4jOptionsTest.scala
+++ b/common/src/test/scala/org/neo4j/spark/util/Neo4jOptionsTest.scala
@@ -20,6 +20,7 @@ import org.junit.Assert._
 import org.junit.Test
 import org.neo4j.driver.AccessMode
 import org.neo4j.driver.net.ServerAddress
+import org.neo4j.spark.util.Neo4jOptions.GDS_TELEMETRY_ACTION
 
 import java.net.URI
 import java.time.Duration
@@ -267,6 +268,33 @@ class Neo4jOptionsTest {
 
     // Then it is not set
     assertNull(transactionConfig.timeout())
+  }
+
+  @Test
+  def testGdsTelemetry(): Unit = {
+    val expectedValue = "Any value really, as this is primarily a test for existence."
+    val rawOptions = new java.util.HashMap[String, String]()
+    rawOptions.put(Neo4jOptions.URL, "neo4j://localhost,neo4j://foo.bar,neo4j://foo.bar.baz:7783")
+    rawOptions.put("gds", expectedValue)
+
+    val neo4jOptions = new Neo4jOptions(rawOptions)
+
+    val transactionConfig = neo4jOptions.toNeo4jTransactionConfig
+
+    assertEquals(expectedValue, transactionConfig.metadata().get(GDS_TELEMETRY_ACTION).asString())
+  }
+
+  @Test
+  def testNoGdsTelemetryWhenNotGds(): Unit = {
+    val rawOptions = new java.util.HashMap[String, String]()
+    rawOptions.put(Neo4jOptions.URL, "neo4j://localhost,neo4j://foo.bar,neo4j://foo.bar.baz:7783")
+    rawOptions.put("query", "MATCH (t: Thing) RETURN t")
+
+    val neo4jOptions = new Neo4jOptions(rawOptions)
+
+    val transactionConfig = neo4jOptions.toNeo4jTransactionConfig
+
+    assertNull(transactionConfig.metadata().get(GDS_TELEMETRY_ACTION))
   }
 
   @Test


### PR DESCRIPTION
In order for us to get statistics on how and if GDS are being used from
the spark connector we need at least some clues of what is going on.

This PR will bring in light telemetry for GDS queryTypes