### PR TITLE
ci: short-circuit pipeline when changes are docs only

### DIFF
--- a/.teamcity/builds/Build.kt
+++ b/.teamcity/builds/Build.kt
@@ -31,41 +31,51 @@ class Build(
             parallel {
               scalaVersions.forEach { scala ->
                 dependentBuildType(
-                    SemgrepCheck(
-                        "${name}-semgrep-check-${scala.version}",
-                        "semgrep check (${scala.version})",
-                        scala))
+                    skipWhenDocsOnly(
+                        SemgrepCheck(
+                            "${name}-semgrep-check-${scala.version}",
+                            "semgrep check (${scala.version})",
+                            scala)))
               }
 
               javaVersions.cartesianProduct(scalaVersions, neo4jVersions).forEach {
                   (java, scala, neo4j) ->
                 sequential {
+                  // note that artifact dependencies are resolved before step conditions are
+                  // evaluated, so for a docs-only change the python integration tests below still
+                  // attempt to download the jar this build has not published
                   val packaging =
-                      Package(
-                          "${name}-package-${java.version}-${scala.version}-${neo4j.version}",
-                          "package (${java.version}, ${scala.version}, ${neo4j.version})",
-                          java,
-                          scala,
+                      skipWhenDocsOnly(
+                          Package(
+                              "${name}-package-${java.version}-${scala.version}-${neo4j.version}",
+                              "package (${java.version}, ${scala.version}, ${neo4j.version})",
+                              java,
+                              scala,
+                          ),
                       )
 
                   dependentBuildType(
-                      Maven(
-                          "${name}-build-${java.version}-${scala.version}-${neo4j.version}",
-                          "build (${java.version}, ${scala.version}, ${neo4j.version})",
-                          "test-compile",
-                          java,
-                          scala,
+                      skipWhenDocsOnly(
+                          Maven(
+                              "${name}-build-${java.version}-${scala.version}-${neo4j.version}",
+                              "build (${java.version}, ${scala.version}, ${neo4j.version})",
+                              "test-compile",
+                              java,
+                              scala,
+                          ),
                       ),
                   )
 
                   dependentBuildType(
-                      Maven(
-                          "${name}-unit-tests-${java.version}-${scala.version}-${neo4j.version}",
-                          "unit tests (${java.version}, ${scala.version}, ${neo4j.version})",
-                          "test",
-                          java,
-                          scala,
-                          neo4j,
+                      skipWhenDocsOnly(
+                          Maven(
+                              "${name}-unit-tests-${java.version}-${scala.version}-${neo4j.version}",
+                              "unit tests (${java.version}, ${scala.version}, ${neo4j.version})",
+                              "test",
+                              java,
+                              scala,
+                              neo4j,
+                          ),
                       ),
                   )
 
@@ -77,13 +87,15 @@ class Build(
 
                   parallel {
                     dependentBuildType(
-                        JavaIntegrationTests(
-                            "${name}-integration-tests-java-${java.version}-${scala.version}-${neo4j.version}",
-                            "java integration tests (${java.version}, ${scala.version}, ${neo4j.version})",
-                            java,
-                            scala,
-                            neo4j,
-                        ) {},
+                        skipWhenDocsOnly(
+                            JavaIntegrationTests(
+                                "${name}-integration-tests-java-${java.version}-${scala.version}-${neo4j.version}",
+                                "java integration tests (${java.version}, ${scala.version}, ${neo4j.version})",
+                                java,
+                                scala,
+                                neo4j,
+                            ) {},
+                        ),
                     )
 
                     pysparkVersions
@@ -91,25 +103,27 @@ class Build(
                         .forEach { pyspark ->
                           pyspark.pythonVersions.forEach { python ->
                             dependentBuildType(
-                                PythonIntegrationTests(
-                                    "${name}-integration-tests-pyspark-${java.version}-${scala.version}-${neo4j.version}-${python.version}-${pyspark.sparkVersion.version}",
-                                    "pyspark integration tests (${java.version}, ${scala.version}, ${neo4j.version}, ${python.version}, ${pyspark.sparkVersion.version})",
-                                    java,
-                                    python,
-                                    scala,
-                                    pyspark.sparkVersion,
-                                    neo4j,
-                                ) {
-                                  dependencies {
-                                    artifacts(packaging) {
-                                      artifactRules =
-                                          """
+                                skipWhenDocsOnly(
+                                    PythonIntegrationTests(
+                                        "${name}-integration-tests-pyspark-${java.version}-${scala.version}-${neo4j.version}-${python.version}-${pyspark.sparkVersion.version}",
+                                        "pyspark integration tests (${java.version}, ${scala.version}, ${neo4j.version}, ${python.version}, ${pyspark.sparkVersion.version})",
+                                        java,
+                                        python,
+                                        scala,
+                                        pyspark.sparkVersion,
+                                        neo4j,
+                                    ) {
+                                      dependencies {
+                                        artifacts(packaging) {
+                                          artifactRules =
+                                              """
                                     +:packages/*.jar => ./scripts/python
                                     """
-                                              .trimIndent()
-                                    }
-                                  }
-                                },
+                                                  .trimIndent()
+                                        }
+                                      }
+                                    },
+                                ),
                             )
                           }
                         }

--- a/.teamcity/builds/Common.kt
+++ b/.teamcity/builds/Common.kt
@@ -282,3 +282,73 @@ fun BuildSteps.pullImage(version: Neo4jVersion): DockerCommandStep =
         commandArgs = "pull ${version.dockerImage}"
       }
     }
+
+/** Build parameter holding the outcome of [docsOnlyDetection], as `"true"` or `"false"`. */
+const val DOCS_ONLY_CHANGE = "docs-only-change"
+
+/**
+ * Paths that cannot influence the build output. Anything not matching this is treated as a code
+ * change, so adding a path here is the only way to make the build skip it.
+ */
+private const val DOCS_PATHS = "^(docs/|\\.github/workflows/docs-)"
+
+/**
+ * Sets [DOCS_ONLY_CHANGE] to `true` when every file changed in this build is documentation.
+ *
+ * Fails safe on the contents of the change list: if it is empty or absent, the change is treated as
+ * touching code so that the build runs in full. The path of the list itself is always echoed, so
+ * that a build reporting no changes can be told apart from one where TeamCity stopped providing the
+ * list. Note that this runs on the agent rather than in a Docker image, so that it works the same
+ * way for every build type.
+ */
+private fun docsOnlyDetection(): ScriptBuildStep = ScriptBuildStep {
+  name = "detect docs-only change"
+  scriptContent =
+      """
+        #!/bin/bash -eu
+
+        changed_files="%teamcity.build.changedFiles.file%"
+        echo "list of changed files: ${'$'}{changed_files}"
+
+        docs_only=false
+        if [ -s "${'$'}{changed_files}" ]; then
+          # each line is <path>:<change type>:<revision>
+          changed_paths=${'$'}(cut -d: -f1 "${'$'}{changed_files}")
+
+          echo "files changed in this build:"
+          echo "${'$'}{changed_paths}"
+
+          if ! echo "${'$'}{changed_paths}" | grep -qvE '$DOCS_PATHS'; then
+            docs_only=true
+          fi
+        else
+          echo "no list of changed files available, assuming code has changed"
+        fi
+
+        echo "docs-only change: ${'$'}{docs_only}"
+        echo "##teamcity[setParameter name='$DOCS_ONLY_CHANGE' value='${'$'}{docs_only}']"
+      """
+          .trimIndent()
+}
+
+/**
+ * Makes [buildType] a no-op for changes that only touch documentation, by prepending
+ * [docsOnlyDetection] and running every other step only when it reports a code change.
+ *
+ * The build itself still runs and still reports its commit status to GitHub, which is what keeps
+ * the required status checks on a docs-only pull request from hanging forever.
+ *
+ * Take care when applying this to a build type whose artifacts another build consumes: artifact
+ * dependencies are resolved before any step condition is evaluated, so the consumer still tries to
+ * download artifacts that were never published.
+ */
+fun skipWhenDocsOnly(buildType: BuildType): BuildType {
+  buildType.params { text(DOCS_ONLY_CHANGE, "false") }
+
+  buildType.steps {
+    items.forEach { it.conditions { doesNotEqual(DOCS_ONLY_CHANGE, "true") } }
+    items.add(0, docsOnlyDetection())
+  }
+
+  return buildType
+}

--- a/.teamcity/builds/Common.kt
+++ b/.teamcity/builds/Common.kt
@@ -307,7 +307,7 @@ private fun docsOnlyDetection(): ScriptBuildStep = ScriptBuildStep {
       """
         #!/bin/bash -eu
 
-        changed_files="%teamcity.build.changedFiles.file%"
+        changed_files="%system.teamcity.build.changedFiles.file%"
         echo "list of changed files: ${'$'}{changed_files}"
 
         docs_only=false

--- a/.teamcity/settings.kts
+++ b/.teamcity/settings.kts
@@ -49,8 +49,6 @@ project {
                 """
               -:comment=^build.*release version.*:**
               -:comment=^build.*update version.*:**
-              -:docs/**
-              -:.github/workflows/docs-*.yml
               """
                     .trimIndent()
           }
@@ -73,13 +71,6 @@ project {
               appendLine("+:pull/*")
               appendLine("+:refs/heads/pull/*")
             }
-
-            this.triggerRules =
-                """
-              -:docs/**
-              -:.github/workflows/docs-*.yml
-              """
-                    .trimIndent()
           }
         }
 


### PR DESCRIPTION
This pull request introduces a mechanism to skip unnecessary CI build steps for documentation-only changes, optimizing build times and resource usage. It does this by detecting when a change only affects documentation files and conditionally skipping most build steps while still reporting commit status to GitHub. Additionally, it removes redundant documentation-specific trigger rules from the TeamCity configuration.

This is because branch protection rules still expect `complete` build to be reported as successful, regardless of whether the PR is a docs only change or not.