### PR TITLE
ci(docs): extend doc artifact validation rules

### DIFF
--- a/.github/workflows/docs-deploy-surge.yml
+++ b/.github/workflows/docs-deploy-surge.yml
@@ -86,13 +86,32 @@ jobs:
 
       - id: suspicious-path-check
         name: Suspicious paths check
+        shell: bash
         env:
           ARTIFACT_DIR: ${{ runner.temp }}/artifacts/docs
         run: |
+          set -euo pipefail
           cd "$ARTIFACT_DIR"
-          if unzip -l docs.zip | grep -q "\.\./"; then
+          
+          mapfile -t ZIP_ENTRIES < <(zipinfo -1 docs.zip)
+          if [ "${#ZIP_ENTRIES[@]}" -eq 0 ]; then
+            echo "docs.zip is empty"
             exit 1
           fi
+          for entry in "${ZIP_ENTRIES[@]}"; do
+            if [[ "$entry" =~ ^/ ]]; then
+              echo "Blocked absolute path in artifact: $entry"
+              exit 1
+            fi
+            if [[ "$entry" =~ (^|/)\.\.(/|$) ]]; then
+              echo "Blocked path traversal in artifact: $entry"
+              exit 1
+            fi
+            if [[ "$entry" == *\\* ]]; then
+              echo "Blocked Windows-style path separator in artifact: $entry"
+              exit 1
+            fi
+          done
 
       - id: hidden-files-check
         name: Hidden files check


### PR DESCRIPTION
Potential fix for [https://github.com/neo4j/neo4j-spark-connector/security/code-scanning/1](https://github.com/neo4j/neo4j-spark-connector/security/code-scanning/1)

General fix: treat workflow-run artifacts as untrusted, extract only into isolated temp dirs, and strictly validate archive entries before extraction/use (reject absolute paths, traversal, symlinks, and unexpected top-level content). Then deploy only validated content.

Best targeted fix in this file: harden the existing `suspicious-path-check` step so it performs robust zip entry validation (not just `../`). Specifically, in `.github/workflows/docs-deploy-surge.yml`, replace the current `unzip -l ... | grep "\.\./"` check with a loop over `zipinfo -1 docs.zip` entries that rejects:
- absolute paths (`^/`)
- traversal segments (`(^|/)\.\.(/|$)`)
- backslashes (`\`)  
Also fail if no entries exist. This keeps behavior (deploy docs artifact) while preventing poisoned archive paths from being extracted/propagated.