### PR TITLE
fix: remove skip/limit validation

### DIFF
--- a/docs/modules/ROOT/pages/read/query.adoc
+++ b/docs/modules/ROOT/pages/read/query.adoc
@@ -55,41 +55,6 @@ RETURN p
 If you need to return a graph entity, use the xref:read/labels.adoc[`labels`] or xref:read/relationship.adoc[`relationship`] read options instead.
 ====
 
-[[limit-query]]
-== Limit the results
-
-The connector uses `SKIP` and `LIMIT` internally to support partitioned reads; as a result, `SKIP` and `LIMIT` clauses are not allowed in a custom Cypher query.
-Attempts to do this will cause execution errors.
-
-A possible workaround is to use `SKIP` and `LIMIT` _before_ the `RETURN` clause.
-For example, the following query fails:
-
-[source,cypher]
-----
-MATCH (p:Person)
-RETURN p.name AS name
-ORDER BY name
-LIMIT 10
-----
-
-The query can be rewritten with `LIMIT` before the `RETURN` to complete successfully:
-
-[source,cypher]
-----
-MATCH (p:Person)
-WITH p.name AS name
-ORDER BY name
-LIMIT 10
-RETURN p.name
-----
-
-[CAUTION]
-====
-When you rewrite a query, make sure the new query is equivalent to your original query so that the result is the same.
-====
-
-You can also use the `query.count` option instead of rewriting your query.
-See the xref:performance/spark.adoc#parallelize[Spark optimizations] page for more details.
 
 [[script-options]]
 == Script options

