### PR TITLE
DOCOPS-176 Add page-tabs attributes to publish playbook

### DIFF
--- a/docs/publish.yml
+++ b/docs/publish.yml
@@ -32,6 +32,8 @@ asciidoc:
   - "@neo4j-documentation/macros"
   - "@neo4j-antora/mark-terms"
   attributes:
+    page-tabs: drivers-apis@
+    page-tabs-index: 70
     page-theme: docs
     page-type: Docs
     page-search-type: Docs


### PR DESCRIPTION
Adds `page-tabs` and `page-tabs-index` to `docs/publish.yml`:

```yaml
page-tabs: drivers-apis@
page-tabs-index: 70
```

Places this docset in the `drivers-apis` tab of the aggregated tabbed navigation, at the
position matching its order in the Docs menu on neo4j.com/docs. The value is
soft-set with a trailing `@` so it can be overridden.
