### PR TITLE
ci: make artifacts optional

### DIFF
--- a/.teamcity/builds/Build.kt
+++ b/.teamcity/builds/Build.kt
@@ -117,7 +117,7 @@ class Build(
                                         artifacts(packaging) {
                                           artifactRules =
                                               """
-                                    +:packages/*.jar => ./scripts/python
+                                    ?:packages/*.jar => ./scripts/python
                                     """
                                                   .trimIndent()
                                         }


### PR DESCRIPTION
This pull request makes a minor update to the artifact rules in the TeamCity build configuration. The change updates the artifact rule pattern to use a non-mandatory match, which helps prevent build failures if no `.jar` files are present.

- Build configuration:
  * [`.teamcity/builds/Build.kt`](diffhunk://#diff-22f6b6be2c489fc85db403a5b424b78d42ea3ed94e74566ec6568eefde1d3c90L120-R120): Changed the artifact rule from `+:packages/*.jar` to `?:packages/*.jar` to make the artifact collection optional.