### PR TITLE
fix: race condition in DriverCache

### DIFF
--- a/src/main/scala/org/neo4j/spark/util/DriverCache.scala
+++ b/src/main/scala/org/neo4j/spark/util/DriverCache.scala
@@ -17,33 +17,47 @@
 package org.neo4j.spark.util
 
 import org.neo4j.driver.Driver
-import org.neo4j.spark.util.DriverCache.cache
 
 import java.util.concurrent.ConcurrentHashMap
 import java.util.concurrent.atomic.AtomicInteger
 
 object DriverCache {
+  private case class DriverWithCounter(driver: Driver, atomicCounter: AtomicInteger)
 
-  private val cache: ConcurrentHashMap[Neo4jDriverOptions, (Driver, AtomicInteger)] =
-    new ConcurrentHashMap[Neo4jDriverOptions, (Driver, AtomicInteger)]
+  private val cache: ConcurrentHashMap[Neo4jDriverOptions, DriverWithCounter] =
+    new ConcurrentHashMap[Neo4jDriverOptions, DriverWithCounter]
 }
 
-class DriverCache(private val options: Neo4jDriverOptions) extends Serializable
-    with AutoCloseable {
+class DriverCache(private val options: Neo4jDriverOptions) extends Serializable with AutoCloseable {
+
+  import DriverCache._
 
   def getOrCreate(): Driver = {
-    val (driver, counter) =
-      cache.computeIfAbsent(options, (t: Neo4jDriverOptions) => (t.createDriver(), new AtomicInteger(0)))
-    counter.incrementAndGet()
-    driver
+    val driverWithCounter = cache.compute(
+      options,
+      (_, current) => {
+        if (current == null) {
+          DriverWithCounter(options.createDriver(), new AtomicInteger(1))
+        } else {
+          current.atomicCounter.incrementAndGet()
+          current
+        }
+      }
+    )
+    driverWithCounter.driver
   }
 
   def close(): Unit = {
-    Option(cache.get(options)).map { case (driver, counter) =>
-      if (counter.decrementAndGet() == 0) {
-        cache.remove(options)
-        Neo4jUtil.closeSafely(driver)
+    cache.computeIfPresent(
+      options,
+      (_, current) => {
+        if (current.atomicCounter.decrementAndGet() == 0) {
+          Neo4jUtil.closeSafely(current.driver)
+          null // i.e. remove from cache
+        } else {
+          current // keep it in cache
+        }
       }
-    }.orElse(None)
+    )
   }
 }


### PR DESCRIPTION
Previous implementation of DriverCache suffered from a check-then-act
race condition, where retrieving drivers from cache and updating the
counter was two separate atomic actions. This can cause race condition
under this scenario

Imagine thread A `close()`. Right after it calls `cache.get()` followed
by `decrementAndGet() == 0`. If the thread gets context-switched before
it get's the chance to `cache.remove()`, the race error happen.

What will happen in thread B, it can `getOrCreate()`, which will then
get the same driver as thread A is about to remove and close. It will
also increment the counter.

Back to A, it will now remove the live driver from cache and close the
driver! This will cause Thread B's driver to be stale. It will also
cause future calls to create a duplicated driver (cache empty).

This fix aims to make counters and accesses into the same atomic action
for the DriverCache. Preventing the above scenario.