### PR TITLE
build: stop attaching the temporary assembly artifact

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -574,6 +574,7 @@
                             <descriptorRef>jar-with-dependencies</descriptorRef>
                         </descriptorRefs>
                         <finalName>${project.build.finalName}</finalName>
+                        <attach>false</attach>
                     </configuration>
                     <executions>
                         <execution>


### PR DESCRIPTION
The assembly JAR is renamed to replace the main artifact during
packaging. Keeping it attached makes Maven attempt to install the
original `-jar-with-dependencies` path after it has been moved.

Disable attachment so Maven only installs and deploys the renamed
main JAR.
