### PR TITLE
docs: notice about maven relocate, update connector links

### DIFF
--- a/docs/modules/ROOT/pages/configuration.adoc
+++ b/docs/modules/ROOT/pages/configuration.adoc
@@ -127,7 +127,7 @@ val df = spark.read
 
 == Neo4j driver options
 
-Under the covers, the Spark connector uses the link:https://neo4j.com/docs/java-manual/current/get-started/#java-driver-get-started-about[official Neo4j Java Driver].
+Under the covers, the Spark connector uses the link:https://neo4j.com/docs/java-manual/6[official Neo4j Java Driver].
 When using the connector, you can set any valid Neo4j driver option using the `option` method:
 
 [source,scala]
@@ -172,7 +172,7 @@ val dfProduct = spark.read.format("org.neo4j.spark.DataSource")
 ----
 
 The following table captures the most common configuration settings to use with the Neo4j driver.  For full
-documentation on all possible configuration options for Neo4j Drivers, see the link:https://neo4j.com/docs/java-manual/current[Neo4j Java Driver manual].
+documentation on all possible configuration options for Neo4j Drivers, see the link:https://neo4j.com/docs/java-manual/6[Neo4j Java Driver manual].
 
 .List of available configuration settings
 |===
@@ -183,7 +183,7 @@ documentation on all possible configuration options for Neo4j Drivers, see the l
 |`url`
 a|The url of the Neo4j instance to connect to.
 
-When provided with a comma-separated list of URIs, the link:https://neo4j.com/docs/java-manual/current/client-applications/#java-driver-resolver-function[resolver function] feature of the driver will be activated.
+When provided with a comma-separated list of URIs, the link:https://neo4j.com/docs/java-manual/6/connect/#cluster[resolver function] feature of the driver will be activated.
 The first URI will be used as original host while the rest are treated as resolver function outputs.
 |_(none)_
 |Yes

--- a/docs/modules/ROOT/pages/configuration.adoc
+++ b/docs/modules/ROOT/pages/configuration.adoc
@@ -199,7 +199,7 @@ The authentication methods to be used:
 * `bearer`
 * any <<custom-auth-supplier, custom authentication supplier>>
 
-See link:https://neo4j.com/docs/java-manual/4.4/client-applications/#java-driver-authentication[Authentication] for more information.
+See link:https://neo4j.com/docs/java-manual/6/connect-advanced[Authentication] for more information.
 |`basic`
 |No
 

--- a/docs/modules/ROOT/pages/databricks.adoc
+++ b/docs/modules/ROOT/pages/databricks.adoc
@@ -56,7 +56,7 @@ A secure alternative is to use <<secrets, secrets>> instead.
 
 == Authentication methods
 
-All the authentication methods supported by the link:{neo4j-docs-base-uri}/java-manual/current/connect-advanced/#_authentication_methods[Neo4j Java Driver] (version 4.4 and higher) are supported.
+All the authentication methods supported by the link:{neo4j-docs-base-uri}/java-manual/6/connect-advanced/#authentication-methods[Neo4j Java Driver] (version 6 and higher) are supported.
 
 See the xref:configuration.adoc#_neo4j_driver_options[Neo4j driver options] for more details on authentication configuration.
 

--- a/docs/modules/ROOT/pages/migration.adoc
+++ b/docs/modules/ROOT/pages/migration.adoc
@@ -4,6 +4,13 @@
 This guide covers the upgrade boundaries to and between the 6.x line that contain *breaking changes*.
 For the complete list of changes per release, see xref:changelog.adoc[].
 
+[NOTE]
+====
+The Maven coordinate for the connector has been changed since major version 6.0.0.
+The new coordinate is `org.neo4j.connectors:spark`.
+When migrating from an older major version, update the Maven coordinate.
+====
+
 [cols="1,3"]
 |===
 |Upgrade |Breaking change


### PR DESCRIPTION
we recently added a maven relocate from the old coordinate
`org.neo4j:neo4j-connector-apache-spark_2.13:6.0.0_for_spark_3`
to the new coordinate.

this PR simply adds a notice box about it. the rest of the migration
documentation already uses the new coordinate.

Also updates all links to the connector manual to be anchored on
version 6 and not version "current".