### PR TITLE
fix: validations for ErrorIfExists in save modes

### DIFF
--- a/spark-3/src/main/scala/org/neo4j/spark/writer/Neo4jWriterBuilder.scala
+++ b/spark-3/src/main/scala/org/neo4j/spark/writer/Neo4jWriterBuilder.scala
@@ -64,7 +64,7 @@ class Neo4jWriterBuilder(
       (o: Neo4jOptions) => {
         ValidationUtil.isFalse(
           o.relationshipMetadata.sourceSaveMode.equals(NodeSaveMode.ErrorIfExists)
-            && o.relationshipMetadata.targetSaveMode.equals(NodeSaveMode.ErrorIfExists),
+            || o.relationshipMetadata.targetSaveMode.equals(NodeSaveMode.ErrorIfExists),
           "Save mode 'ErrorIfExists' is not supported on Spark 3.0, use 'Append' instead."
         )
       }

--- a/spark-3/src/test/scala/org/neo4j/spark/DataSourceWriterTSE.scala
+++ b/spark-3/src/test/scala/org/neo4j/spark/DataSourceWriterTSE.scala
@@ -1268,7 +1268,7 @@ class DataSourceWriterTSE extends SparkConnectorScalaBaseTSE {
         fail(s"should throw ${classOf[IllegalArgumentException].getName}, but ${e.getClass.getName} was thrown")
     }
 
-    assertTrue(didThrow, s"should throw ${classOf[IllegalArgumentException].getName}, but nothing was thrown")
+    assertTrue(s"should throw ${classOf[IllegalArgumentException].getName}, but nothing was thrown", didThrow)
   }
 
   @Test

--- a/spark-3/src/test/scala/org/neo4j/spark/DataSourceWriterTSE.scala
+++ b/spark-3/src/test/scala/org/neo4j/spark/DataSourceWriterTSE.scala
@@ -860,7 +860,7 @@ class DataSourceWriterTSE extends SparkConnectorScalaBaseTSE {
 
     val count = SparkConnectorScalaSuiteIT.session().run(
       """MATCH (p:Person_TimeAndLocalTime)
-        |WHERE p.name STARTS WITH 'Andrea'        
+        |WHERE p.name STARTS WITH 'Andrea'
         |RETURN count(p) AS count
         |""".stripMargin
     ).single().get("count").asInt()
@@ -1237,6 +1237,8 @@ class DataSourceWriterTSE extends SparkConnectorScalaBaseTSE {
 
   @Test
   def `should fail validating options if ErrorIfExists is used`(): Unit = {
+    var didThrow = false
+
     val musicDf = Seq(
       (12, "John Bonham", "Drums"),
       (19, "John Mayer", "Guitar"),
@@ -1261,8 +1263,12 @@ class DataSourceWriterTSE extends SparkConnectorScalaBaseTSE {
     } catch {
       case e: IllegalArgumentException =>
         assertEquals("Save mode 'ErrorIfExists' is not supported on Spark 3.0, use 'Append' instead.", e.getMessage)
-      case _: Throwable => fail(s"should be thrown a ${classOf[IllegalArgumentException].getName}")
+        didThrow = true
+      case e: Throwable =>
+        fail(s"should throw ${classOf[IllegalArgumentException].getName}, but ${e.getClass.getName} was thrown")
     }
+
+    assertTrue(didThrow, s"should throw ${classOf[IllegalArgumentException].getName}, but nothing was thrown")
   }
 
   @Test


### PR DESCRIPTION
Logic for when to disallow ErrorIfExists was wrong, and the test case
covering it did not take into account for when no exception was
thrown.

Fixed this by updating the test to also assert that a test case was
indeed thrown. Then fixed the logic for throwing; if any save mode
is 'ErrorIfExists' then we should throw.

Cherry-pick from: 9e01acf3f56c961e7abcc9b4bca85ca8b3717a33