### PR TITLE
test: parallelize test execution

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -467,8 +467,8 @@
                             <include>**/*TSE.*</include>
                         </includes>
                         <forkCount>1</forkCount>
-                        <reuseForks>false</reuseForks>
-                        <argLine>${test.jvm.args}</argLine>
+                        <reuseForks>true</reuseForks>
+                        <argLine>${test.jvm.args} -Dstrict.cypher=true</argLine>
                         <useModulePath>false</useModulePath>
                     </configuration>
                     <executions>

--- a/src/main/scala/org/neo4j/spark/DataSource.scala
+++ b/src/main/scala/org/neo4j/spark/DataSource.scala
@@ -31,59 +31,45 @@ import org.neo4j.spark.util._
 import java.util.UUID
 
 import scala.jdk.CollectionConverters.MapHasAsScala
+import scala.util.Using
 
 class DataSource extends TableProvider
     with DataSourceRegister {
 
   Validations.validate(ValidateSparkMinVersion("4.0.0"))
 
-  private val jobId: String = UUID.randomUUID().toString
-
-  private var schema: StructType = _
-
-  private var neo4jOptions: Neo4jOptions = _
-
-  private var neo4j: Neo4j = _
-
   override def supportsExternalMetadata(): Boolean = true
 
   override def inferSchema(caseInsensitiveStringMap: CaseInsensitiveStringMap): StructType = {
-    if (schema == null) {
-      val neo4jOpts = getNeo4jOptions(caseInsensitiveStringMap)
-      Validations.validate(ValidateConnection(neo4jOpts, jobId))
-      val neo4j = getNeo4jInfo(neo4jOpts.connection)
-      schema =
-        Neo4jUtil.callSchemaService(
-          neo4j,
-          neo4jOpts,
-          jobId,
-          Array.empty[Filter],
-          { schemaService =>
-            schemaService.struct()
-          }
-        )
-    }
-
-    schema
+    inferSchema(caseInsensitiveStringMap, UUID.randomUUID().toString)
   }
 
-  private def getNeo4jInfo(options: Neo4jDriverOptions): Neo4j = {
-    if (neo4j == null) {
-      val driver = new DriverCache(options).getOrCreate()
-      neo4j = Neo4jDetector.INSTANCE.detect(driver)
-    }
-    neo4j
+  private def inferSchema(caseInsensitiveStringMap: CaseInsensitiveStringMap, jobId: String): StructType = {
+    val neo4jOpts = getNeo4jOptions(caseInsensitiveStringMap)
+    Validations.validate(ValidateConnection(neo4jOpts, jobId))
+    val neo4j = getNeo4jInfo(neo4jOpts.connection)
+    Neo4jUtil.callSchemaService(
+      neo4j,
+      neo4jOpts,
+      jobId,
+      Array.empty[Filter],
+      { schemaService =>
+        schemaService.struct()
+      }
+    )
   }
 
   private def getNeo4jOptions(caseInsensitiveStringMap: CaseInsensitiveStringMap) = {
-    if (neo4jOptions == null) {
-      val session = SparkSession.getActiveSession
-      val externalOptions = caseInsensitiveStringMap.asCaseSensitiveMap().asScala.toMap
-      neo4jOptions = Neo4jOptions.fromSession(session, externalOptions)
-    }
-
+    val session = SparkSession.getActiveSession
+    val externalOptions = caseInsensitiveStringMap.asCaseSensitiveMap().asScala.toMap
+    val neo4jOptions = Neo4jOptions.fromSession(session, externalOptions)
     ValidateNeo4jOptionsConsistency(getNeo4jInfo(neo4jOptions.connection), neo4jOptions).validate()
     neo4jOptions
+  }
+
+  private def getNeo4jInfo(options: Neo4jDriverOptions): Neo4j = {
+    val driverCache = new DriverCache(options)
+    Using.resource(driverCache)(cache => Neo4jDetector.INSTANCE.detect(cache.getOrCreate()))
   }
 
   override def getTable(
@@ -91,11 +77,12 @@ class DataSource extends TableProvider
     transforms: Array[Transform],
     map: java.util.Map[String, String]
   ): Table = {
+    val jobId = UUID.randomUUID().toString
     val caseInsensitiveStringMapNeo4jOptions = new CaseInsensitiveStringMap(map)
     val schema = if (structType != null) {
       structType
     } else {
-      inferSchema(caseInsensitiveStringMapNeo4jOptions)
+      inferSchema(caseInsensitiveStringMapNeo4jOptions, jobId)
     }
     val neo4jOpts = getNeo4jOptions(caseInsensitiveStringMapNeo4jOptions)
     val neo4jInfo = getNeo4jInfo(neo4jOpts.connection)

--- a/src/main/scala/org/neo4j/spark/DataSource.scala
+++ b/src/main/scala/org/neo4j/spark/DataSource.scala
@@ -86,7 +86,7 @@ class DataSource extends TableProvider
     }
     val neo4jOpts = getNeo4jOptions(caseInsensitiveStringMapNeo4jOptions)
     val neo4jInfo = getNeo4jInfo(neo4jOpts.connection)
-    new Neo4jTable(neo4jInfo, schema, neo4jOpts, jobId)
+    new Neo4jTable(neo4jInfo, schema, neo4jOpts, jobId, SparkSession.getActiveSession)
   }
 
   override def shortName(): String = "neo4j"

--- a/src/main/scala/org/neo4j/spark/Neo4jTable.scala
+++ b/src/main/scala/org/neo4j/spark/Neo4jTable.scala
@@ -18,6 +18,7 @@ package org.neo4j.spark
 
 import org.apache.spark.internal.Logging
 import org.apache.spark.sql.SaveMode
+import org.apache.spark.sql.SparkSession
 import org.apache.spark.sql.connector.catalog.SupportsRead
 import org.apache.spark.sql.connector.catalog.SupportsWrite
 import org.apache.spark.sql.connector.catalog.Table
@@ -36,8 +37,13 @@ import org.neo4j.spark.writer.Neo4jWriterBuilder
 
 import scala.jdk.CollectionConverters.SetHasAsJava
 
-class Neo4jTable(neo4j: Neo4j, schema: StructType, neo4jOptions: Neo4jOptions, jobId: String)
-    extends Table
+class Neo4jTable(
+  neo4j: Neo4j,
+  schema: StructType,
+  neo4jOptions: Neo4jOptions,
+  jobId: String,
+  sparkSession: Option[SparkSession]
+) extends Table
     with SupportsRead
     with SupportsWrite
     with Logging {
@@ -64,6 +70,6 @@ class Neo4jTable(neo4j: Neo4j, schema: StructType, neo4jOptions: Neo4jOptions, j
   override def newWriteBuilder(info: LogicalWriteInfo): WriteBuilder = {
     val accessModeWrite = Neo4jOptions.ACCESS_MODE -> AccessMode.WRITE.toString
     val neo4jWriterOptions = new Neo4jOptions(neo4jOptions.toMap + accessModeWrite)
-    new Neo4jWriterBuilder(neo4j, info.queryId(), info.schema(), SaveMode.Append, neo4jWriterOptions)
+    new Neo4jWriterBuilder(neo4j, info.queryId(), info.schema(), SaveMode.Append, neo4jWriterOptions, sparkSession)
   }
 }

--- a/src/main/scala/org/neo4j/spark/streaming/Neo4jStreamingWriter.scala
+++ b/src/main/scala/org/neo4j/spark/streaming/Neo4jStreamingWriter.scala
@@ -17,10 +17,12 @@
 package org.neo4j.spark.streaming
 
 import org.apache.spark.sql.SaveMode
+import org.apache.spark.sql.SparkSession
 import org.apache.spark.sql.connector.write.PhysicalWriteInfo
 import org.apache.spark.sql.connector.write.WriterCommitMessage
 import org.apache.spark.sql.connector.write.streaming.StreamingDataWriterFactory
 import org.apache.spark.sql.connector.write.streaming.StreamingWrite
+import org.apache.spark.sql.streaming.StreamingQueryListener
 import org.apache.spark.sql.types.StructType
 import org.neo4j.caniuse.Neo4j
 import org.neo4j.spark.service.SchemaService
@@ -36,6 +38,22 @@ class Neo4jStreamingWriter(
   val neo4jOptions: Neo4jOptions
 ) extends StreamingWrite {
 
+  private val self = this
+
+  private val listener = new StreamingQueryListener {
+    override def onQueryStarted(event: StreamingQueryListener.QueryStartedEvent): Unit = ()
+
+    override def onQueryProgress(event: StreamingQueryListener.QueryProgressEvent): Unit = ()
+
+    override def onQueryTerminated(event: StreamingQueryListener.QueryTerminatedEvent): Unit = {
+      if (event.id.toString == queryId) {
+        self.close()
+        SparkSession.getDefaultSession.get.streams.removeListener(this)
+      }
+    }
+  }
+  SparkSession.getDefaultSession.get.streams.addListener(listener)
+
   private val driverCache = new DriverCache(neo4jOptions.connection)
 
   private lazy val scriptResult = {
@@ -47,18 +65,14 @@ class Neo4jStreamingWriter(
   }
 
   override def createStreamingWriterFactory(info: PhysicalWriteInfo): StreamingDataWriterFactory = {
-    try {
-      new Neo4jStreamingDataWriterFactory(
-        neo4j,
-        queryId,
-        schema,
-        saveMode,
-        neo4jOptions,
-        scriptResult
-      )
-    } finally {
-      close()
-    }
+    new Neo4jStreamingDataWriterFactory(
+      neo4j,
+      queryId,
+      schema,
+      saveMode,
+      neo4jOptions,
+      scriptResult
+    )
   }
 
   override def commit(epochId: Long, messages: Array[WriterCommitMessage]): Unit = {}

--- a/src/main/scala/org/neo4j/spark/streaming/Neo4jStreamingWriter.scala
+++ b/src/main/scala/org/neo4j/spark/streaming/Neo4jStreamingWriter.scala
@@ -35,10 +35,13 @@ class Neo4jStreamingWriter(
   val queryId: String,
   val schema: StructType,
   saveMode: SaveMode,
-  val neo4jOptions: Neo4jOptions
+  val neo4jOptions: Neo4jOptions,
+  sparkSession: Option[SparkSession]
 ) extends StreamingWrite {
 
-  private val self = this
+  private val driverCache = new DriverCache(neo4jOptions.connection)
+
+  private val queryManager = sparkSession.map(_.streams)
 
   private val listener = new StreamingQueryListener {
     override def onQueryStarted(event: StreamingQueryListener.QueryStartedEvent): Unit = ()
@@ -47,14 +50,12 @@ class Neo4jStreamingWriter(
 
     override def onQueryTerminated(event: StreamingQueryListener.QueryTerminatedEvent): Unit = {
       if (event.id.toString == queryId) {
-        self.close()
-        SparkSession.getDefaultSession.get.streams.removeListener(this)
+        close()
+        queryManager.foreach(_.removeListener(this))
       }
     }
   }
-  SparkSession.getDefaultSession.get.streams.addListener(listener)
-
-  private val driverCache = new DriverCache(neo4jOptions.connection)
+  queryManager.foreach(_.addListener(listener))
 
   private lazy val scriptResult = {
     val schemaService = new SchemaService(neo4j, neo4jOptions, driverCache)

--- a/src/main/scala/org/neo4j/spark/streaming/Neo4jStreamingWriter.scala
+++ b/src/main/scala/org/neo4j/spark/streaming/Neo4jStreamingWriter.scala
@@ -17,12 +17,10 @@
 package org.neo4j.spark.streaming
 
 import org.apache.spark.sql.SaveMode
-import org.apache.spark.sql.SparkSession
 import org.apache.spark.sql.connector.write.PhysicalWriteInfo
 import org.apache.spark.sql.connector.write.WriterCommitMessage
 import org.apache.spark.sql.connector.write.streaming.StreamingDataWriterFactory
 import org.apache.spark.sql.connector.write.streaming.StreamingWrite
-import org.apache.spark.sql.streaming.StreamingQueryListener
 import org.apache.spark.sql.types.StructType
 import org.neo4j.caniuse.Neo4j
 import org.neo4j.spark.service.SchemaService
@@ -38,22 +36,6 @@ class Neo4jStreamingWriter(
   val neo4jOptions: Neo4jOptions
 ) extends StreamingWrite {
 
-  private val self = this
-
-  private val listener = new StreamingQueryListener {
-    override def onQueryStarted(event: StreamingQueryListener.QueryStartedEvent): Unit = ()
-
-    override def onQueryProgress(event: StreamingQueryListener.QueryProgressEvent): Unit = ()
-
-    override def onQueryTerminated(event: StreamingQueryListener.QueryTerminatedEvent): Unit = {
-      if (event.id.toString == queryId) {
-        self.close()
-        SparkSession.getDefaultSession.get.streams.removeListener(this)
-      }
-    }
-  }
-  SparkSession.getDefaultSession.get.streams.addListener(listener)
-
   private val driverCache = new DriverCache(neo4jOptions.connection)
 
   private lazy val scriptResult = {
@@ -65,14 +47,18 @@ class Neo4jStreamingWriter(
   }
 
   override def createStreamingWriterFactory(info: PhysicalWriteInfo): StreamingDataWriterFactory = {
-    new Neo4jStreamingDataWriterFactory(
-      neo4j,
-      queryId,
-      schema,
-      saveMode,
-      neo4jOptions,
-      scriptResult
-    )
+    try {
+      new Neo4jStreamingDataWriterFactory(
+        neo4j,
+        queryId,
+        schema,
+        saveMode,
+        neo4jOptions,
+        scriptResult
+      )
+    } finally {
+      close()
+    }
   }
 
   override def commit(epochId: Long, messages: Array[WriterCommitMessage]): Unit = {}

--- a/src/main/scala/org/neo4j/spark/util/Neo4jOptions.scala
+++ b/src/main/scala/org/neo4j/spark/util/Neo4jOptions.scala
@@ -341,6 +341,13 @@ class Neo4jOptions(private val options: Map[String, String]) extends Serializabl
     builder.build()
   }
 
+  override def equals(other: Any): Boolean = other match {
+    case that: Neo4jOptions => options == that.toMap
+    case _                  => false
+  }
+
+  override def hashCode(): Int = options.hashCode()
+
   private def extractNeo4jGdsMetadata(): Neo4jGdsMetadata = Neo4jGdsMetadata(
     options
       .view

--- a/src/main/scala/org/neo4j/spark/util/Neo4jOptions.scala
+++ b/src/main/scala/org/neo4j/spark/util/Neo4jOptions.scala
@@ -342,7 +342,7 @@ class Neo4jOptions(private val options: Map[String, String]) extends Serializabl
   }
 
   override def equals(other: Any): Boolean = other match {
-    case that: Neo4jOptions => options == that.toMap
+    case that: Neo4jOptions => options == that.options
     case _                  => false
   }
 

--- a/src/main/scala/org/neo4j/spark/util/Validations.scala
+++ b/src/main/scala/org/neo4j/spark/util/Validations.scala
@@ -134,6 +134,7 @@ case class ValidateSparkMinVersion(supportedVersions: String*) extends Validatio
 
   override def validate(): Unit = {
     val sparkVersion = SparkSession.getActiveSession
+      .orElse(SparkSession.getDefaultSession)
       .map(_.version)
       .getOrElse("UNKNOWN")
 

--- a/src/main/scala/org/neo4j/spark/util/Validations.scala
+++ b/src/main/scala/org/neo4j/spark/util/Validations.scala
@@ -134,7 +134,6 @@ case class ValidateSparkMinVersion(supportedVersions: String*) extends Validatio
 
   override def validate(): Unit = {
     val sparkVersion = SparkSession.getActiveSession
-      .orElse(SparkSession.getDefaultSession)
       .map(_.version)
       .getOrElse("UNKNOWN")
 

--- a/src/main/scala/org/neo4j/spark/writer/Neo4jWriterBuilder.scala
+++ b/src/main/scala/org/neo4j/spark/writer/Neo4jWriterBuilder.scala
@@ -17,6 +17,7 @@
 package org.neo4j.spark.writer
 
 import org.apache.spark.sql.SaveMode
+import org.apache.spark.sql.SparkSession
 import org.apache.spark.sql.connector.metric.CustomMetric
 import org.apache.spark.sql.connector.write._
 import org.apache.spark.sql.connector.write.streaming.StreamingWrite
@@ -31,7 +32,8 @@ class Neo4jWriterBuilder(
   queryId: String,
   schema: StructType,
   saveMode: SaveMode,
-  neo4jOptions: Neo4jOptions
+  neo4jOptions: Neo4jOptions,
+  sparkSession: Option[SparkSession]
 ) extends WriteBuilder
     with SupportsOverwrite
     with SupportsTruncate {
@@ -86,7 +88,8 @@ class Neo4jWriterBuilder(
         queryId,
         schema,
         saveMode,
-        validOptions(saveMode)
+        validOptions(saveMode),
+        sparkSession
       )
     }
 
@@ -94,6 +97,6 @@ class Neo4jWriterBuilder(
   }
 
   override def overwrite(filters: Array[Filter]): WriteBuilder = {
-    new Neo4jWriterBuilder(neo4j, queryId, schema, SaveMode.Overwrite, neo4jOptions)
+    new Neo4jWriterBuilder(neo4j, queryId, schema, SaveMode.Overwrite, neo4jOptions, sparkSession)
   }
 }

--- a/src/test/java/org/neo4j/spark/testsupport/InjectNeo4jContainerParameter.java
+++ b/src/test/java/org/neo4j/spark/testsupport/InjectNeo4jContainerParameter.java
@@ -1,0 +1,37 @@
+/*
+ * Copyright (c) "Neo4j"
+ * Neo4j Sweden AB [https://neo4j.com]
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.neo4j.spark.testsupport;
+
+import java.lang.annotation.*;
+
+import org.junit.jupiter.api.TestInstance;
+import org.junit.jupiter.api.parallel.Execution;
+import org.junit.jupiter.api.parallel.ExecutionMode;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.params.ParameterizedClass;
+import org.junit.jupiter.params.provider.ArgumentsSource;
+
+
+@TestInstance(TestInstance.Lifecycle.PER_METHOD)
+@Execution(ExecutionMode.CONCURRENT)
+@ExtendWith(Neo4jTestResourcesExtension.class)
+@Target(ElementType.TYPE)
+@Retention(RetentionPolicy.RUNTIME)
+@ParameterizedClass(name = "{argumentSetName}", autoCloseArguments = false)
+@ArgumentsSource(Neo4jContainerProvider.class)
+public @interface InjectNeo4jContainerParameter {
+}

--- a/src/test/resources/junit-platform.properties
+++ b/src/test/resources/junit-platform.properties
@@ -1,1 +1,7 @@
 junit.jupiter.displayname.generator.default=org.junit.jupiter.api.DisplayNameGenerator$ReplaceUnderscores
+junit.jupiter.execution.parallel.enabled=true
+junit.jupiter.execution.parallel.config.executor-service=WORKER_THREAD_POOL
+junit.jupiter.execution.parallel.config.strategy=fixed
+junit.jupiter.execution.parallel.config.fixed.parallelism=4
+junit.jupiter.execution.parallel.mode.default=same_thread
+junit.jupiter.execution.parallel.mode.classes.default=concurrent

--- a/src/test/scala/org/neo4j/spark/GraphDataScienceIT.scala
+++ b/src/test/scala/org/neo4j/spark/GraphDataScienceIT.scala
@@ -25,20 +25,17 @@ import org.apache.spark.sql.types._
 import org.assertj.core.api.Assertions.assertThat
 import org.assertj.core.api.Assertions.assertThatExceptionOfType
 import org.assertj.core.api.Assertions.assertThatThrownBy
-import org.junit.jupiter.api.AfterEach
+import org.junit.jupiter.api.AfterAll
 import org.junit.jupiter.api.Assumptions
 import org.junit.jupiter.api.Assumptions.assumeTrue
+import org.junit.jupiter.api.BeforeAll
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.DisplayName
 import org.junit.jupiter.api.Test
-import org.junit.jupiter.api.TestInstance
 import org.junit.jupiter.params.Parameter
-import org.junit.jupiter.params.ParameterizedClass
 import org.junit.jupiter.params.ParameterizedTest
-import org.junit.jupiter.params.provider.ArgumentsSource
 import org.junit.jupiter.params.provider.MethodSource
 import org.neo4j.caniuse.Neo4j
-import org.neo4j.caniuse.Neo4jDetector
 import org.neo4j.driver.Driver
 import org.neo4j.spark.cypher.CypherRenderer
 import org.neo4j.spark.cypher.QueryEmbedder
@@ -46,7 +43,7 @@ import org.neo4j.spark.service.Neo4jQueryReadStrategy
 import org.neo4j.spark.service.Neo4jQueryService
 import org.neo4j.spark.service.PartitionPagination
 import org.neo4j.spark.testsupport.Closeables.use
-import org.neo4j.spark.testsupport.Neo4jContainerProvider
+import org.neo4j.spark.testsupport.InjectNeo4jContainerParameter
 import org.neo4j.spark.testsupport.Neo4jExtensions.DriverExtensions
 import org.neo4j.spark.testsupport.Neo4jExtensions.Neo4jContainerExtensions
 import org.neo4j.spark.testsupport.TestUtil
@@ -55,51 +52,32 @@ import org.neo4j.spark.util.DummyNamedReference
 import org.neo4j.spark.util.Neo4jOptions
 import org.testcontainers.neo4j.Neo4jContainer
 
+import java.util.UUID
+
 import scala.math.Ordering.Implicits.infixOrderingOps
 
-@TestInstance(TestInstance.Lifecycle.PER_CLASS)
-@ParameterizedClass(name = "{argumentSetName}")
-@ArgumentsSource(classOf[Neo4jContainerProvider])
+@InjectNeo4jContainerParameter
 @DisplayName("graph data science")
 class GraphDataScienceIT {
 
   @Parameter
   var neo4jContainer: Neo4jContainer = _
 
-  var driver: Driver = _
-
-  var spark: SparkSession = _
-
-  var neo4j: Neo4j = _
-
   @BeforeEach
-  def prepare(): Unit = {
-    if (!neo4jContainer.isRunning) {
-      neo4jContainer.start()
-    }
-    driver = neo4jContainer.driver()
-    Assumptions.assumeTrue(driver.serverSupportsGds())
-    driver.createOrReplaceDatabase("neo4j")
-    spark = neo4jContainer.spark()
-    neo4j = Neo4jDetector.INSTANCE.detect(driver)
-  }
-
-  @AfterEach
-  def cleanUp(): Unit = {
-    Option(driver).filter(_.serverSupportsGds()).foreach { d =>
-      d.executableQuery("CALL gds.graph.drop('myGraph', false)").execute()
-    }
-    Option(spark).foreach(_.close())
-    Option(driver).foreach(_.close())
+  def prepare(driver: Driver, spark: SparkSession, neo4j: Neo4j): Unit = {
+    assumeTrue(driver.serverSupportsGds())
   }
 
   @Test
-  def runs_page_rank(): Unit = {
-    initForPageRank()
+  def runs_page_rank(driver: Driver, spark: SparkSession, neo4j: Neo4j): Unit = {
+    val graphName = unique("pagerank")
+    val nodeLabel = unique("Page")
+    val relationshipType = unique("LINKS")
+    initForPageRank(driver, spark, graphName, nodeLabel, relationshipType)
 
     val df = spark.read.format(classOf[DataSource].getName)
       .option("gds", "gds.pageRank.stream")
-      .option("gds.graphName", "myGraph")
+      .option("gds.graphName", graphName)
       .option("gds.configuration.concurrency", "2")
       .load()
     assertThat(df.count()).isEqualTo(8)
@@ -109,7 +87,7 @@ class GraphDataScienceIT {
 
     val dfEstimate = spark.read.format(classOf[DataSource].getName)
       .option("gds", "gds.pageRank.stream.estimate")
-      .option("gds.graphNameOrConfiguration", "myGraph")
+      .option("gds.graphNameOrConfiguration", graphName)
       .option("gds.algoConfiguration.concurrency", "2")
       .load()
     assertThat(dfEstimate.count()).isEqualTo(1)
@@ -133,7 +111,12 @@ class GraphDataScienceIT {
 
   @ParameterizedTest
   @MethodSource(Array("unsupportedOptionCases"))
-  def fails_with_unsupported_options(testCase: UnsupportedOptionCase): Unit = {
+  def fails_with_unsupported_options(
+    testCase: UnsupportedOptionCase,
+    driver: Driver,
+    spark: SparkSession,
+    neo4j: Neo4j
+  ): Unit = {
     assertThatExceptionOfType(classOf[IllegalArgumentException])
       .isThrownBy(() => {
         spark.read.format(classOf[DataSource].getName)
@@ -145,13 +128,16 @@ class GraphDataScienceIT {
   }
 
   @Test
-  def hits_supports_map_results(): Unit = {
+  def hits_supports_map_results(driver: Driver, spark: SparkSession, neo4j: Neo4j): Unit = {
     assumeTrue(use(driver.session())(s => TestUtil.neo4jVersion(s)) >= Versions.NEO4J_5)
-    initForHits()
+    val graphName = unique("hits")
+    val nodeLabel = unique("Website")
+    val relationshipType = unique("LINK")
+    initForHits(driver, spark, neo4j, graphName, nodeLabel, relationshipType)
 
     val df = spark.read.format(classOf[DataSource].getName)
-      .option("gds", hitsStreamProc)
-      .option("gds.graphName", "myGraph")
+      .option("gds", hitsStreamProc(driver))
+      .option("gds.graphName", graphName)
       .option("gds.configuration.hitsIterations", "20")
       .load()
     assertThat(df.count()).isEqualTo(9)
@@ -162,11 +148,14 @@ class GraphDataScienceIT {
   }
 
   @Test
-  def yens_shortest_path_supports_path_results(): Unit = {
-    initForYens()
+  def yens_shortest_path_supports_path_results(driver: Driver, spark: SparkSession, neo4j: Neo4j): Unit = {
+    val graphName = unique("yens")
+    val nodeLabel = unique("Location")
+    val relationshipType = unique("ROAD")
+    initForYens(driver, spark, neo4j, graphName, nodeLabel, relationshipType)
 
     val sourceTargetNodes = spark.read.format(classOf[DataSource].getName)
-      .option("labels", "Location")
+      .option("labels", nodeLabel)
       .load()
       .where("name IN ('A', 'F')")
       .orderBy("name")
@@ -182,7 +171,7 @@ class GraphDataScienceIT {
 
     val df = spark.read.format(classOf[DataSource].getName)
       .option("gds", "gds.shortestPath.yens.stream")
-      .option("gds.graphName", "myGraph")
+      .option("gds.graphName", graphName)
       .option("gds.configuration.sourceNode", sourceId)
       .option("gds.configuration.targetNode", targetId)
       .option("gds.configuration.k", 3)
@@ -210,7 +199,7 @@ class GraphDataScienceIT {
       else ("graphNameOrConfiguration", "algoConfiguration")
     val dfEstimate = spark.read.format(classOf[DataSource].getName)
       .option("gds", "gds.shortestPath.yens.stream.estimate")
-      .option(s"gds.$graphNameParam", "myGraph")
+      .option(s"gds.$graphNameParam", graphName)
       .option(s"gds.$algoConfigurationParam.sourceNode", sourceId)
       .option(s"gds.$algoConfigurationParam.targetNode", targetId)
       .option(s"gds.$algoConfigurationParam.k", 3)
@@ -236,28 +225,30 @@ class GraphDataScienceIT {
   }
 
   @Test
-  def runs_k_nearest(): Unit = {
+  def runs_k_nearest(driver: Driver, spark: SparkSession, neo4j: Neo4j): Unit = {
+    val graphName = unique("knn")
+    val nodeLabel = unique("Person")
     driver.executableQuery(
-      """
-        |CREATE (alice:Person {name: 'Alice', age: 24, lotteryNumbers: [1, 3], embedding: [1.0, 3.0]})
-        |CREATE (bob:Person {name: 'Bob', age: 73, lotteryNumbers: [1, 2, 3], embedding: [2.1, 1.6]})
-        |CREATE (carol:Person {name: 'Carol', age: 24, lotteryNumbers: [3], embedding: [1.5, 3.1]})
-        |CREATE (dave:Person {name: 'Dave', age: 48, lotteryNumbers: [2, 4], embedding: [0.6, 0.2]})
-        |CREATE (eve:Person {name: 'Eve', age: 67, lotteryNumbers: [1, 5], embedding: [1.8, 2.7]});
-        |""".stripMargin
+      s"""
+         |CREATE (alice:`$nodeLabel` {name: 'Alice', age: 24, lotteryNumbers: [1, 3], embedding: [1.0, 3.0]})
+         |CREATE (bob:`$nodeLabel` {name: 'Bob', age: 73, lotteryNumbers: [1, 2, 3], embedding: [2.1, 1.6]})
+         |CREATE (carol:`$nodeLabel` {name: 'Carol', age: 24, lotteryNumbers: [3], embedding: [1.5, 3.1]})
+         |CREATE (dave:`$nodeLabel` {name: 'Dave', age: 48, lotteryNumbers: [2, 4], embedding: [0.6, 0.2]})
+         |CREATE (eve:`$nodeLabel` {name: 'Eve', age: 67, lotteryNumbers: [1, 5], embedding: [1.8, 2.7]});
+         |""".stripMargin
     ).execute()
 
     spark.read.format(classOf[DataSource].getName)
       .option("gds", "gds.graph.project")
-      .option("gds.graphName", "myGraph")
-      .option("gds.nodeProjection.Person.properties", "['age','lotteryNumbers','embedding']")
+      .option("gds.graphName", graphName)
+      .option(s"gds.nodeProjection.$nodeLabel.properties", "['age','lotteryNumbers','embedding']")
       .option("gds.relationshipProjection", "*")
       .load()
       .count()
 
     val df = spark.read.format(classOf[DataSource].getName)
       .option("gds", "gds.knn.stream")
-      .option("gds.graphName", "myGraph")
+      .option("gds.graphName", graphName)
       .option("gds.configuration.topK", 1)
       .option("gds.configuration.nodeProperties", "['age']")
       .option("gds.configuration.randomSeed", 1337)
@@ -280,7 +271,7 @@ class GraphDataScienceIT {
 
     val dfEstimate = spark.read.format(classOf[DataSource].getName)
       .option("gds", "gds.knn.stream.estimate")
-      .option("gds.graphNameOrConfiguration", "myGraph")
+      .option("gds.graphNameOrConfiguration", graphName)
       .option("gds.algoConfiguration.topK", 1)
       .option("gds.algoConfiguration.nodeProperties", "['age']")
       .option("gds.algoConfiguration.randomSeed", 1337)
@@ -308,7 +299,7 @@ class GraphDataScienceIT {
   }
 
   @Test
-  def generates_read_query_that_aggregates(): Unit = {
+  def generates_read_query_that_aggregates(driver: Driver, spark: SparkSession, neo4j: Neo4j): Unit = {
     val neo4jOptions = new Neo4jOptions(neo4jContainer.authenticatedOptions() ++ Map("gds" -> "gds.pageRank.stream"))
 
     val field = new DummyNamedReference("score")
@@ -351,7 +342,7 @@ class GraphDataScienceIT {
   }
 
   @Test
-  def refuses_read_query_with_cypher_preamble(): Unit = {
+  def refuses_read_query_with_cypher_preamble(driver: Driver, spark: SparkSession, neo4j: Neo4j): Unit = {
     val neo4jOptions: Neo4jOptions = new Neo4jOptions(
       neo4jContainer.authenticatedOptions() ++ Map(
         "gds" -> "gds.pageRank.stream",
@@ -395,117 +386,140 @@ class GraphDataScienceIT {
       .hasMessageContaining("Query tuning parameters are not supported for GDS queries")
   }
 
-  private def hitsStreamProc: String =
+  private def hitsStreamProc(driver: Driver): String =
     if (use(driver.session())(s => TestUtil.gdsVersion(s)) >= Versions.GDS_2_5) "gds.hits.stream"
     else "gds.alpha.hits.stream"
 
-  private def initForPageRank(): Unit = {
+  private def unique(prefix: String): String =
+    s"${prefix}_${UUID.randomUUID().toString.replace("-", "")}"
+
+  private def initForPageRank(
+    driver: Driver,
+    spark: SparkSession,
+    graphName: String,
+    nodeLabel: String,
+    relationshipType: String
+  ): Unit = {
     driver.executableQuery(
-      """
-        |CREATE
-        |  (home:Page {name:'Home'}),
-        |  (about:Page {name:'About'}),
-        |  (product:Page {name:'Product'}),
-        |  (links:Page {name:'Links'}),
-        |  (a:Page {name:'Site A'}),
-        |  (b:Page {name:'Site B'}),
-        |  (c:Page {name:'Site C'}),
-        |  (d:Page {name:'Site D'}),
-        |
-        |  (home)-[:LINKS {weight: 0.2}]->(about),
-        |  (home)-[:LINKS {weight: 0.2}]->(links),
-        |  (home)-[:LINKS {weight: 0.6}]->(product),
-        |  (about)-[:LINKS {weight: 1.0}]->(home),
-        |  (product)-[:LINKS {weight: 1.0}]->(home),
-        |  (a)-[:LINKS {weight: 1.0}]->(home),
-        |  (b)-[:LINKS {weight: 1.0}]->(home),
-        |  (c)-[:LINKS {weight: 1.0}]->(home),
-        |  (d)-[:LINKS {weight: 1.0}]->(home),
-        |  (links)-[:LINKS {weight: 0.8}]->(home),
-        |  (links)-[:LINKS {weight: 0.05}]->(a),
-        |  (links)-[:LINKS {weight: 0.05}]->(b),
-        |  (links)-[:LINKS {weight: 0.05}]->(c),
-        |  (links)-[:LINKS {weight: 0.05}]->(d);
-        |""".stripMargin
+      s"""
+         |CREATE
+         |  (home:`$nodeLabel` {name:'Home'}),
+         |  (about:`$nodeLabel` {name:'About'}),
+         |  (product:`$nodeLabel` {name:'Product'}),
+         |  (links:`$nodeLabel` {name:'Links'}),
+         |  (a:`$nodeLabel` {name:'Site A'}),
+         |  (b:`$nodeLabel` {name:'Site B'}),
+         |  (c:`$nodeLabel` {name:'Site C'}),
+         |  (d:`$nodeLabel` {name:'Site D'}),
+         |
+         |  (home)-[:`$relationshipType` {weight: 0.2}]->(about),
+         |  (home)-[:`$relationshipType` {weight: 0.2}]->(links),
+         |  (home)-[:`$relationshipType` {weight: 0.6}]->(product),
+         |  (about)-[:`$relationshipType` {weight: 1.0}]->(home),
+         |  (product)-[:`$relationshipType` {weight: 1.0}]->(home),
+         |  (a)-[:`$relationshipType` {weight: 1.0}]->(home),
+         |  (b)-[:`$relationshipType` {weight: 1.0}]->(home),
+         |  (c)-[:`$relationshipType` {weight: 1.0}]->(home),
+         |  (d)-[:`$relationshipType` {weight: 1.0}]->(home),
+         |  (links)-[:`$relationshipType` {weight: 0.8}]->(home),
+         |  (links)-[:`$relationshipType` {weight: 0.05}]->(a),
+         |  (links)-[:`$relationshipType` {weight: 0.05}]->(b),
+         |  (links)-[:`$relationshipType` {weight: 0.05}]->(c),
+         |  (links)-[:`$relationshipType` {weight: 0.05}]->(d);
+         |""".stripMargin
     ).execute()
     spark.read.format(classOf[DataSource].getName)
       .option("gds", "gds.graph.project")
-      .option("gds.graphName", "myGraph")
-      .option("gds.nodeProjection", "Page")
-      .option("gds.relationshipProjection", "LINKS")
+      .option("gds.graphName", graphName)
+      .option("gds.nodeProjection", nodeLabel)
+      .option("gds.relationshipProjection", relationshipType)
       .option("gds.configuration.relationshipProperties", "weight")
       .load()
       .count()
   }
 
-  private def initForHits(): Unit = {
+  private def initForHits(
+    driver: Driver,
+    spark: SparkSession,
+    neo4j: Neo4j,
+    graphName: String,
+    nodeLabel: String,
+    relationshipType: String
+  ): Unit = {
     driver.executableQuery(
-      """
-        |CREATE
-        |  (a:Website {name: 'A'}),
-        |  (b:Website {name: 'B'}),
-        |  (c:Website {name: 'C'}),
-        |  (d:Website {name: 'D'}),
-        |  (e:Website {name: 'E'}),
-        |  (f:Website {name: 'F'}),
-        |  (g:Website {name: 'G'}),
-        |  (h:Website {name: 'H'}),
-        |  (i:Website {name: 'I'}),
-        |
-        |  (a)-[:LINK]->(b),
-        |  (a)-[:LINK]->(c),
-        |  (a)-[:LINK]->(d),
-        |  (b)-[:LINK]->(c),
-        |  (b)-[:LINK]->(d),
-        |  (c)-[:LINK]->(d),
-        |
-        |  (e)-[:LINK]->(b),
-        |  (e)-[:LINK]->(d),
-        |  (e)-[:LINK]->(f),
-        |  (e)-[:LINK]->(h),
-        |
-        |  (f)-[:LINK]->(g),
-        |  (f)-[:LINK]->(i),
-        |  (f)-[:LINK]->(h),
-        |  (g)-[:LINK]->(h),
-        |  (g)-[:LINK]->(i),
-        |  (h)-[:LINK]->(i);
-        |""".stripMargin
+      s"""
+         |CREATE
+         |  (a:`$nodeLabel` {name: 'A'}),
+         |  (b:`$nodeLabel` {name: 'B'}),
+         |  (c:`$nodeLabel` {name: 'C'}),
+         |  (d:`$nodeLabel` {name: 'D'}),
+         |  (e:`$nodeLabel` {name: 'E'}),
+         |  (f:`$nodeLabel` {name: 'F'}),
+         |  (g:`$nodeLabel` {name: 'G'}),
+         |  (h:`$nodeLabel` {name: 'H'}),
+         |  (i:`$nodeLabel` {name: 'I'}),
+         |
+         |  (a)-[:`$relationshipType`]->(b),
+         |  (a)-[:`$relationshipType`]->(c),
+         |  (a)-[:`$relationshipType`]->(d),
+         |  (b)-[:`$relationshipType`]->(c),
+         |  (b)-[:`$relationshipType`]->(d),
+         |  (c)-[:`$relationshipType`]->(d),
+         |
+         |  (e)-[:`$relationshipType`]->(b),
+         |  (e)-[:`$relationshipType`]->(d),
+         |  (e)-[:`$relationshipType`]->(f),
+         |  (e)-[:`$relationshipType`]->(h),
+         |
+         |  (f)-[:`$relationshipType`]->(g),
+         |  (f)-[:`$relationshipType`]->(i),
+         |  (f)-[:`$relationshipType`]->(h),
+         |  (g)-[:`$relationshipType`]->(h),
+         |  (g)-[:`$relationshipType`]->(i),
+         |  (h)-[:`$relationshipType`]->(i);
+         |""".stripMargin
     ).execute()
     spark.read.format(classOf[DataSource].getName)
       .option("gds", "gds.graph.project")
-      .option("gds.graphName", "myGraph")
-      .option("gds.nodeProjection", "Website")
-      .option("gds.relationshipProjection.LINK.indexInverse", "true")
+      .option("gds.graphName", graphName)
+      .option("gds.nodeProjection", nodeLabel)
+      .option(s"gds.relationshipProjection.$relationshipType.indexInverse", "true")
       .load()
       .count()
   }
 
-  private def initForYens(): Unit = {
+  private def initForYens(
+    driver: Driver,
+    spark: SparkSession,
+    neo4j: Neo4j,
+    graphName: String,
+    nodeLabel: String,
+    relationshipType: String
+  ): Unit = {
     driver.executableQuery(
-      """
-        |CREATE (a:Location {name: 'A'}),
-        |       (b:Location {name: 'B'}),
-        |       (c:Location {name: 'C'}),
-        |       (d:Location {name: 'D'}),
-        |       (e:Location {name: 'E'}),
-        |       (f:Location {name: 'F'}),
-        |       (a)-[:ROAD {cost: 50}]->(b),
-        |       (a)-[:ROAD {cost: 50}]->(c),
-        |       (a)-[:ROAD {cost: 100}]->(d),
-        |       (b)-[:ROAD {cost: 40}]->(d),
-        |       (c)-[:ROAD {cost: 40}]->(d),
-        |       (c)-[:ROAD {cost: 80}]->(e),
-        |       (d)-[:ROAD {cost: 30}]->(e),
-        |       (d)-[:ROAD {cost: 80}]->(f),
-        |       (e)-[:ROAD {cost: 40}]->(f);
-        |""".stripMargin
+      s"""
+         |CREATE (a:`$nodeLabel` {name: 'A'}),
+         |       (b:`$nodeLabel` {name: 'B'}),
+         |       (c:`$nodeLabel` {name: 'C'}),
+         |       (d:`$nodeLabel` {name: 'D'}),
+         |       (e:`$nodeLabel` {name: 'E'}),
+         |       (f:`$nodeLabel` {name: 'F'}),
+         |       (a)-[:`$relationshipType` {cost: 50}]->(b),
+         |       (a)-[:`$relationshipType` {cost: 50}]->(c),
+         |       (a)-[:`$relationshipType` {cost: 100}]->(d),
+         |       (b)-[:`$relationshipType` {cost: 40}]->(d),
+         |       (c)-[:`$relationshipType` {cost: 40}]->(d),
+         |       (c)-[:`$relationshipType` {cost: 80}]->(e),
+         |       (d)-[:`$relationshipType` {cost: 30}]->(e),
+         |       (d)-[:`$relationshipType` {cost: 80}]->(f),
+         |       (e)-[:`$relationshipType` {cost: 40}]->(f);
+         |""".stripMargin
     ).execute()
     spark.read.format(classOf[DataSource].getName)
       .option("gds", "gds.graph.project")
-      .option("gds.graphName", "myGraph")
-      .option("gds.nodeProjection", "Location")
-      .option("gds.relationshipProjection", "ROAD")
+      .option("gds.graphName", graphName)
+      .option("gds.nodeProjection", nodeLabel)
+      .option("gds.relationshipProjection", relationshipType)
       .option("gds.configuration.relationshipProperties", "cost")
       .load()
       .count()

--- a/src/test/scala/org/neo4j/spark/GraphDataScienceIT.scala
+++ b/src/test/scala/org/neo4j/spark/GraphDataScienceIT.scala
@@ -25,10 +25,7 @@ import org.apache.spark.sql.types._
 import org.assertj.core.api.Assertions.assertThat
 import org.assertj.core.api.Assertions.assertThatExceptionOfType
 import org.assertj.core.api.Assertions.assertThatThrownBy
-import org.junit.jupiter.api.AfterAll
-import org.junit.jupiter.api.Assumptions
 import org.junit.jupiter.api.Assumptions.assumeTrue
-import org.junit.jupiter.api.BeforeAll
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.DisplayName
 import org.junit.jupiter.api.Test

--- a/src/test/scala/org/neo4j/spark/ReadIT.scala
+++ b/src/test/scala/org/neo4j/spark/ReadIT.scala
@@ -25,9 +25,7 @@ import org.apache.spark.sql.types.StructField
 import org.apache.spark.sql.types.StructType
 import org.assertj.core.api.Assertions.assertThat
 import org.assertj.core.api.Assertions.assertThatExceptionOfType
-import org.junit.jupiter.api.AfterAll
 import org.junit.jupiter.api.Assumptions
-import org.junit.jupiter.api.BeforeAll
 import org.junit.jupiter.api.Disabled
 import org.junit.jupiter.api.DisplayName
 import org.junit.jupiter.api.Nested
@@ -44,7 +42,6 @@ import org.neo4j.driver.QueryConfig
 import org.neo4j.driver.exceptions.ClientException
 import org.neo4j.spark.testsupport.InjectNeo4jContainerParameter
 import org.neo4j.spark.testsupport.Neo4jExtensions.DriverExtensions
-import org.neo4j.spark.testsupport.Neo4jExtensions.Neo4jContainerExtensions
 import org.neo4j.spark.util.Neo4jOptions
 import org.testcontainers.neo4j.Neo4jContainer
 

--- a/src/test/scala/org/neo4j/spark/ReadIT.scala
+++ b/src/test/scala/org/neo4j/spark/ReadIT.scala
@@ -25,24 +25,24 @@ import org.apache.spark.sql.types.StructField
 import org.apache.spark.sql.types.StructType
 import org.assertj.core.api.Assertions.assertThat
 import org.assertj.core.api.Assertions.assertThatExceptionOfType
-import org.junit.jupiter.api.AfterEach
+import org.junit.jupiter.api.AfterAll
 import org.junit.jupiter.api.Assumptions
-import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.BeforeAll
+import org.junit.jupiter.api.Disabled
 import org.junit.jupiter.api.DisplayName
 import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
-import org.junit.jupiter.api.TestInstance
+import org.junit.jupiter.api.parallel.Execution
+import org.junit.jupiter.api.parallel.ExecutionMode
 import org.junit.jupiter.api.util.ClearSystemProperty
-import org.junit.jupiter.api.util.SetSystemProperty
 import org.junit.jupiter.params.Parameter
-import org.junit.jupiter.params.ParameterizedClass
 import org.junit.jupiter.params.ParameterizedTest
-import org.junit.jupiter.params.provider.ArgumentsSource
 import org.junit.jupiter.params.provider.ValueSource
+import org.neo4j.caniuse.Neo4j
 import org.neo4j.driver.Driver
 import org.neo4j.driver.QueryConfig
 import org.neo4j.driver.exceptions.ClientException
-import org.neo4j.spark.testsupport.Neo4jContainerProvider
+import org.neo4j.spark.testsupport.InjectNeo4jContainerParameter
 import org.neo4j.spark.testsupport.Neo4jExtensions.DriverExtensions
 import org.neo4j.spark.testsupport.Neo4jExtensions.Neo4jContainerExtensions
 import org.neo4j.spark.util.Neo4jOptions
@@ -57,48 +57,25 @@ import java.time.OffsetDateTime
 import java.time.OffsetTime
 import java.time.ZoneOffset
 import java.util.TimeZone
+import java.util.UUID
 
 import scala.collection.immutable
 import scala.collection.mutable
 import scala.jdk.CollectionConverters.IterableHasAsJava
 import scala.jdk.CollectionConverters.ListHasAsScala
 
-@TestInstance(TestInstance.Lifecycle.PER_CLASS)
-@ParameterizedClass(name = "{argumentSetName}")
-@ArgumentsSource(classOf[Neo4jContainerProvider])
+@InjectNeo4jContainerParameter
 @DisplayName("reading")
-@SetSystemProperty(key = "strict.cypher", value = "true")
 class ReadIT {
 
   @Parameter
   var neo4jContainer: Neo4jContainer = _
 
-  var driver: Driver = _
-
-  var spark: SparkSession = _
-
-  @BeforeEach
-  def prepare(): Unit = {
-    if (!neo4jContainer.isRunning) {
-      neo4jContainer.start()
-    }
-    driver = neo4jContainer.driver()
-    driver.createOrReplaceDatabase("neo4j")
-    spark = neo4jContainer.spark()
-  }
-
-  @AfterEach
-  def cleanUp(): Unit = {
-    if (spark != null) {
-      spark.close()
-    }
-    if (driver != null) {
-      driver.close()
-    }
-  }
+  private def uniqueViewName(prefix: String): String =
+    s"${prefix}_${UUID.randomUUID().toString.replace("-", "")}"
 
   @Test
-  def throws_exception_if_no_valid_read_option_is_set(): Unit = {
+  def throws_exception_if_no_valid_read_option_is_set(driver: Driver, spark: SparkSession, neo4j: Neo4j): Unit = {
     assertThatExceptionOfType(classOf[IllegalArgumentException])
       .isThrownBy(() => {
         spark.read.format(classOf[DataSource].getName)
@@ -108,7 +85,7 @@ class ReadIT {
   }
 
   @Test
-  def throws_exception_if_two_valid_read_options_are_set(): Unit = {
+  def throws_exception_if_two_valid_read_options_are_set(driver: Driver, spark: SparkSession, neo4j: Neo4j): Unit = {
     assertThatExceptionOfType(classOf[IllegalArgumentException])
       .isThrownBy(() => {
         spark.read.format(classOf[DataSource].getName)
@@ -120,7 +97,7 @@ class ReadIT {
   }
 
   @Test
-  def throws_exception_when_cypher_version_invalid(): Unit = {
+  def throws_exception_when_cypher_version_invalid(driver: Driver, spark: SparkSession, neo4j: Neo4j): Unit = {
     assertThatExceptionOfType(classOf[IllegalArgumentException])
       .isThrownBy(() => {
         spark.read.format(classOf[DataSource].getName)
@@ -133,10 +110,11 @@ class ReadIT {
 
   @Nested
   @DisplayName("by node labels")
+  @Execution(ExecutionMode.SAME_THREAD)
   class ByNodeLabels {
 
     @Test
-    def returns_element_id(): Unit = {
+    def returns_element_id(driver: Driver, spark: SparkSession, neo4j: Neo4j): Unit = {
       driver.executableQuery(s"CREATE (:Person {name: 'John'})").execute()
 
       val df = spark.read.format(classOf[DataSource].getName)
@@ -148,7 +126,7 @@ class ReadIT {
     }
 
     @Test
-    def returns_labels(): Unit = {
+    def returns_labels(driver: Driver, spark: SparkSession, neo4j: Neo4j): Unit = {
       driver.executableQuery(s"CREATE (:Person:Customer {name: 'John'})").execute()
 
       val df = spark.read.format(classOf[DataSource].getName)
@@ -161,7 +139,7 @@ class ReadIT {
     }
 
     @Test
-    def supports_unconventional_labels(): Unit = {
+    def supports_unconventional_labels(driver: Driver, spark: SparkSession, neo4j: Neo4j): Unit = {
       driver.executableQuery(s"CREATE (:`Foo Bar`:Person:`(╯°□°）╯︵ ┻━┻`  {name: 'John'})").execute()
 
       val df = spark.read.format(classOf[DataSource].getName)
@@ -173,7 +151,8 @@ class ReadIT {
     }
 
     @Test
-    def supports_joins_from_two_different_databases(): Unit = {
+    @Disabled("Disabled while the shared test containers keep a low database cap")
+    def supports_joins_from_two_different_databases(driver: Driver, spark: SparkSession, neo4j: Neo4j): Unit = {
       driver.createOrReplaceDatabase("db1")
       driver.executableQuery(
         """
@@ -204,7 +183,7 @@ class ReadIT {
     }
 
     @Test
-    def returns_selected_string_column(): Unit = {
+    def returns_selected_string_column(driver: Driver, spark: SparkSession, neo4j: Neo4j): Unit = {
       driver.executableQuery(s"CREATE (:Person {name: 'John'})").execute()
 
       val df = spark.read.format(classOf[DataSource].getName)
@@ -215,7 +194,7 @@ class ReadIT {
     }
 
     @Test
-    def returns_selected_long_column(): Unit = {
+    def returns_selected_long_column(driver: Driver, spark: SparkSession, neo4j: Neo4j): Unit = {
       driver.executableQuery(s"CREATE (:Person {age: 42})").execute()
 
       val df = spark.read.format(classOf[DataSource].getName)
@@ -226,7 +205,7 @@ class ReadIT {
     }
 
     @Test
-    def returns_selected_double_column(): Unit = {
+    def returns_selected_double_column(driver: Driver, spark: SparkSession, neo4j: Neo4j): Unit = {
       driver.executableQuery(s"CREATE (:Person {score: 3.14})").execute()
 
       val df = spark.read.format(classOf[DataSource].getName)
@@ -237,7 +216,7 @@ class ReadIT {
     }
 
     @Test
-    def returns_selected_localtime_column(): Unit = {
+    def returns_selected_localtime_column(driver: Driver, spark: SparkSession, neo4j: Neo4j): Unit = {
       driver.executableQuery(
         s"CREATE (:Person {aTime: localtime({hour:12, minute: 23, second: 0, millisecond: 294})})"
       ).execute()
@@ -252,7 +231,7 @@ class ReadIT {
     }
 
     @Test
-    def returns_selected_time_column(): Unit = {
+    def returns_selected_time_column(driver: Driver, spark: SparkSession, neo4j: Neo4j): Unit = {
       val timezone = TimeZone.getDefault
       driver.executableQuery(
         s"CREATE (:Person {aTime: time({hour:12, minute: 23, second: 0, millisecond: 294})})"
@@ -270,7 +249,7 @@ class ReadIT {
     }
 
     @Test
-    def returns_selected_localdatetime_column(): Unit = {
+    def returns_selected_localdatetime_column(driver: Driver, spark: SparkSession, neo4j: Neo4j): Unit = {
       driver.executableQuery("CREATE (:Person {aTime: localdatetime('2007-12-03T10:15:30')})").execute()
 
       val df = spark.read.format(classOf[DataSource].getName)
@@ -282,7 +261,7 @@ class ReadIT {
     }
 
     @Test
-    def returns_selected_zoneddatetime_column(): Unit = {
+    def returns_selected_zoneddatetime_column(driver: Driver, spark: SparkSession, neo4j: Neo4j): Unit = {
       driver.executableQuery("CREATE (:Person {aTime: datetime('2015-06-24T12:50:35.556+01:00')})").execute()
 
       val df = spark.read.format(classOf[DataSource].getName)
@@ -294,7 +273,7 @@ class ReadIT {
     }
 
     @Test
-    def returns_selected_date_column(): Unit = {
+    def returns_selected_date_column(driver: Driver, spark: SparkSession, neo4j: Neo4j): Unit = {
       driver.executableQuery(s"CREATE (:Person {born: date('2009-10-10')})").execute()
 
       val df = spark.read.format(classOf[DataSource].getName)
@@ -307,7 +286,7 @@ class ReadIT {
     }
 
     @Test
-    def returns_selected_duration_column(): Unit = {
+    def returns_selected_duration_column(driver: Driver, spark: SparkSession, neo4j: Neo4j): Unit = {
       driver.executableQuery(s"CREATE (:Person {range: duration({days: 14, hours:16, minutes: 12})})").execute()
 
       val df = spark.read.format(classOf[DataSource].getName)
@@ -325,7 +304,7 @@ class ReadIT {
     }
 
     @Test
-    def returns_selected_point_column(): Unit = {
+    def returns_selected_point_column(driver: Driver, spark: SparkSession, neo4j: Neo4j): Unit = {
       driver.executableQuery(s"CREATE (:Person {location: point({x: 12.12, y: 13.13})})").execute()
 
       val df = spark.read.format(classOf[DataSource].getName)
@@ -340,7 +319,7 @@ class ReadIT {
     }
 
     @Test
-    def returns_selected_geospatial_point_column(): Unit = {
+    def returns_selected_geospatial_point_column(driver: Driver, spark: SparkSession, neo4j: Neo4j): Unit = {
       driver.executableQuery(s"CREATE (:Person {location: point({longitude: 12.12, latitude: 13.13})})").execute()
 
       val df = spark.read.format(classOf[DataSource].getName)
@@ -355,7 +334,7 @@ class ReadIT {
     }
 
     @Test
-    def returns_selected_3d_point_column(): Unit = {
+    def returns_selected_3d_point_column(driver: Driver, spark: SparkSession, neo4j: Neo4j): Unit = {
       driver.executableQuery(s"CREATE (:Person {location: point({x: 12.12, y: 13.13, z: 1})})").execute()
 
       val df = spark.read.format(classOf[DataSource].getName)
@@ -371,7 +350,7 @@ class ReadIT {
     }
 
     @Test
-    def returns_selected_string_array_column(): Unit = {
+    def returns_selected_string_array_column(driver: Driver, spark: SparkSession, neo4j: Neo4j): Unit = {
       driver.executableQuery(s"CREATE (:Person {names: ['John', 'Doe']})").execute()
 
       val df = spark.read.format(classOf[DataSource].getName)
@@ -384,7 +363,7 @@ class ReadIT {
     }
 
     @Test
-    def returns_selected_long_array_column(): Unit = {
+    def returns_selected_long_array_column(driver: Driver, spark: SparkSession, neo4j: Neo4j): Unit = {
       driver.executableQuery(s"CREATE (:Person {ages: [22, 23]})").execute()
 
       val df = spark.read.format(classOf[DataSource].getName)
@@ -397,7 +376,7 @@ class ReadIT {
     }
 
     @Test
-    def returns_selected_double_array_column(): Unit = {
+    def returns_selected_double_array_column(driver: Driver, spark: SparkSession, neo4j: Neo4j): Unit = {
       driver.executableQuery(s"CREATE (:Person {scores: [22.33, 44.55]})").execute()
 
       val df = spark.read.format(classOf[DataSource].getName)
@@ -410,7 +389,7 @@ class ReadIT {
     }
 
     @Test
-    def returns_selected_datetime_array_column(): Unit = {
+    def returns_selected_datetime_array_column(driver: Driver, spark: SparkSession, neo4j: Neo4j): Unit = {
       driver.executableQuery(
         s"CREATE (p:Person {someTimes: [datetime('2010-10-10T11:13:37+01:00'), datetime('2011-11-11T10:13:37Z')]})"
       ).execute()
@@ -425,7 +404,7 @@ class ReadIT {
     }
 
     @Test
-    def returns_selected_localtime_array_column(): Unit = {
+    def returns_selected_localtime_array_column(driver: Driver, spark: SparkSession, neo4j: Neo4j): Unit = {
       driver.executableQuery(
         s"CREATE (:Person {someTimes: [localtime({hour:12}), localtime({hour:1, minute: 3})]})"
       ).execute()
@@ -444,7 +423,7 @@ class ReadIT {
     }
 
     @Test
-    def returns_selected_boolean_array_column(): Unit = {
+    def returns_selected_boolean_array_column(driver: Driver, spark: SparkSession, neo4j: Neo4j): Unit = {
       driver.executableQuery(s"CREATE (:Person {bools: [true, false]})").execute()
 
       val df = spark.read.format(classOf[DataSource].getName)
@@ -457,7 +436,7 @@ class ReadIT {
     }
 
     @Test
-    def returns_selected_point_array_column(): Unit = {
+    def returns_selected_point_array_column(driver: Driver, spark: SparkSession, neo4j: Neo4j): Unit = {
       driver.executableQuery(
         s"CREATE (:Person {locations: [point({x: 11, y: 33.111}), point({x: 22, y: 44.222})]})"
       ).execute()
@@ -480,7 +459,7 @@ class ReadIT {
     }
 
     @Test
-    def returns_selected_geospatial_array_column(): Unit = {
+    def returns_selected_geospatial_array_column(driver: Driver, spark: SparkSession, neo4j: Neo4j): Unit = {
       driver.executableQuery(
         s"CREATE (:Person {locations: [point({longitude: 11, latitude: 33.111}), point({longitude: 22, latitude: 44.222})]})"
       ).execute()
@@ -503,7 +482,7 @@ class ReadIT {
     }
 
     @Test
-    def returns_selected_3d_array_column(): Unit = {
+    def returns_selected_3d_array_column(driver: Driver, spark: SparkSession, neo4j: Neo4j): Unit = {
       driver.executableQuery(
         s"CREATE (:Person {locations: [point({x: 11, y: 33.111, z: 12}), point({x: 22, y: 44.222, z: 99.1})]})"
       ).execute()
@@ -528,7 +507,7 @@ class ReadIT {
     }
 
     @Test
-    def returns_selected_date_array_column(): Unit = {
+    def returns_selected_date_array_column(driver: Driver, spark: SparkSession, neo4j: Neo4j): Unit = {
       driver.executableQuery(s"CREATE (:Person {dates: [date('2009-10-10'), date('2009-10-11')]})").execute()
 
       val df = spark.read.format(classOf[DataSource].getName)
@@ -541,7 +520,7 @@ class ReadIT {
     }
 
     @Test
-    def returns_selected_zoneddatetime_array_column(): Unit = {
+    def returns_selected_zoneddatetime_array_column(driver: Driver, spark: SparkSession, neo4j: Neo4j): Unit = {
       driver.executableQuery(
         """
        CREATE (:Person {aTime: [
@@ -561,7 +540,7 @@ class ReadIT {
     }
 
     @Test
-    def returns_selected_duration_array_column(): Unit = {
+    def returns_selected_duration_array_column(driver: Driver, spark: SparkSession, neo4j: Neo4j): Unit = {
       driver.executableQuery(
         s"CREATE (:Person {durations: [duration({months: 0.75}), duration({weeks: 2.5})]})"
       ).execute()
@@ -588,7 +567,7 @@ class ReadIT {
     }
 
     @Test
-    def returns_selected_byte_array_column(): Unit = {
+    def returns_selected_byte_array_column(driver: Driver, spark: SparkSession, neo4j: Neo4j): Unit = {
       val bytes = "hello, world!".map(_.toByte).toArray
       val parameters = new java.util.HashMap[String, Object]()
       parameters.put("bytes", bytes)
@@ -608,7 +587,7 @@ class ReadIT {
     }
 
     @Test
-    def returns_selected_field_with_unconventional_name(): Unit = {
+    def returns_selected_field_with_unconventional_name(driver: Driver, spark: SparkSession, neo4j: Neo4j): Unit = {
       driver.executableQuery(
         s"""UNWIND range(1, 100) as id
            |CREATE (:Product {id: id, `(╯°□°)╯︵ ┻━┻`: 'Product ' + id})
@@ -626,7 +605,7 @@ class ReadIT {
     }
 
     @Test
-    def returns_results_filtered_with_string_value_equality(): Unit = {
+    def returns_results_filtered_with_string_value_equality(driver: Driver, spark: SparkSession, neo4j: Neo4j): Unit = {
       driver.executableQuery(
         s"""UNWIND range(1, 100) as id
            |CREATE (:Product {id: id, name: 'Product ' + id})
@@ -646,7 +625,7 @@ class ReadIT {
     }
 
     @Test
-    def returns_results_filtered_with_date_value_equality(): Unit = {
+    def returns_results_filtered_with_date_value_equality(driver: Driver, spark: SparkSession, neo4j: Neo4j): Unit = {
       driver.executableQuery(s"""
        CREATE (:Person {birth: date('1998-02-04')}),
         (:Person {birth: date('1988-01-05')})
@@ -665,7 +644,11 @@ class ReadIT {
     }
 
     @Test
-    def returns_results_filtered_with_string_negated_equality(): Unit = {
+    def returns_results_filtered_with_string_negated_equality(
+      driver: Driver,
+      spark: SparkSession,
+      neo4j: Neo4j
+    ): Unit = {
       driver.executableQuery("CREATE (:Person {name: 'John Doe'}), (:Person {name: 'Jane Doe'})")
         .execute()
 
@@ -682,7 +665,7 @@ class ReadIT {
     }
 
     @Test
-    def returns_results_filtered_with_date_negated_equality(): Unit = {
+    def returns_results_filtered_with_date_negated_equality(driver: Driver, spark: SparkSession, neo4j: Neo4j): Unit = {
       driver.executableQuery("CREATE (:Person {birth: date('1998-02-04')}), (:Person {birth: date('1988-01-05')})")
         .execute()
 
@@ -699,7 +682,7 @@ class ReadIT {
     }
 
     @Test
-    def returns_results_filtered_with_string_difference(): Unit = {
+    def returns_results_filtered_with_string_difference(driver: Driver, spark: SparkSession, neo4j: Neo4j): Unit = {
       driver.executableQuery("CREATE (:Person {name: 'John Doe'}), (:Person {name: 'Jane Doe'})")
         .execute()
 
@@ -716,7 +699,11 @@ class ReadIT {
     }
 
     @Test
-    def returns_results_filtered_with_long_greater_comparison(): Unit = {
+    def returns_results_filtered_with_long_greater_comparison(
+      driver: Driver,
+      spark: SparkSession,
+      neo4j: Neo4j
+    ): Unit = {
       driver.executableQuery(s"""
        CREATE (:Person {age: 19}),
         (:Person {age: 20}),
@@ -736,7 +723,11 @@ class ReadIT {
     }
 
     @Test
-    def returns_results_filtered_with_timestamp_greater_comparison(): Unit = {
+    def returns_results_filtered_with_timestamp_greater_comparison(
+      driver: Driver,
+      spark: SparkSession,
+      neo4j: Neo4j
+    ): Unit = {
       driver.executableQuery("""
        CREATE (:Person {birth: localdatetime('2007-12-03T10:15:30')}),
         (:Person {birth: localdatetime('2007-12-03T10:15:30')})
@@ -753,7 +744,11 @@ class ReadIT {
     }
 
     @Test
-    def returns_results_filtered_with_long_strict_greater_comparison(): Unit = {
+    def returns_results_filtered_with_long_strict_greater_comparison(
+      driver: Driver,
+      spark: SparkSession,
+      neo4j: Neo4j
+    ): Unit = {
       driver.executableQuery(
         s"""
        CREATE (:Person {age: 19}),
@@ -775,7 +770,11 @@ class ReadIT {
     }
 
     @Test
-    def returns_results_filtered_with_date_strict_greater_comparison(): Unit = {
+    def returns_results_filtered_with_date_strict_greater_comparison(
+      driver: Driver,
+      spark: SparkSession,
+      neo4j: Neo4j
+    ): Unit = {
       driver.executableQuery(
         s"""
        CREATE (:Person {birth: date('1998-02-04')}),
@@ -800,7 +799,11 @@ class ReadIT {
     }
 
     @Test
-    def returns_results_filtered_with_geospatial_point_strict_greater_comparison(): Unit = {
+    def returns_results_filtered_with_geospatial_point_strict_greater_comparison(
+      driver: Driver,
+      spark: SparkSession,
+      neo4j: Neo4j
+    ): Unit = {
       driver.executableQuery(
         s"""
        CREATE (:Person {location: point({x: 12, y: 12})}),
@@ -825,7 +828,11 @@ class ReadIT {
     }
 
     @Test
-    def returns_results_filtered_with_long_lesser_comparison(): Unit = {
+    def returns_results_filtered_with_long_lesser_comparison(
+      driver: Driver,
+      spark: SparkSession,
+      neo4j: Neo4j
+    ): Unit = {
       driver.executableQuery(
         s"""
        CREATE (:Person {age: 39}),
@@ -846,7 +853,11 @@ class ReadIT {
     }
 
     @Test
-    def returns_results_filtered_with_long_strict_lesser_comparison(): Unit = {
+    def returns_results_filtered_with_long_strict_lesser_comparison(
+      driver: Driver,
+      spark: SparkSession,
+      neo4j: Neo4j
+    ): Unit = {
       driver.executableQuery(
         s"""
        CREATE (:Person {age: 39}),
@@ -867,7 +878,7 @@ class ReadIT {
     }
 
     @Test
-    def returns_results_filtered_in_long_collection(): Unit = {
+    def returns_results_filtered_in_long_collection(driver: Driver, spark: SparkSession, neo4j: Neo4j): Unit = {
       driver.executableQuery(
         s"""
        CREATE (:Person {age: 39}),
@@ -888,7 +899,7 @@ class ReadIT {
     }
 
     @Test
-    def returns_results_filtered_as_nullable(): Unit = {
+    def returns_results_filtered_as_nullable(driver: Driver, spark: SparkSession, neo4j: Neo4j): Unit = {
       driver.executableQuery(
         s"""
        CREATE (:Person {age: 39}),
@@ -909,7 +920,7 @@ class ReadIT {
     }
 
     @Test
-    def returns_results_filtered_as_not_nullable(): Unit = {
+    def returns_results_filtered_as_not_nullable(driver: Driver, spark: SparkSession, neo4j: Neo4j): Unit = {
       driver.executableQuery(
         s"""
        CREATE (:Person {age: 39}),
@@ -931,7 +942,7 @@ class ReadIT {
     }
 
     @Test
-    def returns_results_filtered_with_ORed_equalities(): Unit = {
+    def returns_results_filtered_with_ORed_equalities(driver: Driver, spark: SparkSession, neo4j: Neo4j): Unit = {
       driver.executableQuery(
         s"""
        CREATE (:Person {age: 39}),
@@ -953,7 +964,7 @@ class ReadIT {
     }
 
     @Test
-    def returns_results_filtered_with_ANDed_comparisons(): Unit = {
+    def returns_results_filtered_with_ANDed_comparisons(driver: Driver, spark: SparkSession, neo4j: Neo4j): Unit = {
       driver.executableQuery(
         s"""
        CREATE (:Person {age: 39}),
@@ -975,7 +986,7 @@ class ReadIT {
     }
 
     @Test
-    def returns_results_filtered_with_string_prefix(): Unit = {
+    def returns_results_filtered_with_string_prefix(driver: Driver, spark: SparkSession, neo4j: Neo4j): Unit = {
       driver.executableQuery(
         s"""
        CREATE (:Person {name: 'John Mayer'}),
@@ -997,7 +1008,7 @@ class ReadIT {
     }
 
     @Test
-    def returns_results_filtered_with_string_suffix(): Unit = {
+    def returns_results_filtered_with_string_suffix(driver: Driver, spark: SparkSession, neo4j: Neo4j): Unit = {
       driver.executableQuery(
         s"""
        CREATE (:Person {name: 'John Mayer'}),
@@ -1019,7 +1030,7 @@ class ReadIT {
     }
 
     @Test
-    def returns_results_filtered_with_substring_suffix(): Unit = {
+    def returns_results_filtered_with_substring_suffix(driver: Driver, spark: SparkSession, neo4j: Neo4j): Unit = {
       driver.executableQuery(
         s"""
        CREATE (:Person {name: 'John Mayer'}),
@@ -1041,7 +1052,7 @@ class ReadIT {
     }
 
     @Test
-    def throws_exception_when_wrong_database_is_provided(): Unit = {
+    def throws_exception_when_wrong_database_is_provided(driver: Driver, spark: SparkSession, neo4j: Neo4j): Unit = {
       assertThatExceptionOfType(classOf[ClientException])
         .isThrownBy(() => {
           spark.read.format(classOf[DataSource].getName)
@@ -1053,7 +1064,7 @@ class ReadIT {
     }
 
     @Test
-    def supports_heterogeneous_schemas_for_same_label_nodes(): Unit = {
+    def supports_heterogeneous_schemas_for_same_label_nodes(driver: Driver, spark: SparkSession, neo4j: Neo4j): Unit = {
       driver.executableQuery("CREATE (:Person {id: 1, field: [12,34]}), (:Person {id: 2, field: 123})").execute()
 
       val df = spark.read.format(classOf[DataSource].getName)
@@ -1067,7 +1078,11 @@ class ReadIT {
     }
 
     @Test
-    def supports_heterogeneous_schemas_for_nodes_with_multiple_labels(): Unit = {
+    def supports_heterogeneous_schemas_for_nodes_with_multiple_labels(
+      driver: Driver,
+      spark: SparkSession,
+      neo4j: Neo4j
+    ): Unit = {
       driver.executableQuery(s"""CREATE (:Person { prop: 25 }),
                                 |(:Person:Player { prop: "hello" }),
                                 |(:Person:Player:Weirdo { prop: true })
@@ -1082,7 +1097,11 @@ class ReadIT {
     }
 
     @Test
-    def returns_same_properties_for_nodes_with_multiple_labels(): Unit = {
+    def returns_same_properties_for_nodes_with_multiple_labels(
+      driver: Driver,
+      spark: SparkSession,
+      neo4j: Neo4j
+    ): Unit = {
       driver.executableQuery(
         s"""CREATE (actor:Person:Actor {name: 'Keanu Reeves', born: 1964, actor: true})
            |CREATE (soccerPlayer:Person:SoccerPlayer {name: 'Zlatan Ibrahimović', born: 1981, soccerPlayer: true})
@@ -1100,7 +1119,7 @@ class ReadIT {
     }
 
     @Test
-    def supports_repartitioning(): Unit = {
+    def supports_repartitioning(driver: Driver, spark: SparkSession, neo4j: Neo4j): Unit = {
       driver.executableQuery("""UNWIND range(1,100) as id
                                |CREATE (p:Person {id:id,ids:[id,id]}) WITH collect(p) as people
                                |UNWIND people as p1
@@ -1119,7 +1138,7 @@ class ReadIT {
     }
 
     @Test
-    def supports_custom_partitions(): Unit = {
+    def supports_custom_partitions(driver: Driver, spark: SparkSession, neo4j: Neo4j): Unit = {
       driver.executableQuery("""UNWIND range(1,100) as id
                                |CREATE (:Person:Customer {id: id, name: 'Person ' + id})
       """.stripMargin).execute()
@@ -1143,7 +1162,7 @@ class ReadIT {
     }
 
     @Test
-    def supports_limit(): Unit = {
+    def supports_limit(driver: Driver, spark: SparkSession, neo4j: Neo4j): Unit = {
       driver.executableQuery(s"""UNWIND range(1, 100) as id
                                 |CREATE (:Product {id: id, name: 'Product ' + id})""".stripMargin)
         .execute()
@@ -1160,10 +1179,11 @@ class ReadIT {
 
   @Nested
   @DisplayName("by relationship type")
+  @Execution(ExecutionMode.SAME_THREAD)
   class ByRelationshipType {
 
     @Test
-    def returns_only_selected_field(): Unit = {
+    def returns_only_selected_field(driver: Driver, spark: SparkSession, neo4j: Neo4j): Unit = {
       driver.executableQuery(
         s"""UNWIND range(1, 100) as id
            |CREATE (pr:Product {id: id * rand(), name: 'Product ' + id})
@@ -1185,7 +1205,7 @@ class ReadIT {
     }
 
     @Test
-    def supports_selecting_relationship_builtin_field(): Unit = {
+    def supports_selecting_relationship_builtin_field(driver: Driver, spark: SparkSession, neo4j: Neo4j): Unit = {
       driver.executableQuery(
         s"""UNWIND range(1, 100) as id
            |CREATE (pr:Product {id: id * rand(), name: 'Product ' + id})
@@ -1207,7 +1227,11 @@ class ReadIT {
     }
 
     @Test
-    def returns_only_selected_field_with_unconventional_name(): Unit = {
+    def returns_only_selected_field_with_unconventional_name(
+      driver: Driver,
+      spark: SparkSession,
+      neo4j: Neo4j
+    ): Unit = {
       driver.executableQuery(
         s"""UNWIND range(1, 100) as id
            |CREATE (pr:Product {id: id * rand(), `(╯°□°)╯︵ ┻━┻`: 'Product ' + id})
@@ -1229,7 +1253,11 @@ class ReadIT {
     }
 
     @Test
-    def returns_results_filtered_with_source_and_target_attributes(): Unit = {
+    def returns_results_filtered_with_source_and_target_attributes(
+      driver: Driver,
+      spark: SparkSession,
+      neo4j: Neo4j
+    ): Unit = {
       driver.executableQuery(
         """UNWIND range(1,100) as id
           |CREATE (p:Person {id:id,ids:[id,id]}) WITH collect(p) as people
@@ -1254,7 +1282,11 @@ class ReadIT {
     }
 
     @Test
-    def returns_results_filtered_with_source_and_target_map_attributes(): Unit = {
+    def returns_results_filtered_with_source_and_target_map_attributes(
+      driver: Driver,
+      spark: SparkSession,
+      neo4j: Neo4j
+    ): Unit = {
       driver.executableQuery(
         """UNWIND range(1,100) as id
           |CREATE (p:Person {id:id,ids:[id,id]}) WITH collect(p) as people
@@ -1279,7 +1311,7 @@ class ReadIT {
     }
 
     @Test
-    def returns_results_filtered_with_target_attributes(): Unit = {
+    def returns_results_filtered_with_target_attributes(driver: Driver, spark: SparkSession, neo4j: Neo4j): Unit = {
       driver.executableQuery(
         s"""UNWIND range(1, 100) as id
            |CREATE (pr:Product {id: id, name: 'Product ' + id})
@@ -1306,7 +1338,11 @@ class ReadIT {
     }
 
     @Test
-    def supports_heterogeneous_schemas_for_property_value_types(): Unit = {
+    def supports_heterogeneous_schemas_for_property_value_types(
+      driver: Driver,
+      spark: SparkSession,
+      neo4j: Neo4j
+    ): Unit = {
       driver.executableQuery(s"""CREATE (pr1:Product {id: '1'})
                                 |CREATE (pr2:Product {id: 2})
                                 |CREATE (pe1:Person {id: '3'})
@@ -1328,7 +1364,7 @@ class ReadIT {
     }
 
     @Test
-    def supports_custom_partitions(): Unit = {
+    def supports_custom_partitions(driver: Driver, spark: SparkSession, neo4j: Neo4j): Unit = {
       driver.executableQuery("""UNWIND range(1,100) as id
                                |CREATE (:Person {id: id, name: 'Person ' + id})-[:BOUGHT{quantity: ceil(rand() * 100)}]->(:Product{id: id, name: 'Product ' + id})
     """.stripMargin).execute()
@@ -1348,7 +1384,7 @@ class ReadIT {
     }
 
     @Test
-    def supports_flattening(): Unit = {
+    def supports_flattening(driver: Driver, spark: SparkSession, neo4j: Neo4j): Unit = {
       driver.executableQuery(s"""UNWIND range(1, 100) as id
                                 |CREATE (pr:Product {id: id * rand(), name: 'Product ' + id})
                                 |CREATE (pe:Person {id: id, fullName: 'Person ' + id})
@@ -1380,7 +1416,7 @@ class ReadIT {
     }
 
     @Test
-    def supports_nodes_as_map(): Unit = {
+    def supports_nodes_as_map(driver: Driver, spark: SparkSession, neo4j: Neo4j): Unit = {
       driver.executableQuery(s"""UNWIND range(1, 100) as id
                                 |CREATE (pr:Product {id: id * rand(), name: 'Product ' + id})
                                 |CREATE (pe:Person {id: id, fullName: 'Person ' + id})
@@ -1410,7 +1446,7 @@ class ReadIT {
     }
 
     @Test
-    def supports_limit(): Unit = {
+    def supports_limit(driver: Driver, spark: SparkSession, neo4j: Neo4j): Unit = {
       driver.executableQuery(s"""UNWIND range(1, 100) as id
                                 |CREATE (pr:Product {id: id * rand(), name: 'Product ' + id})
                                 |CREATE (pe:Person {id: id, fullName: 'Person ' + id})
@@ -1429,7 +1465,7 @@ class ReadIT {
     }
 
     @Test
-    def supports_limit_in_conjunction_with_ordering(): Unit = {
+    def supports_limit_in_conjunction_with_ordering(driver: Driver, spark: SparkSession, neo4j: Neo4j): Unit = {
       driver.executableQuery(s"""UNWIND range(1, 100) as id
                                 |CREATE (pr:Product {id: id * rand(), name: 'Product ' + id})
                                 |CREATE (pe:Person {id: id, fullName: 'Person ' + id})
@@ -1452,7 +1488,8 @@ class ReadIT {
     }
 
     @Test
-    def supports_SQL_sum_aggregation(): Unit = {
+    def supports_SQL_sum_aggregation(driver: Driver, spark: SparkSession, neo4j: Neo4j): Unit = {
+      val viewName = uniqueViewName("BOUGHT")
       driver.executableQuery(s"""CREATE (pe:Person {id: 1, fullName: 'Person'})-[:BOUGHT{when: rand(), quantity: rand() * 1000}]->(pr:Product {id: 0, name: 'Product ' + 0, price: 1})
                                 |WITH pe
                                 |UNWIND range(1, 10) as id
@@ -1467,12 +1504,12 @@ class ReadIT {
         .option("relationship", "BOUGHT")
         .option("relationship.target.labels", "Product")
         .load()
-        .createTempView("BOUGHT")
-      val df = spark.sql("""SELECT `source.fullName`,
-                           |   SUM(DISTINCT(`target.price`)) AS distinctTotal,
-                           |   SUM(`target.price`) AS total
-                           |FROM BOUGHT
-                           |group by `source.fullName`""".stripMargin)
+        .createTempView(viewName)
+      val df = spark.sql(s"""SELECT `source.fullName`,
+                            |   SUM(DISTINCT(`target.price`)) AS distinctTotal,
+                            |   SUM(`target.price`) AS total
+                            |FROM $viewName
+                            |group by `source.fullName`""".stripMargin)
 
       val rows = df.collectAsList()
       assertThat(rows).hasSize(1)
@@ -1483,7 +1520,8 @@ class ReadIT {
     }
 
     @Test
-    def supports_SQL_min_max_aggregation(): Unit = {
+    def supports_SQL_min_max_aggregation(driver: Driver, spark: SparkSession, neo4j: Neo4j): Unit = {
+      val viewName = uniqueViewName("BOUGHT")
       driver.executableQuery(s"""CREATE (pe:Person {id: 1, fullName: 'Person'})-[:BOUGHT{when: rand(), quantity: rand() * 1000}]->(pr:Product {id: 0, name: 'Product ' + 0, price: 1})
                                 |WITH pe
                                 |UNWIND range(1, 10) as id
@@ -1498,12 +1536,12 @@ class ReadIT {
         .option("relationship", "BOUGHT")
         .option("relationship.target.labels", "Product")
         .load()
-        .createTempView("BOUGHT")
-      val df = spark.sql("""SELECT `source.fullName`,
-                           |    MAX(`target.price`) AS max,
-                           |    MIN(`target.price`) AS min
-                           |FROM BOUGHT
-                           |GROUP BY `source.fullName`""".stripMargin)
+        .createTempView(viewName)
+      val df = spark.sql(s"""SELECT `source.fullName`,
+                            |    MAX(`target.price`) AS max,
+                            |    MIN(`target.price`) AS min
+                            |FROM $viewName
+                            |GROUP BY `source.fullName`""".stripMargin)
 
       val rows = df.collectAsList()
       assertThat(rows).hasSize(1)
@@ -1514,7 +1552,8 @@ class ReadIT {
     }
 
     @Test
-    def supports_SQL_count_aggregation(): Unit = {
+    def supports_SQL_count_aggregation(driver: Driver, spark: SparkSession, neo4j: Neo4j): Unit = {
+      val viewName = uniqueViewName("BOUGHT")
       driver.executableQuery(s"""CREATE (pe:Person {id: 1, fullName: 'Person'})-[:BOUGHT{when: rand(), quantity: rand() * 1000}]->(pr:Product {id: 1, name: 'Product ' + 0, price: 1})
                                 |WITH pe
                                 |UNWIND range(1, 10) as id
@@ -1529,12 +1568,12 @@ class ReadIT {
         .option("relationship", "BOUGHT")
         .option("relationship.target.labels", "Product")
         .load()
-        .createTempView("BOUGHT")
-      val df = spark.sql("""SELECT `source.fullName`,
-                           |    COUNT(DISTINCT(`target.id`)) AS distinctTotal,
-                           |    COUNT(`target.id`) AS total
-                           |FROM BOUGHT
-                           |group by `source.fullName`""".stripMargin)
+        .createTempView(viewName)
+      val df = spark.sql(s"""SELECT `source.fullName`,
+                            |    COUNT(DISTINCT(`target.id`)) AS distinctTotal,
+                            |    COUNT(`target.id`) AS total
+                            |FROM $viewName
+                            |group by `source.fullName`""".stripMargin)
 
       val rows = df.collectAsList()
       assertThat(rows).hasSize(1)
@@ -1548,10 +1587,11 @@ class ReadIT {
 
   @Nested
   @DisplayName("by query")
+  @Execution(ExecutionMode.SAME_THREAD)
   class ByQuery {
 
     @Test
-    def supports_returning_lists(): Unit = {
+    def supports_returning_lists(driver: Driver, spark: SparkSession, neo4j: Neo4j): Unit = {
       val df = spark.read.format(classOf[DataSource].getName)
         .option("query", "RETURN [1, 'foo'] AS list")
         .load()
@@ -1562,7 +1602,7 @@ class ReadIT {
     }
 
     @Test
-    def supports_returning_maps(): Unit = {
+    def supports_returning_maps(driver: Driver, spark: SparkSession, neo4j: Neo4j): Unit = {
       val df = spark.read.format(classOf[DataSource].getName)
         .option("query", "RETURN {a: 1, b: '3'} AS map")
         .load()
@@ -1573,7 +1613,7 @@ class ReadIT {
     }
 
     @Test
-    def supports_returning_list_of_maps(): Unit = {
+    def supports_returning_list_of_maps(driver: Driver, spark: SparkSession, neo4j: Neo4j): Unit = {
       val df = spark.read.format(classOf[DataSource].getName)
         .option("query", "RETURN [{a: 1, b: '3'}, {a: 'foo'}] AS listMap")
         .load()
@@ -1584,18 +1624,18 @@ class ReadIT {
     }
 
     @Test
-    def supports_calling_procedure(): Unit = {
+    def supports_calling_procedure(driver: Driver, spark: SparkSession, neo4j: Neo4j): Unit = {
       val df = spark.read.format(classOf[DataSource].getName)
         .option("query", "CALL db.info() YIELD name RETURN *")
         .load()
 
       val dbName = df.select("name").collectAsList().get(0).getString(0)
 
-      assertThat(dbName).isEqualTo("neo4j")
+      assertThat(dbName).startsWith("test-db")
     }
 
     @Test
-    def supports_calling_apoc_procedure(): Unit = {
+    def supports_calling_apoc_procedure(driver: Driver, spark: SparkSession, neo4j: Neo4j): Unit = {
       Assumptions.assumeTrue(driver.serverSupportsApoc())
 
       val df = spark.read.format(classOf[DataSource].getName)
@@ -1607,7 +1647,7 @@ class ReadIT {
     }
 
     @Test
-    def returns_only_selected_field(): Unit = {
+    def returns_only_selected_field(driver: Driver, spark: SparkSession, neo4j: Neo4j): Unit = {
       driver.executableQuery(
         s"""UNWIND range(1, 100) as id
            |CREATE (pr:Product {id: id * rand(), name: 'Product ' + id})
@@ -1629,7 +1669,7 @@ class ReadIT {
     }
 
     @Test
-    def returns_empty_dataset(): Unit = {
+    def returns_empty_dataset(driver: Driver, spark: SparkSession, neo4j: Neo4j): Unit = {
       val df = spark.read
         .format(classOf[DataSource].getName)
         .option("query", "MATCH (e:NotAnExistingLabel) RETURN elementId(e) as f, 1 as g")
@@ -1640,7 +1680,7 @@ class ReadIT {
     }
 
     @Test
-    def returns_ordered_results(): Unit = {
+    def returns_ordered_results(driver: Driver, spark: SparkSession, neo4j: Neo4j): Unit = {
       driver.executableQuery("CREATE (:Instrument {name: 'Drums', id: 1}), (:Instrument {name: 'Guitar', id: 2})")
         .execute()
 
@@ -1657,7 +1697,7 @@ class ReadIT {
     }
 
     @Test
-    def supports_complex_return_clauses(): Unit = {
+    def supports_complex_return_clauses(driver: Driver, spark: SparkSession, neo4j: Neo4j): Unit = {
       driver.executableQuery(
         s"""UNWIND range(1, 100) as id
            |CREATE (pr:Product {id: id * rand(), name: 'Product ' + id})
@@ -1686,7 +1726,7 @@ class ReadIT {
     }
 
     @Test
-    def supports_complex_return_clauses_on_empty_data_set(): Unit = {
+    def supports_complex_return_clauses_on_empty_data_set(driver: Driver, spark: SparkSession, neo4j: Neo4j): Unit = {
       val df = spark.read
         .format(classOf[DataSource].getName)
         .option(
@@ -1706,7 +1746,7 @@ class ReadIT {
     }
 
     @Test
-    def supports_custom_partitions(): Unit = {
+    def supports_custom_partitions(driver: Driver, spark: SparkSession, neo4j: Neo4j): Unit = {
       driver.executableQuery(
         """CREATE (pr:Product{id: 1, name: 'Product 1'})
           |WITH pr
@@ -1740,7 +1780,7 @@ class ReadIT {
     }
 
     @Test
-    def supports_filtering_on_nodes(): Unit = {
+    def supports_filtering_on_nodes(driver: Driver, spark: SparkSession, neo4j: Neo4j): Unit = {
       driver.executableQuery(s"""UNWIND range(1, 100) as id
                                 |CREATE (pr:Product {id: id * rand(), name: 'Product ' + id})
                                 |CREATE (pe:Person {id: id, fullName: 'Person ' + id})
@@ -1763,7 +1803,11 @@ class ReadIT {
     }
 
     @Test
-    def supports_filtering_on_complex_results_encoded_as_strings(): Unit = {
+    def supports_filtering_on_complex_results_encoded_as_strings(
+      driver: Driver,
+      spark: SparkSession,
+      neo4j: Neo4j
+    ): Unit = {
       driver.executableQuery(s"""UNWIND range(1, 100) as id
                                 |CREATE (pr:Product {id: id * rand(), name: 'Product ' + id})
                                 |CREATE (pe:Person {id: id, fullName: 'Person ' + id})
@@ -1790,7 +1834,7 @@ class ReadIT {
     }
 
     @Test
-    def supports_filtering_on_relationships(): Unit = {
+    def supports_filtering_on_relationships(driver: Driver, spark: SparkSession, neo4j: Neo4j): Unit = {
       driver.executableQuery(s"""UNWIND range(1, 100) as id
                                 |CREATE (pr:Product {id: id * rand(), name: 'Product ' + id})
                                 |CREATE (pe:Person {id: id, fullName: 'Person ' + id})
@@ -1819,7 +1863,7 @@ class ReadIT {
     }
 
     @Test
-    def supports_script_result_injection(): Unit = {
+    def supports_script_result_injection(driver: Driver, spark: SparkSession, neo4j: Neo4j): Unit = {
       val df = spark.read
         .format(classOf[DataSource].getName)
         .option("script", "RETURN 'foo' AS val")
@@ -1838,7 +1882,12 @@ class ReadIT {
     @ParameterizedTest
     @ValueSource(strings = Array("limit", "\nlimit", "LIMIT", "\nLIMIT", "lImIT", "\nlImIT"))
     @ClearSystemProperty(key = "strict.cypher")
-    def fails_if_limit_is_used_at_the_end_of_the_query(limitKeyword: String): Unit = {
+    def fails_if_limit_is_used_at_the_end_of_the_query(
+      limitKeyword: String,
+      driver: Driver,
+      spark: SparkSession,
+      neo4j: Neo4j
+    ): Unit = {
       assertThatExceptionOfType(classOf[IllegalArgumentException])
         .isThrownBy(() => {
           spark.read
@@ -1853,7 +1902,12 @@ class ReadIT {
 
     @ParameterizedTest
     @ValueSource(strings = Array("limit", "\nlimit", "LIMIT", "\nLIMIT", "lImIT", "\nlImIT"))
-    def supports_limit_keyword_when_not_at_the_end_of_the_query(limitKeyword: String): Unit = {
+    def supports_limit_keyword_when_not_at_the_end_of_the_query(
+      limitKeyword: String,
+      driver: Driver,
+      spark: SparkSession,
+      neo4j: Neo4j
+    ): Unit = {
       driver.executableQuery(s"""UNWIND range(1, 100) as id
                                 |CREATE (:Product {id: id, name: 'Product ' + id})""".stripMargin)
         .execute()
@@ -1867,7 +1921,7 @@ class ReadIT {
     }
 
     @Test
-    def supports_user_defined_schema(): Unit = {
+    def supports_user_defined_schema(driver: Driver, spark: SparkSession, neo4j: Neo4j): Unit = {
       driver.executableQuery("CREATE (p:Person {name: 'Foo Bar', age: 8})")
         .execute()
 
@@ -1882,7 +1936,7 @@ class ReadIT {
     }
 
     @Test
-    def supports_query_ordering(): Unit = {
+    def supports_query_ordering(driver: Driver, spark: SparkSession, neo4j: Neo4j): Unit = {
       driver.executableQuery("CREATE (p:Person {name: 'Foo Bar', age: 8})")
         .execute()
 
@@ -1896,7 +1950,7 @@ class ReadIT {
     }
 
     @Test // https://github.com/neo4j/neo4j-spark-connector/issues/531
-    def supports_nullable_datetime_properties(): Unit = {
+    def supports_nullable_datetime_properties(driver: Driver, spark: SparkSession, neo4j: Neo4j): Unit = {
       val df = spark.read
         .format(classOf[DataSource].getName)
         .option(
@@ -1923,7 +1977,7 @@ class ReadIT {
     }
 
     @Test // https://github.com/neo4j/neo4j-spark-connector/issues/531
-    def supports_nullable_datetime_properties_with_schema(): Unit = {
+    def supports_nullable_datetime_properties_with_schema(driver: Driver, spark: SparkSession, neo4j: Neo4j): Unit = {
       val df = spark.read
         .format(classOf[DataSource].getName)
         .schema(StructType(Array(

--- a/src/test/scala/org/neo4j/spark/StreamingIT.scala
+++ b/src/test/scala/org/neo4j/spark/StreamingIT.scala
@@ -22,22 +22,24 @@ import org.apache.spark.sql.execution.streaming.runtime.MemoryStream
 import org.apache.spark.sql.streaming.StreamingQuery
 import org.apache.spark.sql.streaming.Trigger
 import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.AfterAll
 import org.junit.jupiter.api.AfterEach
+import org.junit.jupiter.api.BeforeAll
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.DisplayName
 import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
-import org.junit.jupiter.api.TestInstance
 import org.junit.jupiter.api.io.TempDir
-import org.junit.jupiter.api.util.SetSystemProperty
+import org.junit.jupiter.api.parallel.Execution
+import org.junit.jupiter.api.parallel.ExecutionMode
 import org.junit.jupiter.params.Parameter
-import org.junit.jupiter.params.ParameterizedClass
-import org.junit.jupiter.params.provider.ArgumentsSource
+import org.neo4j.caniuse.Neo4j
 import org.neo4j.driver.Driver
 import org.neo4j.spark.testsupport.Assert
-import org.neo4j.spark.testsupport.Neo4jContainerProvider
+import org.neo4j.spark.testsupport.InjectNeo4jContainerParameter
 import org.neo4j.spark.testsupport.Neo4jExtensions.DriverExtensions
 import org.neo4j.spark.testsupport.Neo4jExtensions.Neo4jContainerExtensions
+import org.neo4j.spark.testsupport.StreamingTestState
 import org.testcontainers.neo4j.Neo4jContainer
 
 import java.nio.file.Files
@@ -47,13 +49,11 @@ import java.util.concurrent.TimeUnit
 
 import scala.collection.immutable
 import scala.collection.mutable
+import scala.jdk.CollectionConverters.MapHasAsJava
 import scala.jdk.CollectionConverters.SeqHasAsJava
 
-@TestInstance(TestInstance.Lifecycle.PER_CLASS)
-@ParameterizedClass(name = "{argumentSetName}")
-@ArgumentsSource(classOf[Neo4jContainerProvider])
+@InjectNeo4jContainerParameter
 @DisplayName("streaming")
-@SetSystemProperty(key = "strict.cypher", value = "true")
 class StreamingIT {
 
   @Parameter
@@ -62,13 +62,13 @@ class StreamingIT {
   @TempDir
   var folder: Path = _
 
-  var driver: Driver = _
+  private def query: StreamingQuery = StreamingTestState.current.query
 
-  var spark: SparkSession = _
+  private def query_=(value: StreamingQuery): Unit = {
+    StreamingTestState.current.query = value
+  }
 
-  private var query: StreamingQuery = _
-
-  private val createdTables = mutable.ListBuffer.empty[String]
+  private def createdTables: mutable.ListBuffer[String] = StreamingTestState.current.createdTables
 
   private val dataSourceFormat = classOf[DataSource].getName
 
@@ -76,38 +76,41 @@ class StreamingIT {
   private val OptFrom = "streaming.from"
   private val OptQueryOffset = "streaming.query.offset"
 
+  private def connectionOptions(spark: SparkSession): java.util.Map[String, String] =
+    Map(
+      "url" -> spark.conf.get("neo4j.url"),
+      "authentication.basic.username" -> spark.conf.get("neo4j.authentication.basic.username"),
+      "authentication.basic.password" -> spark.conf.get("neo4j.authentication.basic.password")
+    ).asJava
+
   @BeforeEach
   def prepare(): Unit = {
-    if (!neo4jContainer.isRunning) {
-      neo4jContainer.start()
-    }
-    driver = neo4jContainer.driver()
-    driver.createOrReplaceDatabase("neo4j")
-    spark = neo4jContainer.spark()
+    StreamingTestState.set()
   }
 
   @AfterEach
-  def cleanUp(): Unit = {
+  def cleanUp(spark: SparkSession): Unit = {
     Option(query).foreach(_.stop())
     Option(spark).foreach { session =>
       createdTables.foreach(table => session.sql(s"DROP TABLE IF EXISTS $table"))
       createdTables.clear()
-      session.close()
     }
-    Option(driver).foreach(_.close())
+    StreamingTestState.clear()
   }
 
   @Nested
   @DisplayName("from source")
+  @Execution(ExecutionMode.SAME_THREAD)
   class FromSource {
 
-    private val total = 60
+    private val total = 20
 
     @Test
-    def reads_nodes_from_now(): Unit = {
-      createMovieNodes(0, 1)
+    def reads_nodes_from_now(driver: Driver, spark: SparkSession, neo4j: Neo4j): Unit = {
+      createMovieNodes(driver, 0, 1)
 
       query = spark.readStream.format(dataSourceFormat)
+        .options(connectionOptions(spark))
         .option("labels", "Movie")
         .option(OptPropertyName, "timestamp")
         .option(OptFrom, "NOW")
@@ -117,7 +120,7 @@ class StreamingIT {
         .queryName("nodesFromNow")
         .start()
 
-      Executors.newSingleThreadExecutor().execute(() => createMovieNodes(1, total, 1000, 200))
+      Executors.newSingleThreadExecutor().execute(() => createMovieNodes(driver, 1, total, 1000, 25))
 
       val expected = (1 to total)
         .map(index => Map("<labels>" -> List("Movie"), "title" -> s"My movie $index"))
@@ -125,17 +128,18 @@ class StreamingIT {
 
       Assert.assertEventually(
         expected,
-        () => select("SELECT * FROM nodesFromNow ORDER BY timestamp", "<labels>", "title"),
+        () => select(spark, "SELECT * FROM nodesFromNow ORDER BY timestamp", "<labels>", "title"),
         30L,
         TimeUnit.SECONDS
       )
     }
 
     @Test
-    def reads_all_nodes(): Unit = {
-      createMovieNodes(0, 1)
+    def reads_all_nodes(driver: Driver, spark: SparkSession, neo4j: Neo4j): Unit = {
+      createMovieNodes(driver, 0, 1)
 
       query = spark.readStream.format(dataSourceFormat)
+        .options(connectionOptions(spark))
         .option("labels", "Movie")
         .option(OptPropertyName, "timestamp")
         .option(OptFrom, "ALL")
@@ -145,7 +149,7 @@ class StreamingIT {
         .queryName("allNodes")
         .start()
 
-      Executors.newSingleThreadExecutor().execute(() => createMovieNodes(1, total, 1000, 200))
+      Executors.newSingleThreadExecutor().execute(() => createMovieNodes(driver, 1, total, 1000, 25))
 
       val expected = (0 to total)
         .map(index => Map("<labels>" -> List("Movie"), "title" -> s"My movie $index"))
@@ -153,17 +157,18 @@ class StreamingIT {
 
       Assert.assertEventually(
         expected,
-        () => select("SELECT * FROM allNodes ORDER BY timestamp", "<labels>", "title"),
+        () => select(spark, "SELECT * FROM allNodes ORDER BY timestamp", "<labels>", "title"),
         30L,
         TimeUnit.SECONDS
       )
     }
 
     @Test
-    def resumes_reading_nodes_from_checkpoint(): Unit = {
-      createMovieNodes(0, 1)
+    def resumes_reading_nodes_from_checkpoint(driver: Driver, spark: SparkSession, neo4j: Neo4j): Unit = {
+      createMovieNodes(driver, 0, 1)
 
       val stream = spark.readStream.format(dataSourceFormat)
+        .options(connectionOptions(spark))
         .option("labels", "Movie")
         .option(OptPropertyName, "timestamp")
         .option(OptFrom, "NOW")
@@ -174,23 +179,24 @@ class StreamingIT {
       val partial = total / 2
 
       drainToTable(stream, location, table)
-      createMovieNodes(1, partial, 0, 10)
+      createMovieNodes(driver, 1, partial, 0, 10)
       drainToTable(stream, location, table)
-      createMovieNodes(partial + 1, total - partial, 0, 10)
+      createMovieNodes(driver, partial + 1, total - partial, 0, 10)
       drainToTable(stream, location, table)
 
       val expected = (1 to total)
         .map(index => Map("<labels>" -> List("Movie"), "title" -> s"My movie $index"))
         .toList
-      assertThat(select(s"SELECT * FROM $table ORDER BY timestamp", "<labels>", "title").asJava)
+      assertThat(select(spark, s"SELECT * FROM $table ORDER BY timestamp", "<labels>", "title").asJava)
         .containsExactlyElementsOf(expected.asJava)
     }
 
     @Test
-    def reads_relationships_from_now(): Unit = {
-      createLikesRelationships(0, 1)
+    def reads_relationships_from_now(driver: Driver, spark: SparkSession, neo4j: Neo4j): Unit = {
+      createLikesRelationships(driver, 0, 1)
 
       query = spark.readStream.format(dataSourceFormat)
+        .options(connectionOptions(spark))
         .option("relationship", "LIKES")
         .option("relationship.save.strategy", "native")
         .option(OptPropertyName, "timestamp")
@@ -203,13 +209,14 @@ class StreamingIT {
         .queryName("relationshipsFromNow")
         .start()
 
-      Executors.newSingleThreadExecutor().execute(() => createLikesRelationships(1, total, 1000, 200))
+      Executors.newSingleThreadExecutor().execute(() => createLikesRelationships(driver, 1, total, 1000, 25))
 
       val expected = (1 to total).map(likeRow).toList
       Assert.assertEventually(
         expected,
         () =>
           select(
+            spark,
             "SELECT * FROM relationshipsFromNow ORDER BY `rel.timestamp`",
             "<rel.type>",
             "<source.labels>",
@@ -224,10 +231,11 @@ class StreamingIT {
     }
 
     @Test
-    def reads_all_relationships(): Unit = {
-      createLikesRelationships(0, 1)
+    def reads_all_relationships(driver: Driver, spark: SparkSession, neo4j: Neo4j): Unit = {
+      createLikesRelationships(driver, 0, 1)
 
       query = spark.readStream.format(dataSourceFormat)
+        .options(connectionOptions(spark))
         .option("relationship", "LIKES")
         .option("relationship.save.strategy", "native")
         .option(OptPropertyName, "timestamp")
@@ -240,13 +248,14 @@ class StreamingIT {
         .queryName("allRelationships")
         .start()
 
-      Executors.newSingleThreadExecutor().execute(() => createLikesRelationships(1, total, 1000, 200))
+      Executors.newSingleThreadExecutor().execute(() => createLikesRelationships(driver, 1, total, 1000, 25))
 
       val expected = (0 to total).map(likeRow).toList
       Assert.assertEventually(
         expected,
         () =>
           select(
+            spark,
             "SELECT * FROM allRelationships ORDER BY `rel.timestamp`",
             "<rel.type>",
             "<source.labels>",
@@ -261,10 +270,11 @@ class StreamingIT {
     }
 
     @Test
-    def resumes_reading_relationships_from_checkpoint(): Unit = {
-      createLikesRelationships(0, 1)
+    def resumes_reading_relationships_from_checkpoint(driver: Driver, spark: SparkSession, neo4j: Neo4j): Unit = {
+      createLikesRelationships(driver, 0, 1)
 
       val stream = spark.readStream.format(dataSourceFormat)
+        .options(connectionOptions(spark))
         .option("relationship", "LIKES")
         .option("relationship.save.strategy", "native")
         .option(OptPropertyName, "timestamp")
@@ -278,13 +288,14 @@ class StreamingIT {
       val partial = total / 2
 
       drainToTable(stream, location, table)
-      createLikesRelationships(1, partial, 0, 10)
+      createLikesRelationships(driver, 1, partial, 0, 10)
       drainToTable(stream, location, table)
-      createLikesRelationships(partial + 1, total - partial, 0, 10)
+      createLikesRelationships(driver, partial + 1, total - partial, 0, 10)
       drainToTable(stream, location, table)
 
       val expected = (0 to total).map(likeRow).toList
       assertThat(select(
+        spark,
         s"SELECT * FROM $table ORDER BY `rel.timestamp`",
         "<rel.type>",
         "<source.labels>",
@@ -297,10 +308,11 @@ class StreamingIT {
     }
 
     @Test
-    def reads_query_results_from_now(): Unit = {
-      createPersonNodes(0, 1)
+    def reads_query_results_from_now(driver: Driver, spark: SparkSession, neo4j: Neo4j): Unit = {
+      createPersonNodes(driver, 0, 1)
 
       query = spark.readStream.format(dataSourceFormat)
+        .options(connectionOptions(spark))
         .option(OptFrom, "NOW")
         .option(OptPropertyName, "timestamp")
         .option("query", personStreamingQuery)
@@ -311,22 +323,23 @@ class StreamingIT {
         .queryName("queryFromNow")
         .start()
 
-      Executors.newSingleThreadExecutor().execute(() => createPersonNodes(1, total, 1000, 200))
+      Executors.newSingleThreadExecutor().execute(() => createPersonNodes(driver, 1, total, 1000, 25))
 
       val expected = (1 to total).map(index => Map("age" -> s"$index")).toList
       Assert.assertEventually(
         expected,
-        () => select("SELECT * FROM queryFromNow ORDER BY timestamp", "age"),
+        () => select(spark, "SELECT * FROM queryFromNow ORDER BY timestamp", "age"),
         30L,
         TimeUnit.SECONDS
       )
     }
 
     @Test
-    def reads_all_query_results(): Unit = {
-      createPersonNodes(0, 1)
+    def reads_all_query_results(driver: Driver, spark: SparkSession, neo4j: Neo4j): Unit = {
+      createPersonNodes(driver, 0, 1)
 
       query = spark.readStream.format(dataSourceFormat)
+        .options(connectionOptions(spark))
         .option(OptPropertyName, "timestamp")
         .option(OptFrom, "ALL")
         .option("query", personStreamingQuery)
@@ -337,22 +350,23 @@ class StreamingIT {
         .queryName("allQuery")
         .start()
 
-      Executors.newSingleThreadExecutor().execute(() => createPersonNodes(1, total, 1000, 200))
+      Executors.newSingleThreadExecutor().execute(() => createPersonNodes(driver, 1, total, 1000, 25))
 
       val expected = (0 to total).map(index => Map("age" -> s"$index")).toList
       Assert.assertEventually(
         expected,
-        () => select("SELECT * FROM allQuery ORDER BY timestamp", "age"),
+        () => select(spark, "SELECT * FROM allQuery ORDER BY timestamp", "age"),
         30L,
         TimeUnit.SECONDS
       )
     }
 
     @Test
-    def resumes_reading_query_results_from_checkpoint(): Unit = {
-      createPersonNodes(0, 1)
+    def resumes_reading_query_results_from_checkpoint(driver: Driver, spark: SparkSession, neo4j: Neo4j): Unit = {
+      createPersonNodes(driver, 0, 1)
 
       val stream = spark.readStream.format(dataSourceFormat)
+        .options(connectionOptions(spark))
         .option(OptPropertyName, "timestamp")
         .option(OptFrom, "ALL")
         .option("query", personStreamingQuery)
@@ -364,22 +378,23 @@ class StreamingIT {
       val partial = total / 2
 
       drainToTable(stream, location, table)
-      createPersonNodes(1, partial, 0, 10)
+      createPersonNodes(driver, 1, partial, 0, 10)
       drainToTable(stream, location, table)
-      createPersonNodes(partial + 1, total - partial, 0, 10)
+      createPersonNodes(driver, partial + 1, total - partial, 0, 10)
       drainToTable(stream, location, table)
 
       val expected = (0 to total).map(index => Map("age" -> s"$index")).toList
-      assertThat(select(s"SELECT * FROM $table ORDER BY timestamp", "age").asJava)
+      assertThat(select(spark, s"SELECT * FROM $table ORDER BY timestamp", "age").asJava)
         .containsExactlyElementsOf(expected.asJava)
     }
 
     @Test
-    def keeps_offset_when_query_returns_nothing(): Unit = {
-      createPersonNodes(0, 50)
+    def keeps_offset_when_query_returns_nothing(driver: Driver, spark: SparkSession, neo4j: Neo4j): Unit = {
+      createPersonNodes(driver, 0, 50)
       driver.executableQuery("MATCH (p:Person) SET p:Human").execute()
 
       val stream = spark.readStream.format(dataSourceFormat)
+        .options(connectionOptions(spark))
         .option(OptPropertyName, "timestamp")
         .option(OptFrom, "ALL")
         .option("query", personStreamingQuery)
@@ -428,7 +443,13 @@ class StreamingIT {
         .awaitTermination()
     }
 
-    private def createMovieNodes(from: Int, count: Int, delayMs: Int = 0, intervalMs: Int = 0): Unit = {
+    private def createMovieNodes(
+      driver: Driver,
+      from: Int,
+      count: Int,
+      delayMs: Int = 0,
+      intervalMs: Int = 0
+    ): Unit = {
       Thread.sleep(delayMs)
       (from until from + count).foreach { index =>
         Thread.sleep(intervalMs)
@@ -436,7 +457,13 @@ class StreamingIT {
       }
     }
 
-    private def createPersonNodes(from: Int, count: Int, delayMs: Int = 0, intervalMs: Int = 0): Unit = {
+    private def createPersonNodes(
+      driver: Driver,
+      from: Int,
+      count: Int,
+      delayMs: Int = 0,
+      intervalMs: Int = 0
+    ): Unit = {
       Thread.sleep(delayMs)
       (from until from + count).foreach { index =>
         Thread.sleep(intervalMs)
@@ -444,7 +471,13 @@ class StreamingIT {
       }
     }
 
-    private def createLikesRelationships(from: Int, count: Int, delayMs: Int = 0, intervalMs: Int = 0): Unit = {
+    private def createLikesRelationships(
+      driver: Driver,
+      from: Int,
+      count: Int,
+      delayMs: Int = 0,
+      intervalMs: Int = 0
+    ): Unit = {
       Thread.sleep(delayMs)
       (from until from + count).foreach { index =>
         Thread.sleep(intervalMs)
@@ -467,22 +500,24 @@ class StreamingIT {
       "rel.id" -> index
     )
 
-    private def select(sql: String, columns: String*): immutable.Seq[Map[String, Any]] =
+    private def select(spark: SparkSession, sql: String, columns: String*): immutable.Seq[Map[String, Any]] =
       spark.sql(sql).collect().map(row => columns.map(column => column -> row.getAs[Any](column)).toMap).toList
   }
 
   @Nested
   @DisplayName("to sink")
+  @Execution(ExecutionMode.SAME_THREAD)
   class ToSink {
 
     private val recordSize = 2000
     private val partitions = 5
 
     @Test
-    def writes_nodes_in_append_mode(): Unit = {
-      val stream = memoryStream()
+    def writes_nodes_in_append_mode(driver: Driver, spark: SparkSession, neo4j: Neo4j): Unit = {
+      val stream = memoryStream(spark)
       query = stream.toDF().writeStream
         .format(dataSourceFormat)
+        .options(connectionOptions(spark))
         .option("save.mode", "Append")
         .option("labels", "Timestamp")
         .option("node.keys", "value")
@@ -491,18 +526,19 @@ class StreamingIT {
 
       feed(stream)((1 to recordSize * partitions).toArray)
 
-      assertEventuallyContainsValues("Timestamp", "value", (1 to recordSize * partitions).toList)
+      assertEventuallyContainsValues(spark, "Timestamp", "value", (1 to recordSize * partitions).toList)
     }
 
     @Test
-    def writes_nodes_in_overwrite_mode(): Unit = {
+    def writes_nodes_in_overwrite_mode(driver: Driver, spark: SparkSession, neo4j: Neo4j): Unit = {
       driver.executableQuery(
         "CREATE CONSTRAINT timestamp_value FOR (t:Timestamp) REQUIRE t.value IS UNIQUE"
       ).execute()
 
-      val stream = memoryStream()
+      val stream = memoryStream(spark)
       query = stream.toDF().writeStream
         .format(dataSourceFormat)
+        .options(connectionOptions(spark))
         .option("save.mode", "Overwrite")
         .option("labels", "Timestamp")
         .option("node.keys", "value")
@@ -511,14 +547,15 @@ class StreamingIT {
 
       (1 to partitions).foreach(_ => stream.addData((1 to 500).toArray))
 
-      assertEventuallyContainsValues("Timestamp", "value", (1 to 500).toList)
+      assertEventuallyContainsValues(spark, "Timestamp", "value", (1 to 500).toList)
     }
 
     @Test
-    def writes_relationships_in_append_mode(): Unit = {
-      val stream = memoryStream()
+    def writes_relationships_in_append_mode(driver: Driver, spark: SparkSession, neo4j: Neo4j): Unit = {
+      val stream = memoryStream(spark)
       query = stream.toDF().writeStream
         .format(dataSourceFormat)
+        .options(connectionOptions(spark))
         .option("save.mode", "Append")
         .option("relationship", "PAIRS")
         .option("relationship.source.labels", ":From")
@@ -533,17 +570,18 @@ class StreamingIT {
       feed(stream)((1 to recordSize * partitions).toArray)
 
       val expected = (1 to recordSize * partitions).map(value => (value, value)).toList
-      assertEventuallyContainsPairs(expected)
+      assertEventuallyContainsPairs(spark, expected)
     }
 
     @Test
-    def appends_relationships_while_overwriting_nodes(): Unit = {
+    def appends_relationships_while_overwriting_nodes(driver: Driver, spark: SparkSession, neo4j: Neo4j): Unit = {
       driver.executableQuery("CREATE CONSTRAINT From_value FOR (p:From) REQUIRE p.value IS UNIQUE").execute()
       driver.executableQuery("CREATE CONSTRAINT To_value FOR (p:To) REQUIRE p.value IS UNIQUE").execute()
 
-      val stream = memoryStream()
+      val stream = memoryStream(spark)
       query = stream.toDF().writeStream
         .format(dataSourceFormat)
+        .options(connectionOptions(spark))
         .option("save.mode", "Append")
         .option("relationship", "PAIRS")
         .option("relationship.source.labels", ":From")
@@ -558,24 +596,25 @@ class StreamingIT {
       (1 to partitions).foreach(_ => stream.addData((1 to 500).toArray))
 
       val expected = (1 to 500).flatMap(value => (1 to partitions).map(_ => (value, value))).toList
-      assertEventuallyContainsPairs(expected)
+      assertEventuallyContainsPairs(spark, expected)
     }
 
     @Test
-    def writes_with_query(): Unit = {
-      val stream = memoryStream()
+    def writes_with_query(driver: Driver, spark: SparkSession, neo4j: Neo4j): Unit = {
+      val stream = memoryStream(spark)
       query = stream.toDF().writeStream
         .format(dataSourceFormat)
+        .options(connectionOptions(spark))
         .option("query", "MERGE (m:MyNewNode {the_value: event.value})")
         .option("checkpointLocation", checkpoint())
         .start()
 
       feed(stream)((1 to recordSize * partitions).toArray)
 
-      assertEventuallyContainsValues("MyNewNode", "the_value", (1 to recordSize * partitions).toList)
+      assertEventuallyContainsValues(spark, "MyNewNode", "the_value", (1 to recordSize * partitions).toList)
     }
 
-    private def memoryStream(): MemoryStream[Int] = {
+    private def memoryStream(spark: SparkSession): MemoryStream[Int] = {
       val session = spark
       import session.implicits._
       MemoryStream[Int](session)
@@ -585,35 +624,60 @@ class StreamingIT {
       values.grouped(values.length / partitions).foreach(stream.addData(_))
     }
 
-    private def assertEventuallyContainsValues(label: String, column: String, expected: immutable.Seq[Int]): Unit = {
-      Assert.assertEventually(
-        expected.size,
-        () => readValues(label, column).size,
-        30L,
-        TimeUnit.SECONDS
-      )
-      assertThat(readValues(label, column).map(Int.box).asJava)
+    private def assertEventuallyContainsValues(
+      spark: SparkSession,
+      label: String,
+      column: String,
+      expected: immutable.Seq[Int]
+    ): Unit = {
+      assertEventuallyWithQueryDiagnostics(expected.size, () => readValues(spark, label, column).size)
+      assertThat(readValues(spark, label, column).map(Int.box).asJava)
         .containsExactlyInAnyOrderElementsOf(expected.map(Int.box).asJava)
     }
 
-    private def assertEventuallyContainsPairs(expected: immutable.Seq[(Int, Int)]): Unit = {
-      Assert.assertEventually(
-        expected.size,
-        () => readPairs().size,
-        30L,
-        TimeUnit.SECONDS
-      )
-      assertThat(readPairs().asJava).containsExactlyInAnyOrderElementsOf(expected.asJava)
+    private def assertEventuallyContainsPairs(spark: SparkSession, expected: immutable.Seq[(Int, Int)]): Unit = {
+      assertEventuallyWithQueryDiagnostics(expected.size, () => readPairs(spark).size)
+      assertThat(readPairs(spark).asJava).containsExactlyInAnyOrderElementsOf(expected.asJava)
     }
 
-    private def readValues(label: String, column: String): immutable.Seq[Int] = {
-      val df = spark.read.format(dataSourceFormat).option("labels", label).load()
+    private def assertEventuallyWithQueryDiagnostics(expected: Int, actual: () => Int): Unit = {
+      try {
+        Assert.assertEventually(
+          expected,
+          new Assert.ThrowingSupplier[Int, RuntimeException] {
+            override def get(): Int = actual()
+          },
+          30L,
+          TimeUnit.SECONDS
+        )
+      } catch {
+        case error: AssertionError =>
+          throw new AssertionError(s"${error.getMessage}\n${queryDiagnostics}", error)
+      }
+    }
+
+    private def queryDiagnostics: String =
+      Option(query)
+        .map { streamingQuery =>
+          val progress = streamingQuery.recentProgress.map(_.json).mkString("[", ",", "]")
+          s"""Streaming query diagnostics:
+             |active=${streamingQuery.isActive}
+             |status=${streamingQuery.status}
+             |exception=${Option(streamingQuery.exception).map(_.toString).getOrElse("<none>")}
+             |recentProgress=$progress
+             |""".stripMargin
+        }
+        .getOrElse("Streaming query diagnostics: <no query>")
+
+    private def readValues(spark: SparkSession, label: String, column: String): immutable.Seq[Int] = {
+      val df = spark.read.format(dataSourceFormat).options(connectionOptions(spark)).option("labels", label).load()
       if (df.columns.contains(column)) df.collect().map(_.getAs[Long](column).toInt).toList
       else immutable.Seq.empty
     }
 
-    private def readPairs(): immutable.Seq[(Int, Int)] = {
+    private def readPairs(spark: SparkSession): immutable.Seq[(Int, Int)] = {
       val df: DataFrame = spark.read.format(dataSourceFormat)
+        .options(connectionOptions(spark))
         .option("relationship", "PAIRS")
         .option("relationship.source.labels", ":From")
         .option("relationship.target.labels", ":To")

--- a/src/test/scala/org/neo4j/spark/StreamingIT.scala
+++ b/src/test/scala/org/neo4j/spark/StreamingIT.scala
@@ -22,9 +22,7 @@ import org.apache.spark.sql.execution.streaming.runtime.MemoryStream
 import org.apache.spark.sql.streaming.StreamingQuery
 import org.apache.spark.sql.streaming.Trigger
 import org.assertj.core.api.Assertions.assertThat
-import org.junit.jupiter.api.AfterAll
 import org.junit.jupiter.api.AfterEach
-import org.junit.jupiter.api.BeforeAll
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.DisplayName
 import org.junit.jupiter.api.Nested
@@ -37,8 +35,6 @@ import org.neo4j.caniuse.Neo4j
 import org.neo4j.driver.Driver
 import org.neo4j.spark.testsupport.Assert
 import org.neo4j.spark.testsupport.InjectNeo4jContainerParameter
-import org.neo4j.spark.testsupport.Neo4jExtensions.DriverExtensions
-import org.neo4j.spark.testsupport.Neo4jExtensions.Neo4jContainerExtensions
 import org.neo4j.spark.testsupport.StreamingTestState
 import org.testcontainers.neo4j.Neo4jContainer
 

--- a/src/test/scala/org/neo4j/spark/testsupport/Neo4jContainerProvider.scala
+++ b/src/test/scala/org/neo4j/spark/testsupport/Neo4jContainerProvider.scala
@@ -17,12 +17,15 @@
 package org.neo4j.spark.testsupport
 
 import org.junit.jupiter.api.extension.ExtensionContext
+import org.junit.jupiter.api.extension.ExtensionContext.Namespace
+import org.junit.jupiter.api.extension.ExtensionContext.StoreScope
 import org.junit.jupiter.params.provider.Arguments
 import org.junit.jupiter.params.provider.ArgumentsProvider
 import org.junit.jupiter.params.support.ParameterDeclarations
 import org.testcontainers.neo4j.Neo4jContainer
 
 import java.util.TimeZone
+import java.util.function.Function
 import java.util.stream
 
 class Neo4jContainerProvider extends ArgumentsProvider {
@@ -30,23 +33,52 @@ class Neo4jContainerProvider extends ArgumentsProvider {
   override def provideArguments(
     parameters: ParameterDeclarations,
     context: ExtensionContext
-  ): stream.Stream[Arguments] = {
-    stream.Stream.of(
-      Arguments.argumentSet("with Vanilla Neo4j", baseContainer),
-      Arguments.argumentSet("with Neo4j+APOC core", baseContainer.withPlugins("apoc")),
-      Arguments.argumentSet("with Neo4j+GDS", baseContainer.withPlugins("graph-data-science")),
-      Arguments.argumentSet("with Neo4j+GDS+APOC core", baseContainer.withPlugins("graph-data-science", "apoc"))
-    )
-  }
-
-  private def baseContainer = {
-    new Neo4jContainer(TestUtil.neo4jImage())
-      .withAdminPassword(Neo4jContainerProvider.ADMIN_PASSWORD)
-      .withEnv("NEO4J_db_temporal_timezone", TimeZone.getDefault.getID)
-      .withEnv("NEO4J_ACCEPT_LICENSE_AGREEMENT", "yes")
-  }
+  ): stream.Stream[Arguments] =
+    Neo4jContainerProvider.arguments(context)
 }
 
 object Neo4jContainerProvider {
   val ADMIN_PASSWORD = "letmein!"
+
+  private val NAMESPACE = Namespace.create(classOf[Neo4jContainerProvider])
+  private val CONTAINERS_KEY = "containers"
+
+  private def arguments(context: ExtensionContext): stream.Stream[Arguments] = {
+    val containers = context
+      .getStore(StoreScope.LAUNCHER_SESSION, NAMESPACE)
+      .computeIfAbsent(
+        CONTAINERS_KEY,
+        (_: String) => new SharedNeo4jContainers,
+        classOf[SharedNeo4jContainers]
+      )
+
+    stream.Stream.of(
+      Arguments.argumentSet("with Vanilla Neo4j", containers.vanilla),
+      Arguments.argumentSet("with Neo4j+APOC core", containers.apoc),
+      Arguments.argumentSet("with Neo4j+GDS", containers.gds),
+      Arguments.argumentSet("with Neo4j+GDS+APOC core", containers.gdsAndApoc)
+    )
+  }
+
+  private class SharedNeo4jContainers extends AutoCloseable {
+
+    val vanilla: Neo4jContainer = baseContainer()
+    val apoc: Neo4jContainer = baseContainer().withPlugins("apoc")
+    val gds: Neo4jContainer = baseContainer().withPlugins("graph-data-science")
+    val gdsAndApoc: Neo4jContainer = baseContainer().withPlugins("graph-data-science", "apoc")
+
+    override def close(): Unit = {
+      SparkSessions.stop()
+      Seq(vanilla, apoc, gds, gdsAndApoc).foreach(_.close())
+    }
+
+    private def baseContainer() = {
+      new Neo4jContainer(TestUtil.neo4jImage())
+        .withAdminPassword(ADMIN_PASSWORD)
+        .withEnv("NEO4J_dbms_max__databases", "200")
+        .withEnv("NEO4J_db_temporal_timezone", TimeZone.getDefault.getID)
+        .withEnv("NEO4J_ACCEPT_LICENSE_AGREEMENT", "yes")
+        .withReuse(true)
+    }
+  }
 }

--- a/src/test/scala/org/neo4j/spark/testsupport/Neo4jContainerProvider.scala
+++ b/src/test/scala/org/neo4j/spark/testsupport/Neo4jContainerProvider.scala
@@ -25,7 +25,6 @@ import org.junit.jupiter.params.support.ParameterDeclarations
 import org.testcontainers.neo4j.Neo4jContainer
 
 import java.util.TimeZone
-import java.util.function.Function
 import java.util.stream
 
 class Neo4jContainerProvider extends ArgumentsProvider {

--- a/src/test/scala/org/neo4j/spark/testsupport/Neo4jExtensions.scala
+++ b/src/test/scala/org/neo4j/spark/testsupport/Neo4jExtensions.scala
@@ -16,7 +16,6 @@
  */
 package org.neo4j.spark.testsupport
 
