### PR TITLE
ci: docs changes do not trigger TC

### DIFF
--- a/.teamcity/settings.kts
+++ b/.teamcity/settings.kts
@@ -44,10 +44,13 @@ project {
               appendLine("+:$DEFAULT_BRANCH")
               appendLine("+:refs/heads/$DEFAULT_BRANCH")
             }
+
             this.triggerRules =
                 """
               -:comment=^build.*release version.*:**
               -:comment=^build.*update version.*:**
+              -:docs/**
+              -:.github/workflows/docs-*.yml
               """
                     .trimIndent()
           }
@@ -70,6 +73,13 @@ project {
               appendLine("+:pull/*")
               appendLine("+:refs/heads/pull/*")
             }
+
+            this.triggerRules =
+                """
+              -:docs/**
+              -:.github/workflows/docs-*.yml
+              """
+                    .trimIndent()
           }
         }
 


### PR DESCRIPTION
This PR introduce a new trigger filter aimed to skip team city builds
if and only if the new incoming change only touches documentation files