### PR TITLE
fix: remove custom databases from TransactionTimeoutIT

### DIFF
--- a/spark-3/src/test/scala/org/neo4j/spark/ReauthenticationIT.scala
+++ b/spark-3/src/test/scala/org/neo4j/spark/ReauthenticationIT.scala
@@ -80,10 +80,11 @@ object ReauthenticationIT {
         )
     )
     .withStartupAttempts(3)
-    .withLogConsumer(new Slf4jLogConsumer(log))
+    .withLogConsumer(new Slf4jLogConsumer(log).withPrefix("ReauthenticationIT"))
     .withCommand("start-dev --import-realm")
 
   private val NEO4J = new Neo4jContainerExtension()
+    .withLogPrefix("ReauthenticationIT")
     .withNetwork(NETWORK)
     .withEnv("NEO4J_ACCEPT_LICENSE_AGREEMENT", "yes")
     .withCopyFileToContainer(MountableFile.forClasspathResource("/neo4j-keycloak.jks"), "/tmp/keycloak.jks")

--- a/spark-3/src/test/scala/org/neo4j/spark/TransactionTimeoutIT.scala
+++ b/spark-3/src/test/scala/org/neo4j/spark/TransactionTimeoutIT.scala
@@ -137,7 +137,7 @@ object TransactionTimeoutIT {
     withEnv("NEO4JLABS_PLUGINS", "[\"apoc\"]")
     withEnv("NEO4J_db_temporal_timezone", TimeZone.getDefault.getID)
     withNeo4jConfig("db.transaction.timeout", "10s")
-    withDatabases(Seq("db1", "db2"))
+    withLogPrefix("TransactionTimeoutIT")
   }
 
   @BeforeClass

--- a/test-support/src/main/scala/org/neo4j/Neo4jContainerExtension.scala
+++ b/test-support/src/main/scala/org/neo4j/Neo4jContainerExtension.scala
@@ -16,6 +16,7 @@
  */
 package org.neo4j
 
+import org.neo4j.Neo4jContainerExtension.log
 import org.neo4j.driver.AuthToken
 import org.neo4j.driver.AuthTokens
 import org.neo4j.driver.GraphDatabase

--- a/test-support/src/main/scala/org/neo4j/Neo4jContainerExtension.scala
+++ b/test-support/src/main/scala/org/neo4j/Neo4jContainerExtension.scala
@@ -22,6 +22,9 @@ import org.neo4j.driver.GraphDatabase
 import org.neo4j.driver.SessionConfig
 import org.neo4j.spark.TestUtil
 import org.rnorth.ducttape.unreliables.Unreliables
+import org.slf4j.Logger
+import org.slf4j.LoggerFactory
+import org.testcontainers.containers.output.Slf4jLogConsumer
 import org.testcontainers.containers.wait.strategy.AbstractWaitStrategy
 import org.testcontainers.containers.wait.strategy.WaitAllStrategy
 import org.testcontainers.neo4j.Neo4jContainer
@@ -83,6 +86,8 @@ class Neo4jContainerExtension
 
   private var fixture: Set[(String, String)] = Set.empty
 
+  private var logPrefix: Option[String] = Option.empty
+
   def withDatabases(dbs: Seq[String]): Neo4jContainerExtension = {
     databases ++= dbs
     this
@@ -90,6 +95,11 @@ class Neo4jContainerExtension
 
   def withFixture(database: String, path: String): Neo4jContainerExtension = {
     fixture ++= Set((database, path))
+    this
+  }
+
+  def withLogPrefix(prefix: String): Neo4jContainerExtension = {
+    logPrefix = Some(prefix)
     this
   }
 
@@ -103,6 +113,11 @@ class Neo4jContainerExtension
         new DatabasesWaitStrategy(createAuth()).forDatabases(databases).withStartupTimeout(Duration.ofMinutes(2))
       )
     }
+    val logConsumer = new Slf4jLogConsumer(log)
+    for (value <- logPrefix) {
+      logConsumer.withPrefix(value)
+    }
+    withLogConsumer(logConsumer)
     addEnv("NEO4J_ACCEPT_LICENSE_AGREEMENT", "yes")
     super.start()
 
@@ -125,4 +140,8 @@ class Neo4jContainerExtension
       }
     }
   }
+}
+
+object Neo4jContainerExtension {
+  private val log: Logger = LoggerFactory.getLogger(Neo4jContainerExtension.getClass)
 }


### PR DESCRIPTION
This is a backport of https://github.com/neo4j/neo4j-spark-connector/pull/1047 to `5.0`