### PR TITLE
build: relocate connector v5_2.13 to 6.0.0

### DIFF
--- a/relocation/README.md
+++ b/relocation/README.md
@@ -1,0 +1,15 @@
+# Neo4j Spark Connector v6 relocation
+
+Since version 6.0.0 and later, we now use a different maven coordinate for our Spark connector.
+If you plan to migrate from our v5 family of connectors, please use the new coordinate.
+
+Version 6.0.0 introduces compatibility support for Apache Spark 4.0 and 4.1.
+Since Apache Spark itself dropped support for Scala version 2.12, we followed suite and also dropped 2.12 support.
+Therefore you will only find our v6 connector with support for Scala 2.13 and we only relocate our v5 variant that use Scala 2.13.
+
+This is the maven relocation that was applied:
+
+```patch
+-org.neo4j:neo4j-connector-apache-spark_2.13:6.0.0_for_spark_3
++org.neo4j.connectors:spark:6.0.0-s_2.13
+```

--- a/relocation/relocate.sh
+++ b/relocation/relocate.sh
@@ -1,0 +1,15 @@
+#!/bin/env bash
+
+if ! test -d "spark-3"; then
+  echo "you are likely not in repo root, please run this script from repo root"
+  exit 1
+fi
+
+set -euo pipefail
+
+repository="${PWD}/target/relocation-repository"
+
+rm -rf "${repository}"
+
+./mvnw -B -f relocation/scala_2.13/6.0.0_for_spark_3/pom.xml deploy -DaltDeploymentRepository="relocation::file://${repository}"
+./mvnw -B -f relocation/scala_2.13/6.0.0_for_spark_4/pom.xml deploy -DaltDeploymentRepository="relocation::file://${repository}"

--- a/relocation/scala_2.13/6.0.0_for_spark_3/pom.xml
+++ b/relocation/scala_2.13/6.0.0_for_spark_3/pom.xml
@@ -1,0 +1,58 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="
+           http://maven.apache.org/POM/4.0.0
+           https://maven.apache.org/xsd/maven-4.0.0.xsd">
+
+  <modelVersion>4.0.0</modelVersion>
+
+  <groupId>org.neo4j</groupId>
+  <artifactId>neo4j-connector-apache-spark_2.13</artifactId>
+  <version>6.0.0_for_spark_3</version>
+  <packaging>pom</packaging>
+
+  <name>Neo4j Connector for Apache Spark relocation</name>
+  <description>
+    Relocation POM for the Neo4j Connector for Apache Spark.
+  </description>
+  <url>https://github.com/neo4j/neo4j-spark-connector</url>
+
+  <licenses>
+    <license>
+      <name>Apache License, Version 2.0</name>
+      <url>https://www.apache.org/licenses/LICENSE-2.0.txt</url>
+      <distribution>repo</distribution>
+    </license>
+  </licenses>
+
+  <developers>
+    <developer>
+      <name>Neo4j</name>
+      <organization>Neo4j, Inc.</organization>
+      <organizationUrl>https://neo4j.com</organizationUrl>
+    </developer>
+  </developers>
+
+  <scm>
+    <connection>
+      scm:git:https://github.com/neo4j/neo4j-spark-connector.git
+    </connection>
+    <developerConnection>
+      scm:git:ssh://git@github.com/neo4j/neo4j-spark-connector.git
+    </developerConnection>
+    <url>https://github.com/neo4j/neo4j-spark-connector</url>
+  </scm>
+
+  <distributionManagement>
+    <relocation>
+      <groupId>org.neo4j.connectors</groupId>
+      <artifactId>spark</artifactId>
+      <version>6.0.0-s_2.13</version>
+      <message>
+        Neo4j Connector for Apache Spark 6 moved to org.neo4j.connectors:spark and requires Spark 4 with Scala 2.13.
+      </message>
+    </relocation>
+  </distributionManagement>
+
+</project>

--- a/relocation/scala_2.13/6.0.0_for_spark_4/pom.xml
+++ b/relocation/scala_2.13/6.0.0_for_spark_4/pom.xml
@@ -1,0 +1,58 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="
+           http://maven.apache.org/POM/4.0.0
+           https://maven.apache.org/xsd/maven-4.0.0.xsd">
+
+  <modelVersion>4.0.0</modelVersion>
+
+  <groupId>org.neo4j</groupId>
+  <artifactId>neo4j-connector-apache-spark_2.13</artifactId>
+  <version>6.0.0_for_spark_4</version>
+  <packaging>pom</packaging>
+
+  <name>Neo4j Connector for Apache Spark relocation</name>
+  <description>
+    Relocation POM for the Neo4j Connector for Apache Spark.
+  </description>
+  <url>https://github.com/neo4j/neo4j-spark-connector</url>
+
+  <licenses>
+    <license>
+      <name>Apache License, Version 2.0</name>
+      <url>https://www.apache.org/licenses/LICENSE-2.0.txt</url>
+      <distribution>repo</distribution>
+    </license>
+  </licenses>
+
+  <developers>
+    <developer>
+      <name>Neo4j</name>
+      <organization>Neo4j, Inc.</organization>
+      <organizationUrl>https://neo4j.com</organizationUrl>
+    </developer>
+  </developers>
+
+  <scm>
+    <connection>
+      scm:git:https://github.com/neo4j/neo4j-spark-connector.git
+    </connection>
+    <developerConnection>
+      scm:git:ssh://git@github.com/neo4j/neo4j-spark-connector.git
+    </developerConnection>
+    <url>https://github.com/neo4j/neo4j-spark-connector</url>
+  </scm>
+
+  <distributionManagement>
+    <relocation>
+      <groupId>org.neo4j.connectors</groupId>
+      <artifactId>spark</artifactId>
+      <version>6.0.0-s_2.13</version>
+      <message>
+        Neo4j Connector for Apache Spark 6 moved to org.neo4j.connectors:spark and requires Spark 4 with Scala 2.13.
+      </message>
+    </relocation>
+  </distributionManagement>
+
+</project>


### PR DESCRIPTION
This commit contains a Maven relocation to our new connector. We only
relocate from v5 with Scala 2.13, because there is no such thing as
version 6+ with Scala 2.12 support.

To test the relocation locally, you can do the following from repo
root:

```
./relocation/relocate.sh

find target/relocation-repository/o*/n*/n*/6.0.0_for_spark_*
  -maxdepth 1 -type f -print

mkdir reloc-test

// setup a relocation-test/pom.xml that uses any of these dependency:
// - neo4j-connector-apache-spark_2.13:6.0.0_for_spark_3
// - neo4j-connector-apache-spark_2.13:6.0.0_for_spark_4

./mvnw -U -Dmaven.repo.local=/tmp/reloc-test -f reloc-test/pom.xml \
  dependency:tree

Should output a maven warning:

The artifact
org.neo4j:neo4j-connector-apache-spark_2.13:jar:6.0.0_for_spark_3
has been relocated to
org.neo4j.connectors:spark:jar:6.0.0-s_2.13
```