-import org.apache.spark.SparkConf
 import org.apache.spark.sql.SparkSession
 import org.neo4j.caniuse.Neo4jDetector
 import org.neo4j.driver.AuthTokens

--- a/src/test/scala/org/neo4j/spark/testsupport/Neo4jExtensions.scala
+++ b/src/test/scala/org/neo4j/spark/testsupport/Neo4jExtensions.scala
@@ -28,12 +28,17 @@ import org.neo4j.spark.util.Neo4jOptions
 import org.testcontainers.neo4j.Neo4jContainer
 
 import scala.jdk.CollectionConverters.MapHasAsJava
-import scala.util.Try
 import scala.util.Using
 
 object Neo4jExtensions {
 
   implicit class Neo4jContainerExtensions(container: Neo4jContainer) {
+
+    def startLazily(): Unit = {
+      if (!container.isRunning) {
+        container.start()
+      }
+    }
 
     def cypherRenderer(options: Neo4jOptions = defaultNeo4jSparkOptions): CypherRenderer = {
       Using(driver()) { driver =>
@@ -47,16 +52,12 @@ object Neo4jExtensions {
       GraphDatabase.driver(container.getBoltUrl, auth)
     }
 
-    def spark(): SparkSession = {
-      SparkSession.builder()
-        .config(new SparkConf()
-          .setAppName("neoTest")
-          .setMaster("local[*]")
-          .set("spark.driver.host", "127.0.0.1")
-          .set("neo4j.url", container.getBoltUrl)
-          .set("neo4j.authentication.basic.username", "neo4j")
-          .set("neo4j.authentication.basic.password", container.getAdminPassword))
-        .getOrCreate()
+    def driver(username: String, password: String): Driver = {
+      GraphDatabase.driver(container.getBoltUrl, AuthTokens.basic(username, password))
+    }
+
+    def spark(user: String, password: String): SparkSession = {
+      SparkSessions.forContainer(container, user, password)
     }
 
     def authenticatedOptions(): Map[String, String] = {
@@ -80,9 +81,44 @@ object Neo4jExtensions {
 
   implicit class DriverExtensions(driver: Driver) {
 
+    def createOrReplaceUser(user: String, password: String, homeDb: String): Unit = {
+      driver.executableQuery("""
+                               |CREATE OR REPLACE USER $user
+                               |SET PASSWORD $password CHANGE NOT REQUIRED
+                               |SET HOME DATABASE $homeDb
+      """.stripMargin)
+        .withParameters(Map[String, AnyRef]("user" -> user, "password" -> password, "homeDb" -> homeDb).asJava)
+        .withConfig(QueryConfig.builder().withDatabase("system").build())
+        .execute()
+      driver.executableQuery(
+        """
+          |GRANT ROLE admin TO $user
+          |""".stripMargin
+      )
+        .withParameters(Map[String, AnyRef]("user" -> user).asJava)
+        .withConfig(QueryConfig.builder()
+          .withDatabase("system")
+          .build())
+        .execute()
+    }
+
     def createOrReplaceDatabase(database: String): Unit = {
       driver.executableQuery("CREATE OR REPLACE DATABASE $db WAIT 30 seconds")
         .withParameters(Map[String, AnyRef]("db" -> database).asJava)
+        .withConfig(QueryConfig.builder().withDatabase("system").build())
+        .execute()
+    }
+
+    def dropDatabase(database: String): Unit = {
+      driver.executableQuery("DROP DATABASE $db IF EXISTS WAIT 30 seconds")
+        .withParameters(Map[String, AnyRef]("db" -> database).asJava)
+        .withConfig(QueryConfig.builder().withDatabase("system").build())
+        .execute()
+    }
+
+    def dropUser(user: String): Unit = {
+      driver.executableQuery("DROP USER $user IF EXISTS")
+        .withParameters(Map[String, AnyRef]("user" -> user).asJava)
         .withConfig(QueryConfig.builder().withDatabase("system").build())
         .execute()
     }

--- a/src/test/scala/org/neo4j/spark/testsupport/Neo4jTestResourcesExtension.scala
+++ b/src/test/scala/org/neo4j/spark/testsupport/Neo4jTestResourcesExtension.scala
@@ -1,0 +1,234 @@
+/*
+ * Copyright (c) "Neo4j"
+ * Neo4j Sweden AB [https://neo4j.com]
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.neo4j.spark.testsupport
+
+import org.apache.spark.sql.SparkSession
+import org.junit.jupiter.api.extension.AfterAllCallback
+import org.junit.jupiter.api.extension.BeforeEachCallback
+import org.junit.jupiter.api.extension.ExtensionContext
+import org.junit.jupiter.api.extension.ExtensionContext.Namespace
+import org.junit.jupiter.api.extension.ParameterContext
+import org.junit.jupiter.api.extension.ParameterResolutionException
+import org.junit.jupiter.api.extension.ParameterResolver
+import org.neo4j.caniuse.Neo4j
+import org.neo4j.caniuse.Neo4jDetector
+import org.neo4j.driver.Driver
+import org.neo4j.spark.testsupport.Neo4jExtensions.DriverExtensions
+import org.neo4j.spark.testsupport.Neo4jExtensions.Neo4jContainerExtensions
+import org.testcontainers.neo4j.Neo4jContainer
+
+import java.lang.reflect.Field
+import java.util.Objects
+
+final case class Neo4jTestResources(
+  container: Neo4jContainer,
+  adminDriver: Driver,
+  driver: Driver,
+  spark: SparkSession,
+  neo4j: Neo4j,
+  user: String,
+  password: String,
+  database: String
+) {
+
+  def cleanup(): Unit = {
+    var failure: Throwable = null
+
+    container.synchronized {
+      try {
+        Option(spark).foreach(SparkSessions.release)
+      } catch {
+        case throwable: Throwable => failure = throwable
+      }
+
+      try {
+        Option(driver).foreach(_.close())
+      } catch {
+        case throwable: Throwable =>
+          if (failure != null) {
+            failure.addSuppressed(throwable)
+          } else {
+            failure = throwable
+          }
+      }
+
+      try {
+        adminDriver.dropDatabase(database)
+        adminDriver.dropUser(user)
+      } catch {
+        case throwable: Throwable =>
+          if (failure != null) {
+            failure.addSuppressed(throwable)
+          } else {
+            failure = throwable
+          }
+      } finally {
+        try {
+          adminDriver.close()
+        } catch {
+          case throwable: Throwable =>
+            if (failure != null) {
+              failure.addSuppressed(throwable)
+            } else {
+              failure = throwable
+            }
+        }
+      }
+    }
+
+    if (failure != null) {
+      throw failure
+    }
+  }
+}
+
+class Neo4jTestResourcesExtension
+    extends BeforeEachCallback
+    with AfterAllCallback
+    with ParameterResolver {
+
+  private val namespace = Namespace.create(classOf[Neo4jTestResourcesExtension])
+  private val key = "resources"
+
+  override def supportsParameter(parameterContext: ParameterContext, extensionContext: ExtensionContext): Boolean =
+    parameterContext.getParameter.getType match {
+      case t if t == classOf[Neo4jTestResources] => true
+      case t if t == classOf[Driver]             => true
+      case t if t == classOf[SparkSession]       => true
+      case t if t == classOf[Neo4j]              => true
+      case _                                     => false
+    }
+
+  override def resolveParameter(parameterContext: ParameterContext, extensionContext: ExtensionContext): AnyRef =
+    parameterContext.getParameter.getType match {
+      case t if t == classOf[Neo4jTestResources] => resources(extensionContext)
+      case t if t == classOf[Driver]             => resources(extensionContext).driver
+      case t if t == classOf[SparkSession]       => resources(extensionContext).spark
+      case t if t == classOf[Neo4j]              => resources(extensionContext).neo4j
+      case other =>
+        throw new ParameterResolutionException(
+          s"Unsupported parameter type: ${other.getName}"
+        )
+    }
+
+  override def beforeEach(context: ExtensionContext): Unit = {
+    val testResources = resources(context)
+    if (resetsDatabase(context)) {
+      resetDatabase(testResources)
+    }
+  }
+
+  override def afterAll(context: ExtensionContext): Unit = {
+    Option(store(context).remove(key, classOf[Neo4jTestResources])).foreach(_.cleanup())
+  }
+
+  private def resources(context: ExtensionContext): Neo4jTestResources = {
+    this.synchronized {
+      val existing = store(context).get(key, classOf[Neo4jTestResources])
+      if (existing != null) {
+        existing
+      } else {
+        val created = createResources(context)
+        store(context).put(key, created)
+        created
+      }
+    }
+  }
+
+  private def createResources(context: ExtensionContext): Neo4jTestResources = {
+    val testInstance = context.getRequiredTestInstance
+    val container = readField(testInstance, "neo4jContainer").asInstanceOf[Neo4jContainer]
+    container.startLazily()
+
+    val suffix = Integer.toUnsignedString(Objects.hash(owningContext(context).getUniqueId, container.getBoltUrl), 36)
+    val user = s"test-user-$suffix"
+    val password = s"test-password-$suffix"
+    val database = s"test-db-$suffix"
+
+    val resources = container.synchronized {
+      val adminDriver = container.driver()
+      adminDriver.createOrReplaceUser(user, password, database)
+      adminDriver.createOrReplaceDatabase(database)
+      val driver = container.driver(user, password)
+      val spark = container.spark(user, password)
+      val neo4j = Neo4jDetector.INSTANCE.detect(driver)
+
+      Neo4jTestResources(
+        container,
+        adminDriver,
+        driver,
+        spark,
+        neo4j,
+        user,
+        password,
+        database
+      )
+    }
+
+    resources
+  }
+
+  private def resetDatabase(resources: Neo4jTestResources): Unit = {
+    resources.container.synchronized {
+      resources.adminDriver
+        .executableQuery("MATCH (n) DETACH DELETE n")
+        .withConfig(org.neo4j.driver.QueryConfig.builder().withDatabase(resources.database).build())
+        .execute()
+    }
+  }
+
+  private def resetsDatabase(context: ExtensionContext): Boolean =
+    context.getRequiredTestClass.getName != "org.neo4j.spark.GraphDataScienceIT"
+
+  private def store(context: ExtensionContext) =
+    owningContext(context).getStore(Namespace.create(namespace, context.getRequiredTestClass))
+
+  private def owningContext(context: ExtensionContext): ExtensionContext =
+    if (context.getTestMethod.isPresent) {
+      context.getParent.orElse(context)
+    } else {
+      context
+    }
+
+  private def readField(target: AnyRef, fieldName: String): AnyRef = {
+    var current: AnyRef = target
+    while (current != null) {
+      try {
+        val field = current.getClass.getDeclaredField(fieldName)
+        field.setAccessible(true)
+        return field.get(current)
+      } catch {
+        case _: NoSuchFieldException =>
+          current = outer(current).orNull
+      }
+    }
+
+    throw new ParameterResolutionException(
+      s"Could not find field '$fieldName' on test instance ${target.getClass.getName}"
+    )
+  }
+
+  private def outer(target: AnyRef): Option[AnyRef] = {
+    try {
+      val field = target.getClass.getDeclaredField("$outer")
+      field.setAccessible(true)
+      Option(field.get(target))
+    } catch {
+      case _: NoSuchFieldException => None
+    }
+  }
+}

--- a/src/test/scala/org/neo4j/spark/testsupport/Neo4jTestResourcesExtension.scala
+++ b/src/test/scala/org/neo4j/spark/testsupport/Neo4jTestResourcesExtension.scala
@@ -31,7 +31,6 @@ import org.neo4j.spark.testsupport.Neo4jExtensions.DriverExtensions
 import org.neo4j.spark.testsupport.Neo4jExtensions.Neo4jContainerExtensions
 import org.testcontainers.neo4j.Neo4jContainer
 
-import java.lang.reflect.Field
 import java.util.Objects
 
 final case class Neo4jTestResources(

--- a/src/test/scala/org/neo4j/spark/testsupport/SparkConnectorScalaSuiteIT.scala
+++ b/src/test/scala/org/neo4j/spark/testsupport/SparkConnectorScalaSuiteIT.scala
@@ -43,9 +43,10 @@ object SparkConnectorScalaSuiteIT {
   var driver: Driver = _
   var tmpDir: File = _
   var neo4j: Neo4j = _
+  private var shutdownHookRegistered = false
 
   @BeforeAll
-  def setUpContainer(): Unit = {
+  def setUpContainer(): Unit = this.synchronized {
     if (!server.isRunning) {
       try {
         server.start()
@@ -64,16 +65,34 @@ object SparkConnectorScalaSuiteIT {
       ss = SparkSession.builder().config(conf).getOrCreate()
       driver = GraphDatabase.driver(server.getBoltUrl, AuthTokens.none())
       neo4j = Neo4jDetector.INSTANCE.detect(driver)
+      registerShutdownHook()
     }
     assumeTrue(server.isRunning, "Neo4j container is not started")
   }
 
   @AfterAll
   def tearDownContainer(): Unit = {
+    ()
+  }
+
+  private def registerShutdownHook(): Unit = {
+    if (!shutdownHookRegistered) {
+      sys.addShutdownHook {
+        closeResources()
+      }
+      shutdownHookRegistered = true
+    }
+  }
+
+  private def closeResources(): Unit = this.synchronized {
     TestUtil.closeSafely(driver)
     driver = null
     TestUtil.closeSafely(server)
     TestUtil.closeSafely(ss)
+    ss = null
+    conf = null
+    tmpDir = null
+    neo4j = null
   }
 
   def session(database: String = ""): Session = {

--- a/src/test/scala/org/neo4j/spark/testsupport/SparkConnectorScalaSuiteWithApocIT.scala
+++ b/src/test/scala/org/neo4j/spark/testsupport/SparkConnectorScalaSuiteWithApocIT.scala
@@ -40,9 +40,10 @@ object SparkConnectorScalaSuiteWithApocIT {
   var ss: SparkSession = _
   var driver: Driver = _
   var neo4j: Neo4j = _
+  private var shutdownHookRegistered = false
 
   @BeforeAll
-  def setUpContainer(): Unit = {
+  def setUpContainer(): Unit = this.synchronized {
     if (!server.isRunning) {
       try {
         server.start()
@@ -58,6 +59,7 @@ object SparkConnectorScalaSuiteWithApocIT {
       ss = SparkSession.builder().config(conf).getOrCreate()
       driver = GraphDatabase.driver(server.getBoltUrl, AuthTokens.none())
       neo4j = Neo4jDetector.INSTANCE.detect(driver)
+      registerShutdownHook()
     }
     assumeTrue(server.isRunning, "Neo4j container is not started")
     assumeTrue(TestUtil.hasApoc(session()), "Neo4j Preview versions doesn't have APOC")
@@ -65,10 +67,26 @@ object SparkConnectorScalaSuiteWithApocIT {
 
   @AfterAll
   def tearDownContainer(): Unit = {
+    ()
+  }
+
+  private def registerShutdownHook(): Unit = {
+    if (!shutdownHookRegistered) {
+      sys.addShutdownHook {
+        closeResources()
+      }
+      shutdownHookRegistered = true
+    }
+  }
+
+  private def closeResources(): Unit = this.synchronized {
     TestUtil.closeSafely(driver)
     driver = null
     TestUtil.closeSafely(server)
     TestUtil.closeSafely(ss)
+    ss = null
+    conf = null
+    neo4j = null
   }
 
   def session(database: String = ""): Session = {

--- a/src/test/scala/org/neo4j/spark/testsupport/SparkSessions.scala
+++ b/src/test/scala/org/neo4j/spark/testsupport/SparkSessions.scala
@@ -1,0 +1,65 @@
+/*
+ * Copyright (c) "Neo4j"
+ * Neo4j Sweden AB [https://neo4j.com]
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.neo4j.spark.testsupport
+
+import org.apache.spark.SparkConf
+import org.apache.spark.sql.SparkSession
+import org.testcontainers.neo4j.Neo4jContainer
+
+object SparkSessions {
+  private var root: SparkSession = _
+
+  def forContainer(container: Neo4jContainer, username: String, password: String): SparkSession = {
+    val session = this.synchronized {
+      if (root == null || root.sparkContext.isStopped) {
+        root = SparkSession.builder()
+          .config(new SparkConf()
+            .setAppName("neoTest")
+            .setMaster("local[*]")
+            .set("spark.driver.host", "127.0.0.1"))
+          .getOrCreate()
+        SparkSession.clearActiveSession()
+        SparkSession.clearDefaultSession()
+      }
+      root.newSession()
+    }
+
+    session.conf.set("neo4j.url", container.getBoltUrl)
+    session.conf.set("neo4j.authentication.basic.username", username)
+    session.conf.set("neo4j.authentication.basic.password", password)
+    SparkSession.setActiveSession(session)
+    session
+  }
+
+  def release(session: SparkSession): Unit = {
+    if (session != null) {
+      session.catalog.clearCache()
+      if (SparkSession.getActiveSession.contains(session)) {
+        SparkSession.clearActiveSession()
+      }
+    }
+  }
+
+  def stop(): Unit = this.synchronized {
+    if (root != null && !root.sparkContext.isStopped) {
+      root.stop()
+    }
+    root = null
+    SparkSession.clearActiveSession()
+    SparkSession.clearDefaultSession()
+  }
+}

--- a/src/test/scala/org/neo4j/spark/testsupport/StreamingTestState.scala
+++ b/src/test/scala/org/neo4j/spark/testsupport/StreamingTestState.scala
@@ -1,0 +1,43 @@
+/*
+ * Copyright (c) "Neo4j"
+ * Neo4j Sweden AB [https://neo4j.com]
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.neo4j.spark.testsupport
+
+import org.apache.spark.sql.streaming.StreamingQuery
+
+import scala.collection.mutable
+
+object StreamingTestState {
+
+  final class State {
+    var query: StreamingQuery = _
+    val createdTables: mutable.ListBuffer[String] = mutable.ListBuffer.empty[String]
+  }
+
+  private val currentState = new ThreadLocal[State]()
+
+  def set(): Unit = currentState.set(new State)
+
+  def clear(): Unit = currentState.remove()
+
+  def current: State = {
+    val state = currentState.get()
+    if (state == null) {
+      throw new IllegalStateException("No streaming test state bound to the current thread")
+    }
+    state
+  }
+}

--- a/src/test/scala/org/neo4j/spark/util/ValidationsIT.scala
+++ b/src/test/scala/org/neo4j/spark/util/ValidationsIT.scala
@@ -21,7 +21,6 @@ import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Assertions.assertFalse
 import org.junit.jupiter.api.Assertions.assertThrows
 import org.junit.jupiter.api.Assertions.assertTrue
-import org.junit.jupiter.api.Assertions.fail
 import org.junit.jupiter.api.Test
 import org.neo4j.driver.AccessMode
 import org.neo4j.spark.testsupport.SparkConnectorScalaSuiteIT

--- a/src/test/scala/org/neo4j/spark/util/ValidationsIT.scala
+++ b/src/test/scala/org/neo4j/spark/util/ValidationsIT.scala
@@ -325,22 +325,21 @@ class ValidationsIT extends SparkConnectorScalaSuiteIT {
 
   @Test
   def testVersionThrowsExceptionSparkVersionIsNotSupported(): Unit = {
-    val sparkVersion = SparkSession.getActiveSession
-      .map { _.version }
-      .getOrElse("UNKNOWN")
+    val sparkVersion = SparkConnectorScalaSuiteIT.ss.version
+    SparkSession.setActiveSession(SparkConnectorScalaSuiteIT.ss)
     try {
-      Validations.validate(ValidateSparkMinVersion("4.10000"))
-      fail(s"should be thrown a ${classOf[IllegalArgumentException].getName}")
-    } catch {
-      case e: IllegalArgumentException =>
-        assertEquals(
-          s"""Your current Spark version $sparkVersion is not supported by the current connector.
-             |Please visit https://neo4j.com/developer/spark/overview/#_spark_compatibility to know which connector version you need.
-             |""".stripMargin,
-          e.getMessage
-        )
-      case e: Throwable =>
-        fail(s"should be thrown a ${classOf[IllegalArgumentException].getName}, got ${e.getClass} instead")
+      val exception = assertThrows(
+        classOf[IllegalArgumentException],
+        () => Validations.validate(ValidateSparkMinVersion("4.10000"))
+      )
+      assertEquals(
+        s"""Your current Spark version $sparkVersion is not supported by the current connector.
+           |Please visit https://neo4j.com/developer/spark/overview/#_spark_compatibility to know which connector version you need.
+           |""".stripMargin,
+        exception.getMessage
+      )
+    } finally {
+      SparkSession.clearActiveSession()
     }
   }
 


### PR DESCRIPTION
This changes all new IT tests to run concurrently.

Each new IT class now creates a new user, with a custom
home database. That allows the database configuration to
be omitted.

Containers provided by Neo4jContainerProvider start globally
only once.

Tests have been changed to not assume a blank database by default.

This commit introduces a meta-annotation, InjectNeo4jContainerParameter,
which encapsulates various JUnit settings.