--- a/src/main/scala/org/neo4j/spark/cypher/QueryEmbedder.scala
+++ b/src/main/scala/org/neo4j/spark/cypher/QueryEmbedder.scala
@@ -44,6 +44,8 @@ class QueryEmbedder {
   /**
    * This embeds the write query as a CALL subquery
    * @param originalQuery the original query
+   * @param allEventsVariable variable name for the event batch (e.g. "xs" in "UNWIND xs AS x")
+   * @param eventVariable variable name for one event (e.g. "x" in "UNWIND xs AS x")
    * @param scriptResult the script result, if any
    * @return
    */

--- a/src/main/scala/org/neo4j/spark/cypher/QueryEmbedder.scala
+++ b/src/main/scala/org/neo4j/spark/cypher/QueryEmbedder.scala
@@ -20,7 +20,10 @@ import org.neo4j.cypherdsl.core.Cypher
 import org.neo4j.cypherdsl.core.Cypher.callRawCypher
 import org.neo4j.cypherdsl.core.Expression
 import org.neo4j.cypherdsl.core.ResultStatement
+import org.neo4j.cypherdsl.core.Statement
 import org.neo4j.cypherdsl.core.StatementBuilder
+import org.neo4j.cypherdsl.parser.CypherParser
+import org.neo4j.spark.service.Neo4jQueryStrategy.VARIABLE_EVENT
 
 class QueryEmbedder {
 
@@ -32,10 +35,33 @@ class QueryEmbedder {
    * @param scriptResult the script result, if any
    * @return
    */
-  def embed(originalQuery: String, scriptResult: String): StatementBuilder.BuildableStatement[ResultStatement] = {
+  def embedRead(originalQuery: String, scriptResult: String): StatementBuilder.BuildableStatement[ResultStatement] = {
     val query = aliaser.aliasResults(originalQuery) // unaliased results are not allowed in subqueries
     callRawCypher(s"$scriptResult${query.query}")
       .returning(returnItems(query): _*)
+  }
+
+  /**
+   * This embeds the write query as a CALL subquery
+   * @param originalQuery the original query
+   * @param scriptResult the script result, if any
+   * @return
+   */
+  def embedWrite(
+    originalQuery: String,
+    allEventsVariable: String,
+    eventVariable: String,
+    scriptResult: String
+  ): StatementBuilder.BuildableStatement[Statement] = {
+    val event = Cypher.name(eventVariable)
+    val subquery =
+      CypherParser.parseStatement(
+        scriptResult + originalQuery
+      )
+    Cypher
+      .unwind(Cypher.parameter(allEventsVariable))
+      .as(event)
+      .call(subquery, event)
   }
 
   private def returnItems(query: AliasedQuery): Seq[Expression] =

--- a/src/main/scala/org/neo4j/spark/service/Neo4jQueryService.scala
+++ b/src/main/scala/org/neo4j/spark/service/Neo4jQueryService.scala
@@ -38,6 +38,7 @@ import org.neo4j.spark.cypher.CypherPreamble.fullPreamble
 import org.neo4j.spark.cypher.CypherRenderer
 import org.neo4j.spark.cypher.QueryEmbedder
 import org.neo4j.spark.service.Neo4jQueryStrategy.VARIABLE_EVENT
+import org.neo4j.spark.service.Neo4jQueryStrategy.VARIABLE_EVENTS
 import org.neo4j.spark.service.Neo4jQueryStrategy.eventProperties
 import org.neo4j.spark.service.Neo4jQueryStrategy.relEventProperties
 import org.neo4j.spark.service.Neo4jQueryStrategy.scriptResultClause
@@ -59,6 +60,7 @@ import scala.jdk.CollectionConverters.SeqHasAsJava
 class Neo4jQueryWriteStrategy(
   private val neo4j: Neo4j,
   private val renderer: CypherRenderer,
+  private val embedder: QueryEmbedder,
   private val saveMode: SaveMode,
   private val withPreamble: Boolean = true
 ) extends Neo4jQueryStrategy {
@@ -67,7 +69,8 @@ class Neo4jQueryWriteStrategy(
     val preamble = if (withPreamble) fullPreamble(neo4j, options) else ""
     val scriptResult = scriptResultClause(options)
 
-    preamble + scriptResult + unwindEventsAsEvent + options.query.value
+    val statement = embedder.embedWrite(options.query.value, VARIABLE_EVENTS, VARIABLE_EVENT, scriptResult)
+    s"$preamble${renderer.render(statement.build())}"
   }
 
   override def createStatementForRelationships(options: Neo4jOptions): String = {
@@ -213,7 +216,7 @@ class Neo4jQueryReadStrategy(
   override def createStatementForQuery(options: Neo4jOptions): String = {
     val scriptResult = scriptResultClause(options)
     var statement: StatementBuilder.BuildableStatement[ResultStatement] =
-      queryEmbedder.embed(options.query.value, scriptResult)
+      queryEmbedder.embedRead(options.query.value, scriptResult)
     if (partitionPagination.topN.orders.nonEmpty) {
       statement = statement
         .asInstanceOf[StatementBuilder.TerminalExposesOrderBy]

--- a/src/main/scala/org/neo4j/spark/util/Validations.scala
+++ b/src/main/scala/org/neo4j/spark/util/Validations.scala
@@ -305,10 +305,6 @@ case class ValidateRead(neo4j: Neo4j, neo4jOptions: Neo4jOptions, jobId: String)
           )
         }
         case QueryType.QUERY => {
-          ValidationUtil.isFalse(
-            neo4jOptions.query.value.matches("(?si).*(LIMIT \\d+|SKIP ?\\d+)\\s*\\z"),
-            "SKIP/LIMIT are not allowed at the end of the query"
-          )
           val params = Map[String, AnyRef](
             Neo4jQueryStrategy.VARIABLE_SCRIPT_RESULT -> "",
             Neo4jQueryStrategy.VARIABLE_STREAM -> Collections.emptyMap()

--- a/src/main/scala/org/neo4j/spark/writer/BaseDataWriter.scala
+++ b/src/main/scala/org/neo4j/spark/writer/BaseDataWriter.scala
@@ -28,6 +28,7 @@ import org.neo4j.driver.Transaction
 import org.neo4j.driver.Values
 import org.neo4j.driver.exceptions.ServiceUnavailableException
 import org.neo4j.spark.cypher.CypherRenderer
+import org.neo4j.spark.cypher.QueryEmbedder
 import org.neo4j.spark.service._
 import org.neo4j.spark.util.DriverCache
 import org.neo4j.spark.util.Neo4jOptions
@@ -70,7 +71,7 @@ abstract class BaseDataWriter(
   private val query: String =
     new Neo4jQueryService(
       options,
-      new Neo4jQueryWriteStrategy(neo4j, new CypherRenderer(neo4j, options), saveMode)
+      new Neo4jQueryWriteStrategy(neo4j, new CypherRenderer(neo4j, options), new QueryEmbedder(), saveMode)
     ).createQuery()
 
   private val metrics = DataWriterMetrics()

--- a/src/test/scala/org/neo4j/spark/ReadIT.scala
+++ b/src/test/scala/org/neo4j/spark/ReadIT.scala
@@ -2006,5 +2006,18 @@ class ReadIT {
           )
         )
     }
+
+    @Test
+    def supports_query_with_skip_limit(driver: Driver, spark: SparkSession, neo4j: Neo4j): Unit = {
+      val df = spark.read
+        .format(classOf[DataSource].getName)
+        .option("query", "UNWIND [1,2,3,4,5] AS x RETURN x SKIP 2 LIMIT 2")
+        .load()
+
+      assertThat(df.collect()).containsExactly(
+        Row(3L),
+        Row(4L)
+      )
+    }
   }
 }

--- a/src/test/scala/org/neo4j/spark/ReadIT.scala
+++ b/src/test/scala/org/neo4j/spark/ReadIT.scala
@@ -1876,47 +1876,6 @@ class ReadIT {
         .containsOnlyOnce(("foo", 1), ("foo", 2))
     }
 
-    @ParameterizedTest
-    @ValueSource(strings = Array("limit", "\nlimit", "LIMIT", "\nLIMIT", "lImIT", "\nlImIT"))
-    @ClearSystemProperty(key = "strict.cypher")
-    def fails_if_limit_is_used_at_the_end_of_the_query(
-      limitKeyword: String,
-      driver: Driver,
-      spark: SparkSession,
-      neo4j: Neo4j
-    ): Unit = {
-      assertThatExceptionOfType(classOf[IllegalArgumentException])
-        .isThrownBy(() => {
-          spark.read
-            .format(classOf[DataSource].getName)
-            .option("query", s"MATCH (n:Label) RETURN elementId(n) as id $limitKeyword 100")
-            // generated query would yield 42I63 because of misplaced LIMIT in strict mode
-            .load()
-            .count()
-        })
-        .withMessage("SKIP/LIMIT are not allowed at the end of the query")
-    }
-
-    @ParameterizedTest
-    @ValueSource(strings = Array("limit", "\nlimit", "LIMIT", "\nLIMIT", "lImIT", "\nlImIT"))
-    def supports_limit_keyword_when_not_at_the_end_of_the_query(
-      limitKeyword: String,
-      driver: Driver,
-      spark: SparkSession,
-      neo4j: Neo4j
-    ): Unit = {
-      driver.executableQuery(s"""UNWIND range(1, 100) as id
-                                |CREATE (:Product {id: id, name: 'Product ' + id})""".stripMargin)
-        .execute()
-
-      val df = spark.read
-        .format(classOf[DataSource].getName)
-        .option("query", s"MATCH (p:Product) WITH p $limitKeyword 10\nRETURN p")
-        .load()
-
-      assertThat(df.count()).isEqualTo(10)
-    }
-
     @Test
     def supports_user_defined_schema(driver: Driver, spark: SparkSession, neo4j: Neo4j): Unit = {
       driver.executableQuery("CREATE (p:Person {name: 'Foo Bar', age: 8})")

--- a/src/test/scala/org/neo4j/spark/WriteIT.scala
+++ b/src/test/scala/org/neo4j/spark/WriteIT.scala
@@ -245,6 +245,23 @@ class WriteIT {
     }
 
     @Test
+    def should_insert_data_with_custom_query_with_skip_limit(driver: Driver, spark: SparkSession, neo4j: Neo4j): Unit = {
+      SparkSession.setActiveSession(spark)
+      val df = spark.createDataFrame(
+          (0 to 99).map(i => (i, 99 - i))
+        ).toDF("a", "b")
+
+      df.write
+        .format(classOf[DataSource].getName)
+        .mode(SaveMode.Append)
+        .option("query", "CALL () { UNWIND [1,2] AS x RETURN x SKIP 1 LIMIT 1 } CREATE (q:Query {first: event.a, second: event.b})")
+        .save()
+
+      val got = driver.session().run("MATCH (q:Query) RETURN count(q) AS count").single().get("count").asLong()
+      assertThat(got).isEqualTo(df.count())
+    }
+
+    @Test
     def should_properly_overwrite_when_already_existing(driver: Driver, spark: SparkSession, neo4j: Neo4j): Unit = {
       import spark.implicits._
 

--- a/src/test/scala/org/neo4j/spark/WriteIT.scala
+++ b/src/test/scala/org/neo4j/spark/WriteIT.scala
@@ -245,16 +245,23 @@ class WriteIT {
     }
 
     @Test
-    def should_insert_data_with_custom_query_with_skip_limit(driver: Driver, spark: SparkSession, neo4j: Neo4j): Unit = {
+    def should_insert_data_with_custom_query_with_skip_limit(
+      driver: Driver,
+      spark: SparkSession,
+      neo4j: Neo4j
+    ): Unit = {
       SparkSession.setActiveSession(spark)
       val df = spark.createDataFrame(
-          (0 to 99).map(i => (i, 99 - i))
-        ).toDF("a", "b")
+        (0 to 99).map(i => (i, 99 - i))
+      ).toDF("a", "b")
 
       df.write
         .format(classOf[DataSource].getName)
         .mode(SaveMode.Append)
-        .option("query", "CALL () { UNWIND [1,2] AS x RETURN x SKIP 1 LIMIT 1 } CREATE (q:Query {first: event.a, second: event.b})")
+        .option(
+          "query",
+          "UNWIND [1,2] AS x WITH x, event SKIP 1 LIMIT 1 CREATE (q:Query {first: event.a, second: event.b})"
+        )
         .save()
 
       val got = driver.session().run("MATCH (q:Query) RETURN count(q) AS count").single().get("count").asLong()

--- a/src/test/scala/org/neo4j/spark/cypher/QueryEmbedderIT.scala
+++ b/src/test/scala/org/neo4j/spark/cypher/QueryEmbedderIT.scala
@@ -44,6 +44,7 @@ import org.testcontainers.neo4j.Neo4jContainer
 import java.util.stream.Stream
 
 import scala.jdk.CollectionConverters.MapHasAsJava
+import scala.jdk.CollectionConverters.SeqHasAsJava
 
 @Testcontainers
 @TestInstance(PER_CLASS)
@@ -78,7 +79,7 @@ class QueryEmbedderIT {
     val unaliasedQueryStatement = callRawCypher(query).returning(asterisk()).build()
     verifyQueryFailsWithAliasingError(renderer.render(unaliasedQueryStatement))
 
-    val embeddedQuery = embedder.embed(query, "").build()
+    val embeddedQuery = embedder.embedRead(query, "").build()
 
     assertThat(embeddedQuery.getCypher).isEqualTo(
       "CALL () {MATCH (o:Object) RETURN 42 AS `42`, false AS false, o.name AS `o.name`, o.brother AS `o.brother`} RETURN `42`, false, `o.name`, `o.brother`"
@@ -88,7 +89,7 @@ class QueryEmbedderIT {
   }
 
   @ParameterizedTest
-  @MethodSource(Array("embed_cases"))
+  @MethodSource(Array("embed_read_cases"))
   def embeds_query_as_call_subquery(
     query: String,
     scriptResult: String,
@@ -97,7 +98,7 @@ class QueryEmbedderIT {
   ): Unit = {
     assertThat(driver.isDefined).isTrue
 
-    val embeddedQuery = embedder.embed(query, scriptResult).build()
+    val embeddedQuery = embedder.embedRead(query, scriptResult).build()
 
     val renderer = container.cypherRenderer()
     assertThat(embeddedQuery.getCypher).isEqualTo(expectedEmbeddedQuery)
@@ -109,7 +110,7 @@ class QueryEmbedderIT {
       .doesNotThrowAnyException()
   }
 
-  private def embed_cases(): Stream[Arguments] =
+  private def embed_read_cases(): Stream[Arguments] =
     Stream.of(
       argumentSet(
         "preserves return all",
@@ -140,6 +141,96 @@ class QueryEmbedderIT {
         "CALL () {WITH 42 AS y RETURN *, y AS x} RETURN *, x"
       )
     )
+
+  @ParameterizedTest
+  @MethodSource(Array("embed_write_cases"))
+  def embeds_write_query_as_call_subquery(
+    query: String,
+    scriptResult: String,
+    params: Map[String, AnyRef],
+    expectedEmbeddedQuery: String,
+    resultLabel: String,
+    expectedCreatedNodes: Long
+  ): Unit = {
+    assertThat(driver.isDefined).isTrue
+
+    val embeddedQuery = embedder.embedWrite(query, "events", "event", scriptResult).build()
+
+    val renderer = container.cypherRenderer()
+    assertThat(embeddedQuery.getCypher).isEqualTo(expectedEmbeddedQuery)
+    assertThatCode(() =>
+      driver.get.executableQuery(renderer.render(embeddedQuery))
+        .withParameters(params.asJava)
+        .execute()
+    )
+      .doesNotThrowAnyException()
+    assertThat(countNodesWithLabel(resultLabel)).isEqualTo(expectedCreatedNodes)
+  }
+
+  private def embed_write_cases(): Stream[Arguments] =
+    Stream.of(
+      argumentSet(
+        "embeds write query",
+        "CREATE (:EmbeddedWriteBasic {name: event.name})",
+        "",
+        queryParams(Seq(
+          Map[String, AnyRef]("name" -> "Ada"),
+          Map[String, AnyRef]("name" -> "Bob")
+        )),
+        "UNWIND $events AS event CALL (event) {CREATE (:`EmbeddedWriteBasic` {name: event.name})}",
+        "EmbeddedWriteBasic",
+        2
+      ),
+      argumentSet(
+        "embeds write query with script result",
+        "CREATE (:EmbeddedWriteScript {name: event.name, suffix: scriptResult[0].suffix})",
+        "WITH $scriptResult AS scriptResult ",
+        queryParams(
+          Seq(Map[String, AnyRef]("name" -> "Ada")),
+          Some(Seq(Map[String, AnyRef]("suffix" -> "from-script")).map(_.asJava).asJava)
+        ),
+        "UNWIND $events AS event CALL (event) {WITH $scriptResult AS scriptResult CREATE (:`EmbeddedWriteScript` {name: event.name, suffix: scriptResult[0].suffix})}",
+        "EmbeddedWriteScript",
+        1
+      ),
+      argumentSet(
+        "embeds write query with nested call",
+        "CREATE (n:EmbeddedWriteNested {name: event.name}) CALL (n) { SET n.nested = true } SET n.after = true",
+        "",
+        queryParams(Seq(Map[String, AnyRef]("name" -> "Ada"))),
+        "UNWIND $events AS event CALL (event) {CREATE (n:`EmbeddedWriteNested` {name: event.name}) CALL (*) {SET n.nested = true} SET n.after = true}",
+        "EmbeddedWriteNested",
+        1
+      ),
+      argumentSet(
+        "embeds write query with skip and limit",
+        "UNWIND event.values AS value WITH value ORDER BY value SKIP 1 LIMIT 1 CREATE (:EmbeddedWriteSkipLimit {value: value})",
+        "",
+        queryParams(Seq(
+          Map[String, AnyRef]("values" -> Seq(1, 2, 3).map(_.asInstanceOf[AnyRef]).asJava)
+        )),
+        "UNWIND $events AS event CALL (event) {UNWIND event.values AS value WITH value ORDER BY value ASC SKIP 1 LIMIT 1 CREATE (:`EmbeddedWriteSkipLimit` {value: value})}",
+        "EmbeddedWriteSkipLimit",
+        1
+      )
+    )
+
+  private def queryParams(
+    events: Seq[Map[String, AnyRef]],
+    scriptResult: Option[AnyRef] = None
+  ): Map[String, AnyRef] = {
+    val params = Map[String, AnyRef]("events" -> events.map(_.asJava).asJava)
+    scriptResult.fold(params)(value => params + ("scriptResult" -> value))
+  }
+
+  private def countNodesWithLabel(label: String): Long = {
+    driver.get.executableQuery(s"MATCH (n:`$label`) RETURN count(n) AS count")
+      .execute()
+      .records()
+      .get(0)
+      .get("count")
+      .asLong()
+  }
 
   private def verifyQueryFailsWithAliasingError(query: String): Unit = {
     assertThatThrownBy(() => driver.get.executableQuery(query).execute())

--- a/src/test/scala/org/neo4j/spark/cypher/QueryEmbedderIT.scala
+++ b/src/test/scala/org/neo4j/spark/cypher/QueryEmbedderIT.scala
@@ -195,10 +195,10 @@ class QueryEmbedderIT {
       ),
       argumentSet(
         "embeds write query with nested call",
-        "CREATE (n:EmbeddedWriteNested {name: event.name}) CALL (n) { SET n.nested = true } SET n.after = true",
+        "CREATE (n:EmbeddedWriteNested {name: event.name}) WITH n CALL (n) { SET n.nested = true } SET n.after = true",
         "",
         queryParams(Seq(Map[String, AnyRef]("name" -> "Ada"))),
-        "UNWIND $events AS event CALL (event) {CREATE (n:`EmbeddedWriteNested` {name: event.name}) CALL (*) {SET n.nested = true} SET n.after = true}",
+        "UNWIND $events AS event CALL (event) {CREATE (n:`EmbeddedWriteNested` {name: event.name}) WITH n CALL (*) {SET n.nested = true} SET n.after = true}",
         "EmbeddedWriteNested",
         1
       ),

--- a/src/test/scala/org/neo4j/spark/cypher/QueryEmbedderTest.scala
+++ b/src/test/scala/org/neo4j/spark/cypher/QueryEmbedderTest.scala
@@ -32,14 +32,22 @@ class QueryEmbedderTest {
   private val embedder = new QueryEmbedder()
 
   @ParameterizedTest
-  @MethodSource(Array("embed_cases"))
+  @MethodSource(Array("embed_read_cases"))
   def embeds_user_defined_query(query: String, scriptResult: String, expected: String): Unit = {
-    val result = embedder.embed(query, scriptResult).build().getCypher
+    val result = embedder.embedRead(query, scriptResult).build().getCypher
 
     assertThat(result).isEqualTo(expected)
   }
 
-  private def embed_cases(): Stream[Arguments] =
+  @ParameterizedTest
+  @MethodSource(Array("embed_write_cases"))
+  def embeds_user_defined_write_query(query: String, scriptResult: String, expected: String): Unit = {
+    val result = embedder.embedWrite(query, "events", "event", scriptResult).build().getCypher
+
+    assertThat(result).isEqualTo(expected)
+  }
+
+  private def embed_read_cases(): Stream[Arguments] =
     Stream.of(
       argumentSet(
         "returns automatically aliased fields",
@@ -76,6 +84,34 @@ class QueryEmbedderTest {
         "WITH 42 as y RETURN *, y AS x",
         "",
         "CALL () {WITH 42 AS y RETURN *, y AS x} RETURN *, x"
+      )
+    )
+
+  private def embed_write_cases(): Stream[Arguments] =
+    Stream.of(
+      argumentSet(
+        "embeds write query",
+        "CREATE (:EmbeddedWriteBasic {name: event.name})",
+        "",
+        "UNWIND $events AS event CALL (event) {CREATE (:`EmbeddedWriteBasic` {name: event.name})}"
+      ),
+      argumentSet(
+        "embeds script result prelude",
+        "CREATE (:EmbeddedWriteScript {name: event.name, suffix: scriptResult[0].suffix})",
+        "WITH $scriptResult AS scriptResult ",
+        "UNWIND $events AS event CALL (event) {WITH $scriptResult AS scriptResult CREATE (:`EmbeddedWriteScript` {name: event.name, suffix: scriptResult[0].suffix})}"
+      ),
+      argumentSet(
+        "embeds nested call",
+        "CREATE (n:EmbeddedWriteNested {name: event.name}) CALL (n) { SET n.nested = true } SET n.after = true",
+        "",
+        "UNWIND $events AS event CALL (event) {CREATE (n:`EmbeddedWriteNested` {name: event.name}) CALL (*) {SET n.nested = true} SET n.after = true}"
+      ),
+      argumentSet(
+        "embeds skip and limit",
+        "UNWIND event.values AS value WITH value ORDER BY value SKIP 1 LIMIT 1 CREATE (:EmbeddedWriteSkipLimit {value: value})",
+        "",
+        "UNWIND $events AS event CALL (event) {UNWIND event.values AS value WITH value ORDER BY value ASC SKIP 1 LIMIT 1 CREATE (:`EmbeddedWriteSkipLimit` {value: value})}"
       )
     )
 }

--- a/src/test/scala/org/neo4j/spark/service/Neo4jQueryServiceTest.scala
+++ b/src/test/scala/org/neo4j/spark/service/Neo4jQueryServiceTest.scala
@@ -1551,7 +1551,12 @@ class Neo4jQueryServiceTest {
 
       val writeService = new Neo4jQueryService(
         neo4jOptions,
-        new Neo4jQueryWriteStrategy(neo4jInfo, new CypherRenderer(neo4jInfo, neo4jOptions), SaveMode.Overwrite)
+        new Neo4jQueryWriteStrategy(
+          neo4jInfo,
+          new CypherRenderer(neo4jInfo, neo4jOptions),
+          new QueryEmbedder(),
+          SaveMode.Overwrite
+        )
       )
 
       val wantQuery = "UNWIND $events AS event MERGE (node:`Person`) SET node += event.properties"
@@ -1577,7 +1582,12 @@ class Neo4jQueryServiceTest {
 
       val writeService = new Neo4jQueryService(
         neo4jOptions,
-        new Neo4jQueryWriteStrategy(neo4jInfo, new CypherRenderer(neo4jInfo, neo4jOptions), SaveMode.Overwrite)
+        new Neo4jQueryWriteStrategy(
+          neo4jInfo,
+          new CypherRenderer(neo4jInfo, neo4jOptions),
+          new QueryEmbedder(),
+          SaveMode.Overwrite
+        )
       )
       val wantQuery =
         """UNWIND $events AS event
@@ -1606,10 +1616,16 @@ class Neo4jQueryServiceTest {
       val noPreambleWriteService =
         new Neo4jQueryService(
           neo4jOptions,
-          new Neo4jQueryWriteStrategy(neo4jInfo, new CypherRenderer(neo4jInfo, neo4jOptions), SaveMode.Overwrite, false)
+          new Neo4jQueryWriteStrategy(
+            neo4jInfo,
+            new CypherRenderer(neo4jInfo, neo4jOptions),
+            new QueryEmbedder(),
+            SaveMode.Overwrite,
+            false
+          )
         )
 
-      val wantQuery = "UNWIND $events AS event MATCH (o:Object) RETURN o"
+      val wantQuery = "UNWIND $events AS event CALL {WITH event MATCH (o:`Object`) RETURN o}"
       assertThat(noPreambleWriteService.createQuery().trim).isEqualTo(wantQuery)
     }
 
@@ -1633,7 +1649,11 @@ class Neo4jQueryServiceTest {
       val writeService =
         new Neo4jQueryService(neo4jOptions, plainWriteStrategy(neo4j, neo4jOptions))
 
-      val wantQuery = s"$tuningPrefix\n${cypherVersionPreamble}UNWIND $$events AS event MATCH (o:Object) RETURN o"
+      val callWithEvent =
+        if (CanIUse.canIUse(Cypher.callSubqueryWithVariableScopeClause()).withNeo4j(neo4j)) "CALL (event) {"
+        else "CALL {WITH event "
+      val wantQuery =
+        s"$tuningPrefix\n${cypherVersionPreamble}UNWIND $$events AS event ${callWithEvent}MATCH (o:`Object`) RETURN o}"
       assertThat(writeService.createQuery().trim).isEqualTo(wantQuery.trim)
     }
 
@@ -1658,8 +1678,11 @@ class Neo4jQueryServiceTest {
       val versionedWriteService =
         new Neo4jQueryService(neo4jOptions, plainWriteStrategy(neo4j, neo4jOptions))
 
+      val callWithEvent =
+        if (CanIUse.canIUse(Cypher.callSubqueryWithVariableScopeClause()).withNeo4j(neo4j)) "CALL (event) {"
+        else "CALL {WITH event "
       val wantQuery =
-        s"$tuningPrefix\n${cypherVersionPreamble}WITH $$scriptResult AS scriptResult UNWIND $$events AS event MATCH (o:Object) RETURN o"
+        s"$tuningPrefix\n${cypherVersionPreamble}UNWIND $$events AS event ${callWithEvent}WITH $$scriptResult AS scriptResult MATCH (o:`Object`) RETURN o}"
 
       assertThat(versionedWriteService.createQuery().trim).isEqualTo(wantQuery.trim)
     }
@@ -1669,7 +1692,7 @@ class Neo4jQueryServiceTest {
       neo4jOptions: Neo4jOptions,
       saveMode: SaveMode = SaveMode.Overwrite
     ): Neo4jQueryWriteStrategy =
-      new Neo4jQueryWriteStrategy(neo4j, new CypherRenderer(neo4j, neo4jOptions), saveMode)
+      new Neo4jQueryWriteStrategy(neo4j, new CypherRenderer(neo4j, neo4jOptions), new QueryEmbedder(), saveMode)
   }
 }
 


### PR DESCRIPTION
This is an oversight and should have been removed when https://github.com/neo4j/neo4j-spark-connector/pull/989 was done.